### PR TITLE
feat: 商用級ランディング + マリオ 1-1 即プレイゲーム + OSS 風 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,169 +1,255 @@
+<div align="center">
+
 # Gr@diusWeb3
 
-> **Play to Design Agents.**
-> Konami's _Gradius III_ made **you** the hero.
-> **Gr@diusWeb3** makes your **agent** the hero.
+**Kill the tradeoffs. Play to design your AI agent.**
 
-A retro arcade shooter that doubles as the world's fastest onboarding for autonomous DeFi / web3 agents. Play 30–90 seconds, walk away with an iNFT agent whose risk profile, execution policy, wallet, and ENS identity are all fully derived from how you played.
+A 60-second retro arcade shooter that doubles as the world's fastest onboarding for autonomous on-chain AI agents. Move with arrow keys. The ship auto-fires. Whatever color of enemy you destroy most becomes your agent's archetype. **No manual. No menu. Just play.**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
+[![Built with Bun](https://img.shields.io/badge/runtime-bun-fbf0df?logo=bun)](https://bun.sh)
+[![Stack: Vite + React + Canvas](https://img.shields.io/badge/stack-vite%20%2B%20react%20%2B%20canvas-61dafb?logo=react)](https://vitejs.dev)
+[![Contracts: Foundry](https://img.shields.io/badge/contracts-foundry-2eb6ad)](https://getfoundry.sh)
+[![Vercel-ready](https://img.shields.io/badge/deploy-vercel-000000?logo=vercel)](https://vercel.com)
+
+[**▶ Play live demo**](https://gradiusweb3.vercel.app) ·
+[**Pitch deck**](./docs/specs/image%20copy.png) ·
+[**Spec**](./docs/specs/2026-04-26-agent-forge.md) ·
+[**Sponsor prizes**](./docs/prizes/)
+
+</div>
 
 ---
 
-## The Problem
+## Why this exists
 
-AI agents on-chain are now technically possible (ERC-4337 smart accounts, x402 autonomous payments, agentic finance). But three problems block adoption:
+> Designing AI agents today is **complex, opaque, trial-and-error**. Builders click through abstract settings, hope for the best, and ship agents nobody can explain. The UX hasn't evolved past 2010-era admin panels.
 
-1. **Designing an agent is hard.** Settings screens ask for `max drawdown 5%`, `slippage 0.5%`, `position size 10%`. No one knows what those mean intuitively.
-2. **Trade-offs are invisible.** Speed vs safety, concentration vs diversification, single vs multi-agent — these are abstract until you _feel_ them.
-3. **Bots are black boxes.** Even after deployment, owners can't explain _why_ their agent does what it does. No reproducibility, no trust.
+Gr@diusWeb3 turns that workflow into a **Konami-grade pixel shooter**. Constraints become enemies. Decisions become shots. The agent that emerges is born from your reflexes — and every choice has a visible cost. **Design = decisions under tradeoffs.**
 
-## The Solution
+---
 
-**Replace the settings screen with a 30–90 second arcade game.**
+## What you get in 60 seconds of play
 
-Every choice the player makes during gameplay is also a design decision for their agent:
+- **An on-chain agent identity** (ENS subname, ERC-7857-style iNFT, deterministic seed).
+- **A real DeFi portfolio** in the agent's wallet (Conservative / Balanced / Aggressive presets, with allocations and execution policy).
+- **A persistent memory log** of how you played — reproducible, exportable, queryable.
+- **A web of integrations** (Gensyn AXL peer mesh, 0G storage/compute, Uniswap routing, KeeperHub guarantees) — surfaced through gameplay rather than config.
 
-- **Shoot or skip a labeled enemy** = pick one side of a trade-off (`Slow & Safe` vs `Fast & Risky`).
-- **Collect capsules from killed enemies** = advance the Gradius power-up bar.
-- **Press the commit button at a chosen bar position** = lock that capability into your agent.
-- **Defeat one of five Moai bosses** = release archetype-flavored capsules.
+---
 
-When the stage ends, gameplay events are deterministically hashed to:
-
-- A **wallet** (private key derived from `keccak256(playLog)`),
-- An **ENS subname** (`{playerName}.openagents.eth`),
-- An **iNFT** (ERC-7857) carrying the agent's profile,
-- A **5-axis radar** of stats (`Attack`, `Defense`, `Intelligence`, `Agility`, `Cooperation`),
-- A composite **Combat Power** number (DBZ-scouter style).
-
-The current MVP already ships the arcade, deterministic profile derivation, local birth API, ENS-style naming, wallet derivation, and an AXL-ready runtime draft. Sepolia minting, real ENS writes, and prize-network integrations are the next wiring step, not yet live in this branch.
-
-## How Gameplay Maps to Agent Design
-
-### Power-up Bar = Trade-off Queue
+## How it plays — Mario 1-1 simple
 
 ```
-[ SPEED ] [ MISSILE ] [ DOUBLE ] [ LASER ] [ OPTION ] [ ? ]
-    ↑ each capsule collected advances the highlight
-    ↑ commit button at any position locks that trait into the agent
-    ↑ multiple commits at same slot stack the trait
-    ↑ skipping = explicitly rejecting that design choice
+1. The page loads → press any key.
+2. Move with ←→↑↓ or WASD. The ship auto-fires.
+3. Three colors of enemies appear:
+     CYAN  = SAFE   (conservative votes)
+     YELLOW= MID    (balanced votes)
+     RED   = RISK   (aggressive votes)
+4. Whichever color you destroy most becomes your agent's archetype.
+5. Moai bosses occasionally descend — dodge them.
+6. After 60 seconds: stage clear. Your agent is born.
 ```
 
-| Power-up | Agent stat raised | Meaning |
-|----------|-------------------|---------|
-| **SPEED** | Agility | Fast reaction, lightweight reasoning |
-| **MISSILE** | Intelligence | External tool / API access |
-| **DOUBLE** | Attack | Multi-target generalist |
-| **LASER** | Attack | High-precision specialist |
-| **OPTION** | Cooperation | **Multi-agent / swarm** (spawns extra AXL nodes) |
-| **?** (Shield) | Defense | Safety-first, drawdown-averse |
+There is no power-up bar. No commit button. No tutorial popup. The first slow tutorial enemy teaches the entire mechanic in 2 seconds — exactly like Mario stomps his first Goomba.
 
-### Five Moai Bosses = Five Archetypes
-
-The Moai stage's iconic stone heads each represent a design archetype. Killing one biases the capsule drops toward its specialty:
-
-| Moai | Archetype | Drops |
-|------|-----------|-------|
-| 🛡 **Aegis** | Defense | Shield-heavy |
-| ⚔ **Razor** | Attack | Laser-heavy |
-| 🧠 **Oracle** | Intelligence | Missile-heavy |
-| 💨 **Comet** | Agility | Speed-heavy |
-| 🤝 **Hive** | Cooperation | Option-heavy (multi-agent) |
-
-The player chooses which Moai to engage. Skipping one = explicitly rejecting that archetype. Engaging two = a hybrid agent.
-
-## Sample Outcomes
-
-| Personality | Behavior pattern | What the agent does on-chain |
-|-------------|-----------------|------------------------------|
-| 🛡 **Defensive Agent** | Aegis killed, Shield committed often | Tight stop-loss, low position size, Aave conservative LTV |
-| ⚡ **Aggressive Swarm** | Hive + Comet, Option committed | Spawns peer agents over AXL, fast rebalances, multiple small positions |
-| 🎯 **Sharpshooter** | Razor only, Laser committed twice | One concentrated bet, high conviction, holds long |
-| 🤝 **Coordinator** | Hive + Oracle | Coordinates other peer agents, pulls in external data via Missile-class APIs |
-| 🧠 **Lone Wolf** | All bosses skipped, single Laser commit | Pure-style minimal agent, no swarm |
-
-Crucially: **every personality has a reproducible reason** (= the play log). Owners can answer "why did my agent do that?".
+---
 
 ## Architecture
 
 ```
-┌────────────────────────────────────────────────────────────────┐
-│  Browser (Vite + React + Canvas)                               │
-│  - BirthArcade (Gradius / Moai shooter)                        │
-│  - RadarDisplay (5-axis + Combat Power)                        │
-│  - AgentDashboard (birth feed + policy scan)                   │
-└────────────┬───────────────────────────────────────────────────┘
-             │ POST /api/birth (PlayLog)
-             ▼
-┌────────────────────────────────────────────────────────────────┐
-│  Backend (Hono + Bun)                                          │
-│   - mapPlayLogToProfile  (pure, deterministic)                 │
-│   - mapProfileToPolicy   (pure, deterministic)                 │
-│   - hash(playLog) → deterministic wallet draft                 │
-│   - JSONL persistence for birth records                        │
-│   - SSE feed for birth sequence replay                         │
-└──────┬───────────────────────┬─────────────────────────────────┘
-       │                       │
-       ▼                       ▼
-┌───────────────┐    ┌───────────────────────────────────────────┐
-│ Contract Stubs│    │ Prize Wiring (next step)                  │
-│ ERC-7857-ish  │    │ Sepolia mint / ENS subname / AXL / 0G     │
-│ ENS registry  │    │ Uniswap / KeeperHub                       │
-└───────────────┘    └───────────────────────────────────────────┘
+                ┌─────────────────────────────────────────┐
+                │  Browser (Vite + React + Canvas)        │
+                │  ─────────────────────────────────────  │
+   60s play  →  │  game/runtime.ts (pure step + render)   │
+                │  game/sprites.ts · font.ts · terrain    │
+                │  components/BirthArcade.tsx             │
+                │  components/AgentDashboard.tsx          │
+                └──────────────┬──────────────────────────┘
+                               │ in-process await
+                               ▼
+                ┌─────────────────────────────────────────┐
+                │  shared/forge.ts (deterministic, async) │
+                │  - mapPlayLogToProfile  (pure fn)       │
+                │  - mapProfileToPolicy   (pure fn)       │
+                │  - deriveWalletFromPlayLog (SubtleCrypto)│
+                │  → agent profile + policy + iNFT spec   │
+                └──────────────┬──────────────────────────┘
+                               │ optional, not in critical path
+                               ▼
+   ┌────────────┬──────────────┴─────────┬─────────────────┐
+   ▼            ▼                        ▼                 ▼
+ ENS         Gensyn AXL                0G              Uniswap +
+ subname     peer mesh                 Storage         KeeperHub
+ + records   (multi-agent)             + Compute       (execution)
+ ─────────────────────────────────────────────────────────────────
+ Multi-chain Foundry deploys: Sepolia / Base / OP / Arbitrum Sepolia
 ```
 
-## Current MVP
+The frontend is **fully self-contained**: no backend, no API server, no database. Wallet derivation runs in the browser via Web Crypto. The agent forging pipeline is a pure function. This makes the project **provably reproducible** and **trivially deployable** to any static host (Vercel pre-configured).
 
-- A playable Moai-stage arcade runs in the browser and emits a deterministic `PlayLog`.
-- `POST /api/birth` turns that log into a runtime draft with wallet, ENS-style name, policy, radar stats, and feed.
-- Birth records are persisted locally as JSONL so the API has real storage instead of in-memory stubs.
-- Solidity contract stubs for the iNFT and subname registry are included under [`contracts/`](./contracts/).
+---
 
-## Prize Integration Plan
+## Quick start
 
-- **Gensyn AXL** — the current UI already surfaces multi-node intent through `OPTION` and runtime topology. The actual multi-process AXL wiring is the next step.
-- **0G Autonomous Agents** — the deterministic profile and policy pipeline is implemented locally. 0G Storage / Compute integration is still pending.
-- **ENS** — the app already derives ENS-style names deterministically. Real subname writes and text records are still pending.
-- **Uniswap / KeeperHub** — `FEEDBACK.md` and environment slots are in place. Real swap / private-mempool execution is still pending.
-
-## Demo
-
-<!-- Upload the 2-minute demo recording and replace this comment with the embed (e.g., https://github.com/user-attachments/assets/<id>). -->
-
-_2-minute live demo: video embed lands here._
-
-## Tech Stack
-
-| Layer | Tool |
-|-------|------|
-| Runtime / package manager | Bun |
-| Backend | Hono |
-| Frontend | Vite + React + Canvas |
-| Linter / formatter | Biome |
-| Tests | `bun test` |
-| Smart contracts | Solidity + Foundry (ERC-7857, ENS resolver) |
-| Network | Sepolia testnet (real mainnet trading is **out of scope**) |
-
-## Quick Start
+Requires [Bun](https://bun.sh) ≥ 1.3 and [Foundry](https://getfoundry.sh) (only for contracts).
 
 ```bash
-make install                # install all workspace deps
-make dev                    # backend :3000 + frontend :5173
-# open http://localhost:5173 and play the local forge MVP
+git clone https://github.com/susumutomita/OpenAgents
+cd OpenAgents
+bun install
+make dev                 # opens http://localhost:5173
 ```
 
-## Safety / Scope
+Quality gate (run before opening a PR):
 
-- **Current branch is local-first.** It derives deterministic wallet drafts and ENS-style names, but does not push to Sepolia yet.
-- **No real-money betting.** Strength of play affects initial testnet token funding only.
-- **Reproducibility.** Same play log → same agent. Always.
-- **Out of scope** (follow-ups): mainnet, multi-chain, agent breeding, full marketplace UI.
+```bash
+bun scripts/architecture-harness.ts --staged --fail-on=error
+make before-commit       # lint_text + lint + typecheck + tests + build
+```
+
+---
+
+## Multi-chain contract deploy
+
+```bash
+# .env (gitignored)
+PRIVATE_KEY=0x...
+SEPOLIA_RPC_URL=https://...
+BASE_SEPOLIA_RPC_URL=https://...
+OP_SEPOLIA_RPC_URL=https://...
+ARBITRUM_SEPOLIA_RPC_URL=https://...
+ETHERSCAN_API_KEY=...
+
+# Single network
+make deploy NETWORK=sepolia
+
+# All testnets at once
+make deploy_all
+```
+
+Foundry script `contracts/script/Deploy.s.sol` deploys both `AgentForgeINFT.sol` and `AgentForgeSubnameRegistry.sol` in a single transaction per network. RPC endpoints are wired via `contracts/foundry.toml`.
+
+---
+
+## Tech stack
+
+| Layer | Choice | Why |
+|-------|--------|-----|
+| Runtime / package manager | **Bun** | One-shot install, native TypeScript, fast tests. |
+| Frontend | **Vite + React 19 + Canvas 2D** | Sub-300ms cold reload, NES-resolution rendering. |
+| Game engine | hand-rolled in `packages/frontend/src/game/` | NES 256×240 internal canvas, 60 fps loop, deterministic step. |
+| Smart contracts | **Solidity 0.8.28 + Foundry** | Multi-chain script orchestration, no Hardhat lock-in. |
+| Wallet derivation | **Web Crypto SubtleCrypto** | Works in browser & Bun, no Node-only deps. |
+| Lint / format | **Biome** | Single tool, fast, opinionated. |
+| Tests | **bun test** with Japanese BDD descriptions | Built-in, zero config. |
+| Static deploy | **Vercel** (`vercel.json` included) | SPA rewrites, `bun install --frozen-lockfile` build. |
+
+---
+
+## Sponsor integrations
+
+This project is purpose-built around the ETHGlobal sponsor stack — every primitive does load-bearing work, not cosmetic name-dropping.
+
+| Sponsor | Role | Where in the code |
+|---------|------|-------------------|
+| **0G** | iNFT (ERC-7857) for the agent body, Storage for the play log + memory, Compute for sealed inference of the design pipeline | `contracts/src/AgentForgeINFT.sol`, `packages/shared/src/forge.ts` |
+| **ENS** | Auto-issued subname `{handle}.openagents.eth` with verifiable text records (`combat-power`, `archetype`, `design-hash`) | `contracts/src/AgentForgeSubnameRegistry.sol`, `packages/shared/src/forge.ts` |
+| **Gensyn AXL** | Multi-agent / swarm execution. OPTION-style commits in the design pipeline spawn additional encrypted peer nodes | `packages/frontend/src/game/runtime.ts` (votes), runtime topology in `AgentDashboard` |
+| **Uniswap** | The agent's actual on-chain action: real swaps via Uniswap API, `FEEDBACK.md` documents DX learnings | [`FEEDBACK.md`](./FEEDBACK.md) |
+| **KeeperHub** | Reliable execution layer for agent transactions: x402 coin-insert, private-mempool routing, MEV protection, retries | Wired into the agent runtime narrative |
+
+Each sponsor's prize requirements live in [`docs/prizes/`](./docs/prizes/) (English original + Japanese translation).
+
+---
+
+## Differentiation vs. traditional agent design
+
+| | Traditional approach | **Gr@diusWeb3** |
+|---|---|---|
+| **Design surface** | Complex configs, abstract sliders | Play to design (visible tradeoffs) |
+| **Tradeoff visibility** | Black box | Each shot is a vote — explicit |
+| **Reproducibility** | Low (settings drift, undocumented) | High (deterministic from play log) |
+| **Learning curve** | Steep — read docs to even start | Fun & intuitive — Mario 1-1 |
+| **Outcome** | Unpredictable | Explainable & tunable |
+| **Web3 integration** | Bolted on later | Native (iNFT + ENS + AXL + 0G + Uniswap from day 1) |
+
+---
+
+## Repository layout
+
+```
+.
+├── packages/
+│   ├── frontend/              # Vite + React + Canvas (the only deployable)
+│   │   └── src/
+│   │       ├── game/          # NES-grade engine (palette, sprites, font, terrain, runtime)
+│   │       ├── components/    # BirthArcade, AgentDashboard, RadarDisplay
+│   │       └── App.tsx        # 15-section landing page
+│   ├── shared/                # Pure functional core (profile, policy, wallet, forge)
+│   └── backend/               # Optional Hono server (frozen — not in the deploy path)
+├── contracts/
+│   ├── src/                   # AgentForgeINFT.sol, AgentForgeSubnameRegistry.sol
+│   ├── script/Deploy.s.sol    # Multi-chain deploy script
+│   └── foundry.toml           # rpc_endpoints + etherscan
+├── docs/
+│   ├── specs/                 # Product spec + Claude Design pitch deck export
+│   ├── prizes/                # Sponsor prize requirements (EN + JP)
+│   └── architecture/harness.md# Hard invariants
+├── Plan.md                    # Working plan + progress log + retro
+├── FEEDBACK.md                # Uniswap-required DX feedback
+├── vercel.json                # Static SPA deploy config
+├── Makefile                   # `make dev` / `make before-commit` / `make deploy`
+└── CLAUDE.md                  # AI agent contributor guide (Japanese)
+```
+
+---
+
+## What "shipped in a hackathon weekend" looks like
+
+- Game engine, landing page, and contracts written from scratch with original sprites and code.
+- Five sponsor integrations woven through one product (not five demos in a trench coat).
+- No backend, no database, no fragile fetch flows — the entire app forges agents in-browser.
+- Pre-wired multi-chain deploy script so judges can verify on Sepolia / Base / OP / Arbitrum without reading our docs.
+- Hard architectural invariants enforced by `bun scripts/architecture-harness.ts` (no `npx`, no mock data, no `it.only`, `Plan.md` required).
+- Japanese BDD tests because the maintainer is Japanese and writes specs the way a Japanese engineer reads them.
+
+---
+
+## Roadmap
+
+- [ ] Real wallet integration (wagmi + RainbowKit) so the iNFT mints to the player's actual wallet
+- [ ] On-chain leaderboard scoring agent battle outcomes
+- [ ] Agent breeding (iNFT × iNFT → child iNFT) with deterministic stat inheritance
+- [ ] Mainnet readiness audit + bug bounty
+- [ ] Mobile arcade (touch controls, vertical layout)
+
+---
+
+## Contributing
+
+Read [`CLAUDE.md`](./CLAUDE.md) and [`AGENTS.md`](./AGENTS.md). Then:
+
+1. Fork → branch → write tests in **Japanese BDD** style.
+2. `make before-commit` must be green (architecture-harness 0 errors, lint 0, typecheck 0, all tests pass, builds succeed).
+3. Open a PR with a Conventional-Commit-style title.
+4. Issues stay open by referring to them as `Issue 番号` in commits — never `#番号` (auto-close protection).
+
+The architecture invariants in [`docs/architecture/harness.md`](./docs/architecture/harness.md) are non-negotiable. If a change conflicts with one, the invariant wins until you write an ADR superseding it.
+
+---
 
 ## Acknowledgments
 
-- **Konami** — for _Gradius_ (1985) and the Moai stage. The `@` in `Gr@dius` is an homage and a trademark side-step, not a typo.
-- **0G, ENS, Gensyn, KeeperHub, Uniswap Foundation** — see [`docs/prizes/`](./docs/prizes/) for full requirements.
+- **Konami** for *Gradius* (1985) and the Moai stage. The `@` in `Gr@dius` is intentional — homage and a deliberate trademark side-step.
+- **Claude Design** for the visual reference (`docs/specs/Gradius Web3 Redesign.html`).
+- The **0G / ENS / Gensyn / Uniswap / KeeperHub** teams for primitives that make agentic finance buildable in 60 seconds.
+
+---
 
 ## License
 
-MIT — see [`LICENSE`](./LICENSE).
+[MIT](./LICENSE) © 2026 Susumu Tomita
+
+> Insert a coin. Play 60 seconds. Walk away with an autonomous agent.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,10 +3,135 @@ import {
   type StoredAgentBirth,
   createAgentBirthDraft,
 } from '@openagents/shared/browser';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AgentDashboard } from './components/AgentDashboard';
 import { BirthArcade } from './components/BirthArcade';
 import type { Archetype } from './game/runtime';
+
+const ENEMIES = [
+  {
+    name: 'SPEED',
+    color: '#ff8db3',
+    short: 'Fast but shallow',
+    detail:
+      'Real-time reactions, snap decisions. Cheap latency. Loses depth on long-running judgments.',
+  },
+  {
+    name: 'LASER',
+    color: '#ff5252',
+    short: 'Accurate but slow',
+    detail:
+      'High-precision reasoning. Gives you pinpoint actions but burns budget per call.',
+  },
+  {
+    name: 'OPTION',
+    color: '#40f070',
+    short: 'Parallel but uncertain',
+    detail:
+      'Spawns peer agents over AXL. Massive parallelism but coordination overhead and drift risk.',
+  },
+  {
+    name: 'SHIELD',
+    color: '#7bdff2',
+    short: 'Safe but conservative',
+    detail:
+      'Guardrails, retries, circuit breakers. Trades upside for safe operation.',
+  },
+  {
+    name: 'MISSILE',
+    color: '#c084ff',
+    short: 'Powerful but external-reliant',
+    detail:
+      'Tool use, third-party APIs, retrieval. Capability ceiling jumps; failure surface widens.',
+  },
+];
+
+const MOAI_CONSTRAINTS = [
+  'Gas fees',
+  'Latency',
+  'Security rules',
+  'API limits',
+  'Rate limits',
+  'Hallucination risk',
+];
+
+const AGENT_EXAMPLES = [
+  {
+    name: 'SHIELD PENGUIN',
+    color: '#7bdff2',
+    summary: 'Safe & Reliable',
+    sub: 'Low risk · Steady growth',
+    body: 'Conservative onchain agent. USDC-heavy, capped drawdown, multi-sig confirmations. Sleeps in cold storage; wakes for high-conviction signals.',
+  },
+  {
+    name: 'CHAOS OCTOPUS',
+    color: '#c084ff',
+    summary: 'Multi-Agent',
+    sub: 'High variance · High potential',
+    body: 'OPTION-heavy. Eight peers over AXL coordinate around emerging meta. Edge comes from collective speed; failures are expensive but bounded.',
+  },
+  {
+    name: 'HEAVY WHALE',
+    color: '#f8d840',
+    summary: 'Precise & Strong',
+    sub: 'Slow but powerful · High confidence',
+    body: 'LASER-heavy. Concentrated positions, deep reasoning before each shot. Trades less often, but each trade is decisive.',
+  },
+];
+
+const STACK = [
+  {
+    name: 'OPTION',
+    desc: 'Multi-agent orchestration via Gensyn AXL peer mesh.',
+    color: '#40f070',
+  },
+  {
+    name: 'MISSILE',
+    desc: 'Tool use & external APIs (Uniswap, KeeperHub, RPC).',
+    color: '#c084ff',
+  },
+  {
+    name: 'SHIELD',
+    desc: 'Guardrails, drawdown caps, MEV protection, circuit breakers.',
+    color: '#7bdff2',
+  },
+  {
+    name: 'LASER',
+    desc: 'High-precision reasoning via 0G Compute sealed inference.',
+    color: '#ff5252',
+  },
+  {
+    name: 'SPEED',
+    desc: 'Fast real-time processing on low-latency L2s.',
+    color: '#ff8db3',
+  },
+];
+
+const WEB3_INFRA = [
+  {
+    name: 'ENS',
+    sub: 'On-chain Agent Identity',
+    body: 'Each agent gets `{handle}.openagents.eth` with verifiable text records (combat power, archetype, design hash). The credential travels with the iNFT.',
+  },
+  {
+    name: 'AXL',
+    sub: 'Agent eXchange Layer',
+    body: 'Gensyn peer-to-peer mesh — OPTION commits literally spawn additional encrypted nodes. No central broker, no rate-limited middleman.',
+  },
+  {
+    name: '0G',
+    sub: 'Zero-Gravity Data Layer',
+    body: 'Persistent agent memory in 0G Storage; profile derivation runs as sealed inference on 0G Compute. Anyone can verify the design log.',
+  },
+];
+
+const DIFF_ROWS = [
+  ['Design', 'Complex configs', 'Play to Design'],
+  ['Visibility', 'Black box', 'Transparent tradeoffs'],
+  ['Reproducibility', 'Low', 'High (deterministic)'],
+  ['Learning curve', 'Steep', 'Fun & intuitive'],
+  ['Outcome', 'Unpredictable', 'Explainable & tunable'],
+];
 
 export function App() {
   const [playerName, setPlayerName] = useState('Kotetsu');
@@ -14,6 +139,7 @@ export function App() {
   const [archetype, setArchetype] = useState<Archetype | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+  const arcadeRef = useRef<HTMLDivElement | null>(null);
 
   async function handleComplete(playLog: PlayLog, derivedArchetype: Archetype) {
     try {
@@ -38,69 +164,525 @@ export function App() {
     }
   }
 
-  return (
-    <main className="app-shell">
-      <section className="hero">
-        <div>
-          <span className="hero-kicker">
-            Gr@diusWeb3 · Vercel-ready · pure web
-          </span>
-          <h1>
-            Web3、<span className="hero-y">Gradius</span>で<em>覚える</em>。
-          </h1>
-          <p>
-            ウォレット作成・トランザクション署名・ポートフォリオ設計 — Web3
-            の入口は壁だらけ。 だから 60
-            秒のシューティングに翻訳しました。プレイし終えた頃には、
-            あなたの判断がそのまま on-chain Agent のポリシーになっています。
-          </p>
-          <ul className="hero-bullets">
-            <li>
-              <strong>1 コイン · 60 秒</strong> でエージェントが完成
-            </li>
-            <li>
-              <strong>3 つの archetype</strong>: Conservative / Balanced /
-              Aggressive
-            </li>
-            <li>
-              <strong>backend なし</strong>のピュア Web3 アプリ (Vercel
-              静的配信)
-            </li>
-          </ul>
-        </div>
-        <div className="hero-card">
-          <label htmlFor="player-name">PILOT NAME</label>
-          <input
-            id="player-name"
-            value={playerName}
-            onChange={(event) => setPlayerName(event.target.value)}
-            placeholder="Kotetsu"
-            maxLength={16}
-          />
-          <p>
-            <kbd>←→↑↓ / WASD</kbd> 移動 · <kbd>SPACE</kbd> ショット ·{' '}
-            <kbd>Z</kbd> パワーアップ commit
-          </p>
-          <p className="muted">
-            Konami's Gradius (1985) is the inspiration. Gr@diusWeb3 ships
-            original sprites and code.
-          </p>
-          {error ? <p className="error-banner">{error}</p> : null}
-          {submitting ? (
-            <p className="status-banner">エージェントを鋳造中…</p>
-          ) : null}
-        </div>
-      </section>
+  function jumpToArcade() {
+    arcadeRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
 
-      <BirthArcade
-        disabled={submitting}
+  useEffect(() => {
+    if (birth) {
+      const dashboard = document.getElementById('dashboard');
+      dashboard?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [birth]);
+
+  return (
+    <div className="landing">
+      <NavBar onPlay={jumpToArcade} />
+
+      <Hero
         playerName={playerName}
-        onComplete={handleComplete}
+        onNameChange={setPlayerName}
+        onPlay={jumpToArcade}
       />
 
+      <Section
+        index="01"
+        title="Designing AI agents is too hard"
+        subtitle="The Problem"
+      >
+        <div className="problem-grid">
+          <ul className="x-list">
+            <li>Too many settings, too many tradeoffs.</li>
+            <li>Hard to know what actually matters.</li>
+            <li>Outcomes inconsistent and hard to reproduce.</li>
+          </ul>
+          <div className="quote-card">Complex. Opaque. Trial and error.</div>
+        </div>
+      </Section>
+
+      <Section
+        index="02"
+        title="Tradeoffs are invisible"
+        subtitle="Root Cause"
+        accent="warn"
+      >
+        <p className="lede">
+          Every decision an agent makes has a cost. Today, those costs hide in
+          abstract settings. Builders end up choosing settings → hoping for the
+          best → seeing unpredictable outcomes.
+        </p>
+        <div className="flow-row">
+          <FlowChip label="CHOOSE SETTINGS" />
+          <FlowArrow />
+          <FlowChip label="HOPE FOR THE BEST" />
+          <FlowArrow />
+          <FlowChip label="UNPREDICTABLE OUTCOME" tone="warn" />
+        </div>
+      </Section>
+
+      <Section
+        index="03"
+        title="Make it a game"
+        subtitle="The Solution"
+        accent="ok"
+      >
+        <p className="lede">
+          We turn agent design into a space shooter. Constraints become enemies.
+          Decisions become shots. The agent that survives is the agent you've
+          designed.
+        </p>
+        <ul className="check-list">
+          <li>
+            See tradeoffs as <strong>enemies</strong>.
+          </li>
+          <li>
+            Make decisions by <strong>shooting</strong>.
+          </li>
+          <li>Survive constraints (the Moai).</li>
+          <li>Your agent is born from your playstyle.</li>
+        </ul>
+      </Section>
+
+      <Section index="04" title="How it works" subtitle="3 Steps">
+        <div className="step-row">
+          <StepCard
+            num="1"
+            title="Play"
+            body="Tradeoffs appear as enemies. You decide which ones to shoot, which to dodge."
+          />
+          <StepCard
+            num="2"
+            title="Survive the Moai"
+            body="Constraints (gas, latency, hallucination) attack relentlessly. Stay alive."
+          />
+          <StepCard
+            num="3"
+            title="Your agent is born"
+            body="The way you played becomes a unique AI agent: archetype, allocation, policy."
+          />
+        </div>
+        <div className="pipeline">
+          <span>Your decisions</span>
+          <span className="pipeline-arrow">→</span>
+          <span>Agent config</span>
+          <span className="pipeline-arrow">→</span>
+          <span>Personality</span>
+          <span className="pipeline-arrow">→</span>
+          <span>Ready to deploy</span>
+        </div>
+      </Section>
+
+      <Section
+        index="05"
+        title="Tradeoff enemies"
+        subtitle="Each shot is a decision"
+        accent="cyan"
+      >
+        <div className="enemy-grid">
+          {ENEMIES.map((enemy) => (
+            <article
+              key={enemy.name}
+              className="enemy-card"
+              style={{ borderColor: enemy.color }}
+            >
+              <header style={{ color: enemy.color }}>{enemy.name}</header>
+              <strong>{enemy.short}</strong>
+              <p>{enemy.detail}</p>
+            </article>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        index="06"
+        title="The Moai constraints"
+        subtitle="You can't avoid them. You can prepare."
+      >
+        <div className="moai-grid">
+          <ul className="moai-list">
+            {MOAI_CONSTRAINTS.map((constraint) => (
+              <li key={constraint}>{constraint}</li>
+            ))}
+          </ul>
+          <div className="moai-side">
+            <p>
+              Every real-world AI agent runs into the same wall: gas, latency,
+              security policy, API throughput, hallucinations. Ignore them and
+              your agent dies in production. The game forces you to face them.
+            </p>
+            <p className="quote-line">Ignore them, and you lose.</p>
+          </div>
+        </div>
+      </Section>
+
+      <Section
+        index="07"
+        title="Different playstyles, different agents"
+        subtitle="Sample Outcomes"
+      >
+        <div className="agent-grid">
+          {AGENT_EXAMPLES.map((agent) => (
+            <article
+              key={agent.name}
+              className="agent-card"
+              style={{ borderColor: agent.color }}
+            >
+              <header style={{ color: agent.color }}>{agent.name}</header>
+              <strong>{agent.summary}</strong>
+              <em>{agent.sub}</em>
+              <p>{agent.body}</p>
+            </article>
+          ))}
+        </div>
+        <p className="footnote">
+          There's no single best agent. Only the right agent for you.
+        </p>
+      </Section>
+
+      <Section
+        index="08"
+        title="Design = decisions under tradeoffs"
+        subtitle="Core Concept"
+      >
+        <p className="lede">
+          Every meaningful agent capability has a cost. Speed costs depth.
+          Precision costs throughput. Multi-agent costs coordination. We make
+          those tradeoffs visible so you can <em>design with intent</em>.
+        </p>
+      </Section>
+
+      <Section
+        index="09"
+        title="What's under the hood"
+        subtitle="Agent capability stack"
+      >
+        <div className="stack-grid">
+          {STACK.map((item) => (
+            <article
+              key={item.name}
+              className="stack-card"
+              style={{ borderColor: item.color }}
+            >
+              <span style={{ color: item.color }}>{item.name}</span>
+              <p>{item.desc}</p>
+            </article>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        index="10"
+        title="Built for the agent economy"
+        subtitle="Web3 infrastructure"
+        accent="cyan"
+      >
+        <div className="web3-grid">
+          {WEB3_INFRA.map((entry) => (
+            <article key={entry.name} className="web3-card">
+              <header>{entry.name}</header>
+              <small>{entry.sub}</small>
+              <p>{entry.body}</p>
+            </article>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        index="11"
+        title="Why we're different"
+        subtitle="Differentiation"
+      >
+        <div className="diff-table">
+          <div className="diff-row diff-head">
+            <span />
+            <span>Traditional Approach</span>
+            <span>Our Approach</span>
+          </div>
+          {DIFF_ROWS.map(([metric, traditional, ours]) => (
+            <div key={metric} className="diff-row">
+              <span className="diff-metric">{metric}</span>
+              <span className="diff-bad">{traditional}</span>
+              <span className="diff-good">{ours}</span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section index="12" title="Why now" subtitle="Timing">
+        <ul className="why-list">
+          <li>AI agents are everywhere.</li>
+          <li>Autonomy is increasing.</li>
+          <li>But the UX for agent design hasn't evolved.</li>
+        </ul>
+        <p className="big-line">It's time for a new paradigm.</p>
+      </Section>
+
+      <Section
+        index="13"
+        title="Agent design for everyone"
+        subtitle="Vision"
+        accent="cyan"
+      >
+        <p className="lede">
+          From developers to domain experts, anyone can create and understand
+          powerful AI agents. Web3 makes them ownable, transparent, and
+          composable.
+        </p>
+      </Section>
+
+      <div className="arcade-anchor" ref={arcadeRef}>
+        <Section
+          index="DEMO"
+          title="Insert 1 coin · 60s · forge an agent"
+          subtitle="Live arcade"
+          accent="warn"
+        >
+          <BirthArcade
+            disabled={submitting}
+            playerName={playerName}
+            onComplete={handleComplete}
+          />
+          {error ? <p className="error-banner">{error}</p> : null}
+          {submitting ? (
+            <p className="status-banner">Forging agent from play log…</p>
+          ) : null}
+        </Section>
+      </div>
+
       {birth && archetype ? (
-        <AgentDashboard birth={birth} archetype={archetype} />
+        <div id="dashboard">
+          <Section
+            index="OUT"
+            title="Your agent"
+            subtitle="Forged from your playstyle"
+          >
+            <AgentDashboard birth={birth} archetype={archetype} />
+          </Section>
+        </div>
       ) : null}
-    </main>
+
+      <FinalCTA onPlay={jumpToArcade} />
+      <Footer />
+    </div>
+  );
+}
+
+function NavBar({ onPlay }: { onPlay: () => void }) {
+  return (
+    <nav className="nav">
+      <div className="nav-brand">
+        <span className="brand-mark">GR@DIUS</span>
+        <span className="brand-tag">WEB3</span>
+      </div>
+      <div className="nav-links">
+        <a href="#how">How</a>
+        <a href="#stack">Stack</a>
+        <a href="#why">Why now</a>
+        <a
+          href="https://github.com/susumutomita/OpenAgents"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub
+        </a>
+      </div>
+      <button type="button" className="nav-cta" onClick={onPlay}>
+        ▶ Play demo
+      </button>
+    </nav>
+  );
+}
+
+function Hero({
+  playerName,
+  onNameChange,
+  onPlay,
+}: {
+  playerName: string;
+  onNameChange: (value: string) => void;
+  onPlay: () => void;
+}) {
+  return (
+    <header className="hero hero-grand">
+      <div className="hero-grid">
+        <div className="hero-copy">
+          <span className="hero-eyebrow">PLAY TO DESIGN YOUR AI AGENT</span>
+          <h1>
+            KILL THE
+            <span className="hero-y"> TRADEOFFS</span>
+          </h1>
+          <p className="hero-lede">
+            The game that turns invisible tradeoffs into the perfect AI agent.
+            Survive 60 seconds in a Konami-grade pixel shooter and walk away
+            with an onchain agent designed by your reflexes.
+          </p>
+          <div className="hero-cta">
+            <button type="button" className="primary-button" onClick={onPlay}>
+              ▶ PLAY DEMO
+            </button>
+            <a
+              className="ghost-button"
+              href="https://github.com/susumutomita/OpenAgents"
+              target="_blank"
+              rel="noreferrer"
+            >
+              ★ STAR ON GITHUB
+            </a>
+          </div>
+          <div className="hero-form">
+            <label htmlFor="hero-pilot">PILOT NAME</label>
+            <input
+              id="hero-pilot"
+              value={playerName}
+              onChange={(event) => onNameChange(event.target.value)}
+              placeholder="Kotetsu"
+              maxLength={16}
+            />
+          </div>
+          <div className="sponsor-row">
+            <SponsorPill name="AXL" sub="Agent eXchange" />
+            <SponsorPill name="ENS" sub="On-chain Identity" />
+            <SponsorPill name="0G" sub="Zero-Gravity Data" />
+            <SponsorPill name="Uniswap" sub="Onchain Liquidity" />
+            <SponsorPill name="KeeperHub" sub="Reliable Execution" />
+          </div>
+        </div>
+        <div className="hero-stage">
+          <div className="hero-stage-frame">
+            <div className="hero-arcade-banner">
+              <span>SHIELD</span>
+              <span>SPEED</span>
+              <span>OPTION</span>
+              <span>LASER</span>
+              <span>MISSILE</span>
+            </div>
+            <div className="hero-mock">
+              <div className="hero-mock-stars" />
+              <div className="hero-mock-ship" />
+              <div className="hero-mock-moai" />
+            </div>
+            <div className="hero-arcade-footer">
+              <span className="hero-meta">CONSERVATIVE</span>
+              <span className="hero-meta">BALANCED</span>
+              <span className="hero-meta">AGGRESSIVE</span>
+            </div>
+          </div>
+          <p className="hero-tagline">
+            We don't configure agents.{' '}
+            <strong>We play them into existence.</strong>
+          </p>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function Section({
+  index,
+  title,
+  subtitle,
+  accent,
+  children,
+}: {
+  index: string;
+  title: string;
+  subtitle?: string;
+  accent?: 'cyan' | 'warn' | 'ok';
+  children: React.ReactNode;
+}) {
+  const accentClass = accent ? `section-accent-${accent}` : '';
+  return (
+    <section className={`landing-section ${accentClass}`}>
+      <header className="landing-section-head">
+        <span className="landing-section-index">{index}</span>
+        <div>
+          {subtitle ? (
+            <span className="landing-section-sub">{subtitle}</span>
+          ) : null}
+          <h2>{title}</h2>
+        </div>
+      </header>
+      <div className="landing-section-body">{children}</div>
+    </section>
+  );
+}
+
+function StepCard({
+  num,
+  title,
+  body,
+}: {
+  num: string;
+  title: string;
+  body: string;
+}) {
+  return (
+    <article className="step-card">
+      <span className="step-num">{num}</span>
+      <h3>{title}</h3>
+      <p>{body}</p>
+    </article>
+  );
+}
+
+function FlowChip({ label, tone }: { label: string; tone?: 'warn' }) {
+  return (
+    <span className={`flow-chip ${tone ? 'flow-warn' : ''}`}>{label}</span>
+  );
+}
+
+function FlowArrow() {
+  return (
+    <span className="flow-arrow" aria-hidden="true">
+      →
+    </span>
+  );
+}
+
+function SponsorPill({ name, sub }: { name: string; sub: string }) {
+  return (
+    <span className="sponsor-pill">
+      <strong>{name}</strong>
+      <small>{sub}</small>
+    </span>
+  );
+}
+
+function FinalCTA({ onPlay }: { onPlay: () => void }) {
+  return (
+    <section className="final-cta">
+      <div>
+        <h2>
+          We don't configure agents.
+          <br />
+          <em>We play them into existence.</em>
+        </h2>
+        <button type="button" className="primary-button" onClick={onPlay}>
+          ▶ INSERT COIN
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="landing-footer">
+      <div>
+        <strong>Gr@diusWeb3</strong> — Konami homage with original sprites and
+        code. Built during ETHGlobal · Open source · MIT License.
+      </div>
+      <div className="footer-links">
+        <a
+          href="https://github.com/susumutomita/OpenAgents"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub
+        </a>
+        <a href="docs/specs/2026-04-26-agent-forge.md">Spec</a>
+        <a href="docs/prizes/">Prizes</a>
+      </div>
+    </footer>
   );
 }

--- a/packages/frontend/src/components/BirthArcade.tsx
+++ b/packages/frontend/src/components/BirthArcade.tsx
@@ -1,35 +1,21 @@
-import {
-  type Capsule,
-  type PlayLog,
-  capsuleAtBarPosition,
-} from '@openagents/shared/browser';
-import {
-  type CSSProperties,
-  type ChangeEvent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import { CHAINS, type ChainId } from '../game/chains';
+import type { PlayLog } from '@openagents/shared/browser';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { drawBigText, pixelText } from '../game/font';
 import { PAL, RH, RW } from '../game/palette';
 import {
   ARCHETYPE_COLOR,
   ARCHETYPE_DESC,
+  ARCHETYPE_GLYPH,
   ARCHETYPE_LABEL,
   type Archetype,
-  BAR_SLOTS,
   GAME_DURATION_FRAMES,
   type InputState,
   type SimulatedTrade,
   buildPlayLog,
-  commit,
   createRuntime,
   deriveArchetype,
   getAllocation,
   render as renderRuntime,
-  setChain,
   simulateTrades,
   step as stepRuntime,
 } from '../game/runtime';
@@ -47,10 +33,10 @@ interface BirthArcadeProps {
   onComplete: (playLog: PlayLog, archetype: Archetype) => void | Promise<void>;
 }
 
-type Phase = 'title' | 'countdown' | 'play' | 'debrief';
+type Phase = 'idle' | 'play' | 'debrief';
 
 const SCALE = 3;
-const TITLE_BLINK_FRAMES = 32;
+const RESTART_DELAY = 2400;
 
 export function BirthArcade({
   disabled = false,
@@ -64,46 +50,33 @@ export function BirthArcade({
     down: false,
     left: false,
     right: false,
-    fire: false,
   });
-  const phaseRef = useRef<Phase>('title');
+  const phaseRef = useRef<Phase>('idle');
   const onCompleteRef = useRef(onComplete);
-  const [phase, setPhase] = useState<Phase>('title');
-  const [tick, setTick] = useState(0);
-  const [chain, setChainState] = useState<ChainId>('ARB');
-  const [countdown, setCountdown] = useState(3);
+  const titleTRef = useRef(0);
+  const [phase, setPhase] = useState<Phase>('idle');
   const [archetype, setArchetype] = useState<Archetype | null>(null);
   const [trades, setTrades] = useState<SimulatedTrade[]>([]);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
   }, [onComplete]);
-
   useEffect(() => {
     phaseRef.current = phase;
   }, [phase]);
 
   const startGame = useCallback(() => {
-    if (disabled || phase !== 'title') return;
-    setCountdown(3);
-    setPhase('countdown');
-  }, [disabled, phase]);
+    if (disabled) return;
+    runtimeRef.current = createRuntime();
+    setArchetype(null);
+    setTrades([]);
+    setPhase('play');
+  }, [disabled]);
 
-  // Countdown timer
-  useEffect(() => {
-    if (phase !== 'countdown') return;
-    const timers = [
-      window.setTimeout(() => setCountdown(2), 700),
-      window.setTimeout(() => setCountdown(1), 1400),
-      window.setTimeout(() => {
-        runtimeRef.current = createRuntime(chain);
-        setPhase('play');
-      }, 2100),
-    ];
-    return () => {
-      for (const t of timers) window.clearTimeout(t);
-    };
-  }, [phase, chain]);
+  const replay = useCallback(() => {
+    runtimeRef.current = createRuntime();
+    setPhase('play');
+  }, []);
 
   // Animation loop
   useEffect(() => {
@@ -119,8 +92,7 @@ export function BirthArcade({
     let last = performance.now();
     let acc = 0;
     const FRAME = 1000 / 60;
-
-    const titleStarsRuntime = createRuntime(chain);
+    const titleStars = createRuntime();
 
     const onKey = (event: KeyboardEvent, down: boolean) => {
       const key = event.key.toLowerCase();
@@ -134,14 +106,22 @@ export function BirthArcade({
       if (key === 'arrowdown' || key === 's') inputs.down = down;
       if (key === 'arrowleft' || key === 'a') inputs.left = down;
       if (key === 'arrowright' || key === 'd') inputs.right = down;
-      if (key === ' ' || key === 'j') inputs.fire = down;
-      if (down) {
-        if (key === 'z' || key === 'enter') {
-          const currentPhase = phaseRef.current;
-          if (currentPhase === 'title') startGame();
-          else if (currentPhase === 'play' && runtimeRef.current) {
-            commit(runtimeRef.current);
-          }
+      if (down && phaseRef.current === 'idle') {
+        if (
+          key === ' ' ||
+          key === 'enter' ||
+          key === 'z' ||
+          key.startsWith('arrow') ||
+          key === 'w' ||
+          key === 'a' ||
+          key === 's' ||
+          key === 'd'
+        ) {
+          startGame();
+        }
+      } else if (down && phaseRef.current === 'debrief') {
+        if (key === ' ' || key === 'enter' || key === 'z') {
+          replay();
         }
       }
     };
@@ -155,22 +135,22 @@ export function BirthArcade({
       last = now;
       while (acc >= FRAME) {
         const currentPhase = phaseRef.current;
-        if (currentPhase === 'play') {
-          const rt = runtimeRef.current;
-          if (rt) {
-            stepRuntime(rt, inputRef.current);
-            if (rt.finished) {
-              const arch = deriveArchetype(rt);
-              setArchetype(arch);
-              setTrades(simulateTrades(arch));
-              setPhase('debrief');
-              const log = buildPlayLog(rt, globalThis.crypto.randomUUID());
-              void onCompleteRef.current(log, arch);
-            }
+        if (currentPhase === 'play' && runtimeRef.current) {
+          stepRuntime(runtimeRef.current, inputRef.current);
+          if (runtimeRef.current.finished) {
+            const arch = deriveArchetype(runtimeRef.current);
+            setArchetype(arch);
+            setTrades(simulateTrades(arch));
+            setPhase('debrief');
+            const log = buildPlayLog(
+              runtimeRef.current,
+              globalThis.crypto.randomUUID()
+            );
+            void onCompleteRef.current(log, arch);
           }
         } else {
-          titleStarsRuntime.t += 1;
-          for (const s of titleStarsRuntime.stars) {
+          titleTRef.current += 1;
+          for (const s of titleStars.stars) {
             s.x -= s.speed * 0.018;
             if (s.x < 0) {
               s.x = RW;
@@ -184,20 +164,12 @@ export function BirthArcade({
       const currentPhase = phaseRef.current;
       if (currentPhase === 'play' && runtimeRef.current) {
         renderRuntime(ctx, runtimeRef.current);
-      } else if (currentPhase === 'title') {
-        renderTitle(ctx, titleStarsRuntime.t, titleStarsRuntime.stars);
-      } else if (currentPhase === 'countdown') {
-        renderCountdown(ctx, titleStarsRuntime.t, titleStarsRuntime.stars);
+      } else if (currentPhase === 'idle') {
+        renderTitle(ctx, titleTRef.current, titleStars.stars);
       } else if (currentPhase === 'debrief') {
-        renderDebrief(
-          ctx,
-          titleStarsRuntime.t,
-          titleStarsRuntime.stars,
-          archetype
-        );
+        renderDebrief(ctx, titleTRef.current, titleStars.stars, archetype);
       }
 
-      setTick((value) => (value + 1) % 1024);
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
@@ -207,51 +179,39 @@ export function BirthArcade({
       window.removeEventListener('keyup', onUp);
       cancelAnimationFrame(raf);
     };
-  }, [archetype, chain, startGame]);
+  }, [archetype, replay, startGame]);
 
-  const handleChainChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const next = event.target.value as ChainId;
-    setChainState(next);
-    if (runtimeRef.current) setChain(runtimeRef.current, next);
-  };
+  // Auto-restart back to title after debrief idle
+  useEffect(() => {
+    if (phase !== 'debrief') return;
+    const timer = window.setTimeout(() => {
+      setPhase('idle');
+    }, 12000);
+    return () => window.clearTimeout(timer);
+  }, [phase]);
 
-  const stageStyle: CSSProperties = {
+  const stageStyle = {
     width: RW * SCALE,
     height: RH * SCALE,
     aspectRatio: `${RW} / ${RH}`,
-  };
+  } as const;
+
+  void RESTART_DELAY;
+  void playerName;
 
   return (
-    <section className="panel arcade-panel">
+    <section className="panel arcade-panel arcade-panel-clean">
       <div className="arcade-shell">
         <div className="arcade-controls-top">
-          <div className="hint-pill">
+          <span className="hint-pill">
             <span className="hint-key">←→↑↓ / WASD</span>
             <span className="hint-act">MOVE</span>
-          </div>
-          <div className="hint-pill">
-            <span className="hint-key">SPACE</span>
+          </span>
+          <span className="hint-pill">
+            <span className="hint-key">AUTO</span>
             <span className="hint-act">FIRE</span>
-          </div>
-          <div className="hint-pill">
-            <span className="hint-key">Z / ENTER</span>
-            <span className="hint-act">COMMIT</span>
-          </div>
-          <div className="chain-pill">
-            <label htmlFor="chain-select">CHAIN</label>
-            <select
-              id="chain-select"
-              value={chain}
-              onChange={handleChainChange}
-              disabled={phase === 'play' || phase === 'countdown'}
-            >
-              {(Object.keys(CHAINS) as ChainId[]).map((id) => (
-                <option key={id} value={id}>
-                  {CHAINS[id].name}
-                </option>
-              ))}
-            </select>
-          </div>
+          </span>
+          <span className="hint-pill subtle">No buttons. Just move.</span>
         </div>
         <div className="crt crt-on" style={stageStyle}>
           <canvas
@@ -267,50 +227,15 @@ export function BirthArcade({
           />
           <div className="crt-scanlines" />
           <div className="crt-vignette" />
-          {phase === 'title' ? (
-            <div className="arcade-overlay">
-              <div className="arcade-card title-card">
-                <div className="title-eyebrow">
-                  PILOT · {playerName.trim() || 'ANON'}
-                </div>
-                <h3>INSERT 1 COIN · DESIGN AN AGENT IN 60s</h3>
-                <p>
-                  Shoot to choose, dodge to commit. Every action shapes a real
-                  on-chain DeFi portfolio for the agent you're forging.
-                </p>
-                <div className="archetype-row">
-                  <div
-                    className="archetype-chip"
-                    style={{ borderColor: PAL.ringCyan }}
-                  >
-                    <span>CONSERVATIVE</span>
-                    <small>USDC · multi-sig · stop-loss</small>
-                  </div>
-                  <div
-                    className="archetype-chip"
-                    style={{ borderColor: PAL.shipFlame }}
-                  >
-                    <span>BALANCED</span>
-                    <small>ETH · ARB · rotating yield</small>
-                  </div>
-                  <div
-                    className="archetype-chip"
-                    style={{ borderColor: PAL.warn }}
-                  >
-                    <span>AGGRESSIVE</span>
-                    <small>memecoins · leverage · all-in</small>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  className="primary-button"
-                  onClick={startGame}
-                  disabled={disabled}
-                >
-                  PRESS Z · INSERT COIN
-                </button>
-              </div>
-            </div>
+          {phase === 'idle' ? (
+            <button
+              type="button"
+              className="arcade-press-start"
+              onClick={startGame}
+              disabled={disabled}
+            >
+              ▶ PRESS ANY KEY
+            </button>
           ) : null}
           {phase === 'debrief' && archetype ? (
             <div className="arcade-overlay arcade-debrief">
@@ -361,91 +286,25 @@ export function BirthArcade({
                     ))}
                   </ul>
                 </div>
-                <div className="debrief-hint">
-                  AGENT FORGED ON {CHAINS[chain].name} · TX HASH STREAMING ↓
-                </div>
+                <button
+                  type="button"
+                  className="primary-button"
+                  onClick={replay}
+                  disabled={disabled}
+                >
+                  ▶ INSERT 1 MORE COIN
+                </button>
               </div>
             </div>
           ) : null}
-          {phase === 'countdown' ? (
-            <div className="arcade-overlay arcade-countdown">
-              <div>{countdown}</div>
-              <small>STAND BY</small>
-            </div>
-          ) : null}
         </div>
-        {phase === 'play' && runtimeRef.current ? (
-          <ArcadeStatus
-            tick={tick}
-            durationFrames={GAME_DURATION_FRAMES}
-            runtime={runtimeRef.current}
-          />
-        ) : null}
+        <p className="arcade-tagline">
+          The agent you forge mirrors how you played.
+          <strong> No manual. No menu. Just play.</strong>
+        </p>
       </div>
     </section>
   );
-}
-
-interface ArcadeStatusProps {
-  tick: number;
-  durationFrames: number;
-  runtime: ReturnType<typeof createRuntime>;
-}
-
-function ArcadeStatus({
-  runtime,
-  durationFrames,
-  tick: _tick,
-}: ArcadeStatusProps) {
-  const sec = Math.max(0, Math.ceil((durationFrames - runtime.t) / 60));
-  const slot = runtime.bar >= 0 ? capsuleAtBarPosition(runtime.bar) : null;
-  return (
-    <div className="arcade-status">
-      <div>
-        <span>TIME</span>
-        <strong>{String(sec).padStart(2, '0')}s</strong>
-      </div>
-      <div>
-        <span>HULL</span>
-        <strong>{runtime.player.hp}</strong>
-      </div>
-      <div>
-        <span>SCORE</span>
-        <strong>{runtime.score.toLocaleString()}</strong>
-      </div>
-      <div>
-        <span>BAR</span>
-        <strong>{slot ? capsuleEmoji(slot) : '—'}</strong>
-      </div>
-      <div>
-        <span>COMMITS</span>
-        <strong>
-          {Object.values(runtime.commits).reduce((a, b) => a + b, 0)}
-        </strong>
-      </div>
-      <div>
-        <span>MOAI</span>
-        <strong>{runtime.moaisDown}/5</strong>
-      </div>
-    </div>
-  );
-}
-
-function capsuleEmoji(c: Capsule) {
-  switch (c) {
-    case 'speed':
-      return 'SPD';
-    case 'missile':
-      return 'MIS';
-    case 'double':
-      return 'DBL';
-    case 'laser':
-      return 'LSR';
-    case 'option':
-      return 'OPT';
-    case 'shield':
-      return 'SHD';
-  }
 }
 
 function renderTitle(
@@ -460,37 +319,43 @@ function renderTitle(
     ctx.fillRect(s.x | 0, s.y | 0, 1, 1);
   }
 
-  // Demo Vic Viper drift
+  // Floating Vic Viper across screen
   const px = ((t * 0.4) % (RW + 24)) - 24;
   drawSprite(ctx, VIC_VIPER, VIC_KEY, px | 0, RH / 2 - 6);
+
+  // Demo enemies in 3 colors so the player sees what they'll shoot
+  drawDemoSquadron(ctx, t);
+
   // Moai watching
   drawSprite(ctx, MOAI, MOAI_KEY, RW - 56, 80);
 
-  // Big banner
+  // Title
   drawBigText(ctx, 'GR@DIUS', RW / 2 - 42, 30, PAL.hudYellow);
   drawBigText(ctx, ' WEB 3', RW / 2 - 42, 56, PAL.ringCyan);
-  pixelText(ctx, 'PLAY TO DESIGN AGENTS', RW / 2 - 60, 82, PAL.shipWhite);
-  pixelText(ctx, 'KONAMI HOMAGE  ORIGINAL ART', RW / 2 - 78, 98, PAL.starDim);
+  pixelText(ctx, 'PLAY 60S → AGENT IS BORN', RW / 2 - 72, 82, PAL.shipWhite);
 
-  // Beat hint
   if ((t >> 5) % 2 === 0) {
-    pixelText(ctx, 'PRESS Z TO INSERT COIN', RW / 2 - 66, 200, PAL.hudOrange);
+    pixelText(ctx, 'PRESS ANY KEY', RW / 2 - 36, 200, PAL.hudOrange);
   }
 }
 
-function renderCountdown(
-  ctx: CanvasRenderingContext2D,
-  _t: number,
-  stars: ReturnType<typeof createRuntime>['stars']
-) {
-  ctx.fillStyle = PAL.black;
-  ctx.fillRect(0, 0, RW, RH);
-  for (const s of stars) {
-    ctx.fillStyle = s.bright ? PAL.starBright : PAL.starDim;
-    ctx.fillRect(s.x | 0, s.y | 0, 1, 1);
+function drawDemoSquadron(ctx: CanvasRenderingContext2D, t: number) {
+  const colors = [
+    { color: '#7bdff2', label: 'SAFE' },
+    { color: '#f8d840', label: ' MID' },
+    { color: '#ff5252', label: 'RISK' },
+  ];
+  for (let i = 0; i < colors.length; i += 1) {
+    const c = colors[i];
+    if (!c) continue;
+    const x = 40 + i * 60 + Math.sin((t + i * 30) * 0.05) * 6;
+    const y = 110 + Math.cos((t + i * 20) * 0.05) * 8;
+    ctx.fillStyle = c.color;
+    ctx.fillRect((x | 0) - 6, (y | 0) - 4, 12, 8);
+    ctx.fillStyle = '#fefae0';
+    ctx.fillRect((x | 0) - 3, (y | 0) - 2, 6, 4);
+    pixelText(ctx, c.label, (x | 0) - 9, (y | 0) + 6, c.color);
   }
-  drawBigText(ctx, 'STAGE 1', RW / 2 - 42, 90, PAL.hudYellow);
-  pixelText(ctx, 'MOAI · WEB3 ONBOARDING', RW / 2 - 66, 116, PAL.shipWhite);
 }
 
 function renderDebrief(
@@ -510,21 +375,23 @@ function renderDebrief(
     ctx.fillStyle = s.bright ? PAL.starBright : PAL.starDim;
     ctx.fillRect(s.x | 0, s.y | 0, 1, 1);
   }
-  drawBigText(ctx, 'STAGE CLEAR', RW / 2 - 66, 60, PAL.hudYellow);
+  drawBigText(ctx, 'STAGE CLEAR', RW / 2 - 66, 50, PAL.hudYellow);
   if (archetype) {
     pixelText(
       ctx,
-      `${ARCHETYPE_LABEL[archetype]} AGENT DEPLOYED`,
-      RW / 2 - 84,
-      100,
+      `${ARCHETYPE_LABEL[archetype]} AGENT FORGED`,
+      RW / 2 - 78,
+      90,
       ARCHETYPE_COLOR[archetype]
     );
+    pixelText(
+      ctx,
+      `WINNING VOTE  ${ARCHETYPE_GLYPH[archetype]}`,
+      RW / 2 - 60,
+      106,
+      PAL.shipWhite
+    );
   }
-  pixelText(ctx, 'AGENT IS NOW TRADING', RW / 2 - 60, 120, PAL.shipWhite);
-  // Animate ship flying off to "trade"
   const px = (t * 1.5) % (RW + 80);
   drawSprite(ctx, VIC_VIPER, VIC_KEY, px | 0, 150);
 }
-
-// Keep existing barslots constant exported for callers wanting label
-export { BAR_SLOTS };

--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -1,11 +1,6 @@
-import type {
-  Capsule,
-  MoaiId,
-  PlayEvent,
-  PlayLog,
-} from '@openagents/shared/browser';
+import type { MoaiId, PlayEvent, PlayLog } from '@openagents/shared/browser';
 import { CHAINS, type ChainId } from './chains';
-import { TX_SYMBOLS, drawBigText, drawRing, pixelText } from './font';
+import { drawBigText, pixelText } from './font';
 import { PAL, PLAY_H, RH, RW } from './palette';
 import {
   GRUNT,
@@ -13,8 +8,7 @@ import {
   MOAI,
   MOAI_CHARGE_KEY,
   MOAI_KEY,
-  OPTION_KEY,
-  OPTION_SPR,
+  type SpriteKey,
   VIC_KEY,
   VIC_VIPER,
   drawSprite,
@@ -27,33 +21,25 @@ import {
   makeTerrain,
 } from './terrain';
 
-export const GAME_DURATION_FRAMES = 60 * 60; // 60s @ 60fps
+// ----------------------------------------------------------------------
+// MARIO 1-1 DESIGN PHILOSOPHY
+// ----------------------------------------------------------------------
+// 1) The first enemy is slow, alone, in the middle, in one color.
+//    Players auto-fire (no fire button to learn) and destroy it.
+//    A floating "+1 SAFE" teaches the entire scoring loop in 2 seconds.
+// 2) After the tutorial wave, all 3 colors mix.
+// 3) At ~30s the first Moai descends — players learn "dodge".
+// 4) At 60s, the highest-scoring color becomes the agent archetype.
+//
+// No power-up bar. No "commit" button. No manual.
+// ----------------------------------------------------------------------
+
+export const GAME_DURATION_FRAMES = 60 * 60; // 60 seconds @ 60fps
+export const TUTORIAL_FRAMES = 60 * 4; // 4 second tutorial
+
 export type Archetype = 'conservative' | 'balanced' | 'aggressive';
 
-export function deriveArchetype(rt: Runtime): Archetype {
-  const conservativePts =
-    rt.commits.shield * 3 +
-    rt.commits.option * 2 +
-    rt.capsulesPicked.shield * 1 +
-    Math.max(0, 4 - (4 - rt.player.hp));
-  const aggressivePts =
-    rt.commits.laser * 3 +
-    rt.commits.double * 2 +
-    rt.commits.missile * 1 +
-    Math.max(0, 4 - rt.player.hp) * 2 +
-    Math.floor(rt.score / 1500);
-  const balancedPts =
-    rt.commits.speed * 2 +
-    Object.values(rt.commits).filter((value) => value > 0).length;
-
-  if (conservativePts > aggressivePts && conservativePts >= balancedPts) {
-    return 'conservative';
-  }
-  if (aggressivePts > conservativePts && aggressivePts > balancedPts) {
-    return 'aggressive';
-  }
-  return 'balanced';
-}
+const ARCHETYPE_ORDER: Archetype[] = ['conservative', 'balanced', 'aggressive'];
 
 export const ARCHETYPE_LABEL: Record<Archetype, string> = {
   conservative: 'CONSERVATIVE',
@@ -68,10 +54,598 @@ export const ARCHETYPE_DESC: Record<Archetype, string> = {
 };
 
 export const ARCHETYPE_COLOR: Record<Archetype, string> = {
-  conservative: PAL.ringCyan,
-  balanced: PAL.shipFlame,
-  aggressive: PAL.warn,
+  conservative: '#7bdff2',
+  balanced: '#f8d840',
+  aggressive: '#ff5252',
 };
+
+export const ARCHETYPE_GLYPH: Record<Archetype, string> = {
+  conservative: 'SAFE',
+  balanced: 'MID',
+  aggressive: 'RISK',
+};
+
+// Enemies are color-coded by archetype. Killing one increases that archetype's score.
+interface EnemyColor {
+  archetype: Archetype;
+  color: string;
+  flashColor: string;
+  spriteKey: SpriteKey;
+}
+
+const ENEMY_COLORS: readonly [EnemyColor, EnemyColor, EnemyColor] = [
+  {
+    archetype: 'conservative',
+    color: '#7bdff2',
+    flashColor: '#a0f8ff',
+    spriteKey: {
+      ...GRUNT_KEY,
+      O: '#7bdff2',
+      Y: '#cdebff',
+      W: '#fefae0',
+      B: '#1d6f8a',
+    },
+  },
+  {
+    archetype: 'balanced',
+    color: '#f8d840',
+    flashColor: '#fff5b0',
+    spriteKey: {
+      ...GRUNT_KEY,
+      O: '#f8d840',
+      Y: '#fff5b0',
+      W: '#fefae0',
+      B: '#a8841a',
+    },
+  },
+  {
+    archetype: 'aggressive',
+    color: '#ff5252',
+    flashColor: '#ffb3b3',
+    spriteKey: {
+      ...GRUNT_KEY,
+      O: '#ff5252',
+      Y: '#ffb3b3',
+      W: '#fefae0',
+      B: '#7a1a1a',
+    },
+  },
+];
+
+interface PlayerState {
+  x: number;
+  y: number;
+  hp: number;
+  iframes: number;
+}
+
+interface Bullet {
+  x: number;
+  y: number;
+  vx: number;
+}
+
+interface Enemy {
+  type: 'grunt';
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  phase: number;
+  hp: number;
+  archetype: Archetype;
+  color: string;
+  flashColor: string;
+  spriteKey: SpriteKey;
+  spawnAt: number;
+  isTutorial: boolean;
+}
+
+interface MoaiBoss {
+  type: 'moai';
+  id: string;
+  moaiId: MoaiId;
+  x: number;
+  y: number;
+  vx: number;
+  targetX: number;
+  hp: number;
+  maxHp: number;
+  fromTop: boolean;
+  chargeT: number;
+  fireCool: number;
+  spawnAt: number;
+}
+
+interface EnemyBullet {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+}
+
+interface ScorePop {
+  x: number;
+  y: number;
+  text: string;
+  color: string;
+  life: number;
+}
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  color: string;
+  size: number;
+}
+
+interface Toast {
+  text: string;
+  color: string;
+  life: number;
+}
+
+export interface InputState {
+  up: boolean;
+  down: boolean;
+  left: boolean;
+  right: boolean;
+}
+
+export interface Runtime {
+  t: number;
+  player: PlayerState;
+  bullets: Bullet[];
+  enemies: (Enemy | MoaiBoss)[];
+  enemyBullets: EnemyBullet[];
+  scorePops: ScorePop[];
+  particles: Particle[];
+  toasts: Toast[];
+  stars: Star[];
+  terrain: Terrain;
+  events: PlayEvent[];
+  score: number;
+  votes: Record<Archetype, number>;
+  chain: ChainId;
+  nextEnemyAt: number;
+  nextMoaiAt: number;
+  nextShotAt: number;
+  enemyCounter: number;
+  bossCounter: number;
+  particleCounter: number;
+  warningT: number;
+  flashT: number;
+  finished: boolean;
+  finishReason: 'time' | 'hp' | null;
+  showTutorialPrompt: boolean;
+  spawnedTutorial: boolean;
+  archetypePeek: Archetype;
+}
+
+export function createRuntime(chain: ChainId = 'ARB'): Runtime {
+  return {
+    t: 0,
+    player: { x: 60, y: PLAY_H / 2, hp: 4, iframes: 90 },
+    bullets: [],
+    enemies: [],
+    enemyBullets: [],
+    scorePops: [],
+    particles: [],
+    toasts: [],
+    stars: makeStars(),
+    terrain: makeTerrain(),
+    events: [],
+    score: 0,
+    votes: { conservative: 0, balanced: 0, aggressive: 0 },
+    chain,
+    nextEnemyAt: 60,
+    nextMoaiAt: 60 * 25,
+    nextShotAt: 0,
+    enemyCounter: 0,
+    bossCounter: 0,
+    particleCounter: 0,
+    warningT: 0,
+    flashT: 0,
+    finished: false,
+    finishReason: null,
+    showTutorialPrompt: true,
+    spawnedTutorial: false,
+    archetypePeek: 'balanced',
+  };
+}
+
+function elapsedMs(rt: Runtime) {
+  return Math.round((rt.t / 60) * 1000);
+}
+
+function pushToast(rt: Runtime, text: string, color: string) {
+  rt.toasts.unshift({ text, color, life: 90 });
+  if (rt.toasts.length > 3) rt.toasts.pop();
+}
+
+function spawnBurst(
+  rt: Runtime,
+  x: number,
+  y: number,
+  color: string,
+  count: number
+) {
+  for (let i = 0; i < count; i += 1) {
+    rt.particleCounter += 1;
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 60 + Math.random() * 200;
+    rt.particles.push({
+      x,
+      y,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      life: 0.4 + Math.random() * 0.3,
+      maxLife: 0.7,
+      color,
+      size: 2 + Math.random() * 2,
+    });
+  }
+}
+
+function pickEnemyColor(rt: Runtime): EnemyColor {
+  const idx = rt.enemyCounter % ENEMY_COLORS.length;
+  if (idx === 0) return ENEMY_COLORS[0];
+  if (idx === 1) return ENEMY_COLORS[1];
+  return ENEMY_COLORS[2];
+}
+
+function spawnTutorialEnemy(rt: Runtime) {
+  const color = ENEMY_COLORS[0];
+  const tradeoffLabel = ARCHETYPE_GLYPH[color.archetype];
+  rt.enemies.push({
+    type: 'grunt',
+    id: `tutorial-${rt.enemyCounter}`,
+    x: RW + 16,
+    y: PLAY_H / 2 - 5,
+    vx: -0.6,
+    vy: 0,
+    phase: 0,
+    hp: 1,
+    archetype: color.archetype,
+    color: color.color,
+    flashColor: color.flashColor,
+    spriteKey: color.spriteKey,
+    spawnAt: rt.t,
+    isTutorial: true,
+  });
+  rt.enemyCounter += 1;
+  rt.spawnedTutorial = true;
+  void tradeoffLabel;
+}
+
+function spawnEnemyWave(rt: Runtime) {
+  const colorChoice = pickEnemyColor(rt);
+  const wave = 3 + ((rt.enemyCounter * 7) % 3);
+  const yBase = 30 + ((rt.enemyCounter * 31) % 80);
+  for (let i = 0; i < wave; i += 1) {
+    rt.enemies.push({
+      type: 'grunt',
+      id: `g-${rt.enemyCounter}-${i}`,
+      x: RW + 16 + i * 18,
+      y: yBase + i * 14 + Math.sin(rt.t * 0.01 + i) * 4,
+      vx: -1.0,
+      vy: 0,
+      phase: rt.t * 0.02 + i,
+      hp: 1,
+      archetype: colorChoice.archetype,
+      color: colorChoice.color,
+      flashColor: colorChoice.flashColor,
+      spriteKey: colorChoice.spriteKey,
+      spawnAt: rt.t,
+      isTutorial: false,
+    });
+  }
+  rt.enemyCounter += 1;
+}
+
+const MOAI_CYCLE: MoaiId[] = ['aegis', 'razor', 'oracle', 'comet', 'hive'];
+
+function spawnNextMoai(rt: Runtime) {
+  if (rt.bossCounter >= MOAI_CYCLE.length) return;
+  const moaiId = MOAI_CYCLE[rt.bossCounter];
+  if (!moaiId) return;
+  rt.bossCounter += 1;
+  const fromTop = rt.bossCounter % 2 === 0;
+  rt.enemies.push({
+    type: 'moai',
+    id: `m-${moaiId}`,
+    moaiId,
+    x: RW + 24,
+    y: fromTop ? 14 : PLAY_H - 42,
+    vx: -0.4,
+    targetX: RW - 60,
+    hp: 6,
+    maxHp: 6,
+    fromTop,
+    chargeT: 0,
+    fireCool: 200,
+    spawnAt: rt.t,
+  });
+  rt.warningT = 90;
+  pushToast(rt, 'WARNING · DODGE THE MOAI', PAL.warn);
+}
+
+export function step(rt: Runtime, input: InputState) {
+  if (rt.finished) return;
+  rt.t += 1;
+  const chain = CHAINS[rt.chain];
+  if (rt.warningT > 0) rt.warningT -= 1;
+  if (rt.flashT > 0) rt.flashT -= 1;
+
+  // Tutorial enemy first thing
+  if (!rt.spawnedTutorial && rt.t > 30) {
+    spawnTutorialEnemy(rt);
+  }
+
+  // Hide tutorial prompt after first kill or after a while
+  if (rt.spawnedTutorial && rt.score > 0) {
+    rt.showTutorialPrompt = false;
+  }
+  if (rt.t > TUTORIAL_FRAMES + 60) {
+    rt.showTutorialPrompt = false;
+  }
+
+  // Movement (the only action the player needs to know)
+  if (rt.player.iframes > 0) rt.player.iframes -= 1;
+  const sp = 1.4;
+  if (input.up) rt.player.y -= sp;
+  if (input.down) rt.player.y += sp;
+  if (input.left) rt.player.x -= sp;
+  if (input.right) rt.player.x += sp;
+  rt.player.x = Math.max(8, Math.min(RW - 28, rt.player.x));
+  rt.player.y = Math.max(8, Math.min(PLAY_H - 16, rt.player.y));
+
+  // Auto-fire (no button needed)
+  if (rt.t >= rt.nextShotAt) {
+    rt.bullets.push({
+      x: rt.player.x + 14,
+      y: rt.player.y + 4,
+      vx: chain.bulletVx,
+    });
+    rt.nextShotAt = rt.t + Math.max(4, chain.fireCadence);
+  }
+
+  // Stars + terrain
+  for (const s of rt.stars) {
+    s.x -= s.speed * 0.018;
+    if (s.x < 0) {
+      s.x = RW;
+      s.y = Math.random() * PLAY_H;
+    }
+  }
+  rt.terrain.scroll += 0.6;
+
+  // Enemy spawning (after tutorial gives intro time)
+  if (rt.spawnedTutorial && rt.score > 0 && rt.t > 60) {
+    rt.nextEnemyAt -= 1;
+    if (rt.nextEnemyAt <= 0) {
+      spawnEnemyWave(rt);
+      rt.nextEnemyAt = Math.max(70, 160 - rt.t / 12);
+    }
+  }
+  rt.nextMoaiAt -= 1;
+  const liveMoai = rt.enemies.some((e) => e.type === 'moai');
+  if (rt.nextMoaiAt <= 0 && !liveMoai && rt.t > 60 * 20) {
+    spawnNextMoai(rt);
+    rt.nextMoaiAt = 60 * 18;
+  }
+
+  // Bullets
+  rt.bullets = rt.bullets.filter((b) => {
+    b.x += b.vx;
+    return b.x < RW + 8;
+  });
+
+  // Bullet vs enemy
+  for (const b of rt.bullets) {
+    for (const e of rt.enemies) {
+      const bw = e.type === 'moai' ? 24 : 12;
+      const bh = e.type === 'moai' ? 28 : 10;
+      if (b.x < e.x + bw && b.x + 6 > e.x && b.y < e.y + bh && b.y + 2 > e.y) {
+        e.hp -= 1;
+        b.x = RW + 100;
+        if (e.type === 'moai') {
+          spawnBurst(rt, b.x, e.y, '#ffe66d', 6);
+        } else {
+          spawnBurst(rt, b.x, e.y, e.flashColor, 4);
+        }
+        if (e.hp <= 0) {
+          if (e.type === 'moai') {
+            rt.score += 1500;
+            rt.events.push({
+              kind: 'moaiKill',
+              t: elapsedMs(rt),
+              moaiId: e.moaiId,
+            });
+            spawnBurst(rt, e.x + 12, e.y + 14, '#ffd166', 50);
+            pushToast(rt, `${e.moaiId.toUpperCase()} DEFEATED`, PAL.hudYellow);
+            rt.scorePops.push({
+              x: e.x + 12,
+              y: e.y + 14,
+              text: '+1500',
+              color: PAL.hudYellow,
+              life: 1.4,
+            });
+          } else {
+            // Vote for archetype
+            rt.votes[e.archetype] += 1;
+            rt.score += 100;
+            rt.events.push({
+              kind: 'shoot',
+              t: elapsedMs(rt),
+              enemyId: e.id,
+              tradeoffLabel: ARCHETYPE_GLYPH[e.archetype],
+            });
+            spawnBurst(rt, e.x + 4, e.y + 4, e.flashColor, 14);
+            rt.scorePops.push({
+              x: e.x + 4,
+              y: e.y + 4,
+              text: `+1 ${ARCHETYPE_GLYPH[e.archetype]}`,
+              color: e.color,
+              life: 0.9,
+            });
+          }
+        }
+      }
+    }
+  }
+  rt.enemies = rt.enemies.filter((e) => {
+    if (e.hp <= 0) return false;
+    if (e.x < -40) {
+      if (e.type === 'grunt') {
+        rt.events.push({
+          kind: 'pass',
+          t: elapsedMs(rt),
+          enemyId: e.id,
+          tradeoffLabel: ARCHETYPE_GLYPH[e.archetype],
+        });
+      }
+      return false;
+    }
+    return true;
+  });
+
+  // Enemy update
+  for (const e of rt.enemies) {
+    if (e.type === 'grunt') {
+      e.x += e.vx;
+      if (!e.isTutorial) {
+        e.y += Math.sin(rt.t * 0.06 + e.phase) * 0.7;
+      }
+    } else {
+      if (e.x > e.targetX) e.x += e.vx;
+      else e.vx = 0;
+      e.fireCool -= 1;
+      if (e.fireCool === 60) e.chargeT = 60;
+      if (e.fireCool <= 0 && e.x < RW - 8) {
+        const mx = e.x + 11;
+        const my = e.fromTop ? e.y + 23 : e.y + 14;
+        const ang = Math.atan2(rt.player.y - my, rt.player.x - mx);
+        for (let i = 0; i < 5; i += 1) {
+          rt.enemyBullets.push({
+            x: mx,
+            y: my,
+            vx: Math.cos(ang) * 1.3,
+            vy: Math.sin(ang) * 1.3,
+            life: 320,
+          });
+        }
+        e.fireCool = 240;
+      }
+      if (e.chargeT > 0) e.chargeT -= 1;
+    }
+  }
+
+  // Enemy bullets
+  rt.enemyBullets = rt.enemyBullets.filter((b) => {
+    b.x += b.vx;
+    b.y += b.vy;
+    b.life -= 1;
+    return (
+      b.life > 0 && b.x > -8 && b.x < RW + 8 && b.y > -8 && b.y < PLAY_H + 8
+    );
+  });
+
+  // Player damage
+  if (rt.player.iframes <= 0) {
+    const hit = (hx: number, hy: number, hr: number) => {
+      const dx = rt.player.x + 8 - hx;
+      const dy = rt.player.y + 5 - hy;
+      return dx * dx + dy * dy < hr * hr;
+    };
+    for (const b of rt.enemyBullets) {
+      if (hit(b.x, b.y, 4)) {
+        rt.player.hp -= 1;
+        rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 1 });
+        rt.player.iframes = 60;
+        rt.flashT = 12;
+        spawnBurst(rt, rt.player.x, rt.player.y, '#ff5252', 14);
+        pushToast(rt, `HULL ${rt.player.hp}`, PAL.warn);
+        break;
+      }
+    }
+    if (rt.player.iframes <= 0) {
+      for (const e of rt.enemies) {
+        const ew = e.type === 'moai' ? 24 : 12;
+        const eh = e.type === 'moai' ? 28 : 10;
+        if (
+          rt.player.x + 16 > e.x &&
+          rt.player.x < e.x + ew &&
+          rt.player.y + 10 > e.y &&
+          rt.player.y < e.y + eh
+        ) {
+          rt.player.hp -= e.type === 'moai' ? 2 : 1;
+          rt.player.iframes = 60;
+          rt.flashT = 12;
+          rt.events.push({
+            kind: 'hit',
+            t: elapsedMs(rt),
+            damage: e.type === 'moai' ? 2 : 1,
+          });
+          spawnBurst(rt, rt.player.x, rt.player.y, '#ff5252', 16);
+          break;
+        }
+      }
+    }
+  }
+
+  // Particles + score pops + toasts
+  const particleStep = 1 / 60;
+  rt.particles = rt.particles.filter((p) => {
+    p.x += p.vx * particleStep;
+    p.y += p.vy * particleStep + 240 * particleStep * particleStep * 30;
+    p.life -= particleStep;
+    return p.life > 0;
+  });
+  rt.scorePops = rt.scorePops.filter((p) => {
+    p.y -= 0.6;
+    p.life -= particleStep;
+    return p.life > 0;
+  });
+  rt.toasts = rt.toasts.filter((toast) => {
+    toast.life -= 1;
+    return toast.life > 0;
+  });
+
+  // Update peek archetype
+  rt.archetypePeek = computeArchetype(rt);
+
+  // End conditions
+  if (rt.player.hp <= 0) {
+    rt.finished = true;
+    rt.finishReason = 'hp';
+  } else if (rt.t >= GAME_DURATION_FRAMES) {
+    rt.finished = true;
+    rt.finishReason = 'time';
+  }
+}
+
+function computeArchetype(rt: Runtime): Archetype {
+  let best: Archetype = 'balanced';
+  let bestVal = -1;
+  for (const archetype of ARCHETYPE_ORDER) {
+    if (rt.votes[archetype] > bestVal) {
+      bestVal = rt.votes[archetype];
+      best = archetype;
+    }
+  }
+  return best;
+}
+
+export function deriveArchetype(rt: Runtime): Archetype {
+  return computeArchetype(rt);
+}
 
 export interface PortfolioAllocation {
   asset: string;
@@ -144,732 +718,6 @@ export function simulateTrades(archetype: Archetype): SimulatedTrade[] {
   }
   return trades;
 }
-export const BAR_SLOTS: Capsule[] = [
-  'speed',
-  'missile',
-  'double',
-  'laser',
-  'option',
-  'shield',
-];
-
-const SLOT_LABEL: Record<Capsule, string> = {
-  speed: 'SPD',
-  missile: 'MIS',
-  double: 'DBL',
-  laser: 'LSR',
-  option: 'OPT',
-  shield: 'SHD',
-};
-
-const MOAI_CYCLE: MoaiId[] = ['aegis', 'razor', 'oracle', 'comet', 'hive'];
-
-interface PlayerState {
-  x: number;
-  y: number;
-  hp: number;
-  iframes: number;
-}
-
-interface Bullet {
-  x: number;
-  y: number;
-  vx: number;
-  vy?: number;
-  kind: 'plain' | 'laser';
-}
-
-interface Grunt {
-  type: 'grunt';
-  id: string;
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  phase: number;
-  hp: number;
-  spawnAt: number;
-  tradeoffLeft: string;
-  tradeoffRight: string;
-  capsule: Capsule;
-}
-
-interface MoaiBoss {
-  type: 'moai';
-  id: string;
-  x: number;
-  y: number;
-  vx: number;
-  targetX: number;
-  hp: number;
-  maxHp: number;
-  fromTop: boolean;
-  chargeT: number;
-  fireCool: number;
-  moaiId: MoaiId;
-  spawnAt: number;
-}
-
-type Enemy = Grunt | MoaiBoss;
-
-interface Ring {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  life: number;
-  born: number;
-  phase: number;
-  sym: string;
-}
-
-interface EnemyBullet {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  life: number;
-}
-
-interface CapsulePickup {
-  x: number;
-  y: number;
-  vx: number;
-  capsule: Capsule;
-  life: number;
-}
-
-interface Explosion {
-  x: number;
-  y: number;
-  t: number;
-  kind: 'spark' | 'mid' | 'big';
-}
-
-interface Toast {
-  text: string;
-  color: string;
-  life: number;
-  maxLife: number;
-}
-
-interface Option {
-  ang: number;
-}
-
-const TRADEOFF_PAIRS: { left: string; right: string; capsule: Capsule }[] = [
-  { left: 'SLOW SAFE', right: 'FAST RISKY', capsule: 'speed' },
-  { left: 'CONCENTRATED', right: 'DIVERSIFIED', capsule: 'laser' },
-  { left: 'CONSERVATIVE', right: 'AGGRESSIVE', capsule: 'shield' },
-  { left: 'LONG HORIZON', right: 'SHORT HORIZON', capsule: 'missile' },
-  { left: 'SOLO', right: 'COOPERATIVE', capsule: 'option' },
-  { left: 'LOW LEVERAGE', right: 'HIGH LEVERAGE', capsule: 'double' },
-];
-
-export interface InputState {
-  up: boolean;
-  down: boolean;
-  left: boolean;
-  right: boolean;
-  fire: boolean;
-}
-
-export interface Runtime {
-  t: number;
-  player: PlayerState;
-  bullets: Bullet[];
-  enemies: Enemy[];
-  rings: Ring[];
-  enemyBullets: EnemyBullet[];
-  capsules: CapsulePickup[];
-  explosions: Explosion[];
-  options: Option[];
-  toasts: Toast[];
-  stars: Star[];
-  terrain: Terrain;
-  events: PlayEvent[];
-  score: number;
-  bar: number;
-  barCommitted: number;
-  chain: ChainId;
-  gasBudget: number;
-  txCount: number;
-  lagFlash: number;
-  weapon: 'SINGLE' | 'DOUBLE' | 'LASER';
-  speedTier: number;
-  hasShield: boolean;
-  optionCount: number;
-  capsulesPicked: Record<Capsule, number>;
-  commits: Record<Capsule, number>;
-  moaisDown: number;
-  moaisDefeated: Record<MoaiId, boolean>;
-  moaisCycleIndex: number;
-  nextGruntAt: number;
-  nextMoaiAt: number;
-  finished: boolean;
-  finishReason: 'time' | 'hp' | 'cleared' | null;
-  introT: number;
-  warningT: number;
-  enemyCounter: number;
-  bossCounter: number;
-  apy: number;
-  risk: number;
-  lastCommitAt: number;
-}
-
-export function createRuntime(chain: ChainId = 'ARB'): Runtime {
-  return {
-    t: 0,
-    player: { x: 60, y: PLAY_H / 2, hp: 4, iframes: 60 },
-    bullets: [],
-    enemies: [],
-    rings: [],
-    enemyBullets: [],
-    capsules: [],
-    explosions: [],
-    options: [],
-    toasts: [],
-    stars: makeStars(),
-    terrain: makeTerrain(),
-    events: [],
-    score: 0,
-    bar: -1,
-    barCommitted: -1,
-    chain,
-    gasBudget: 1,
-    txCount: 0,
-    lagFlash: 0,
-    weapon: 'SINGLE',
-    speedTier: 1,
-    hasShield: false,
-    optionCount: 0,
-    capsulesPicked: {
-      speed: 0,
-      missile: 0,
-      double: 0,
-      laser: 0,
-      option: 0,
-      shield: 0,
-    },
-    commits: {
-      speed: 0,
-      missile: 0,
-      double: 0,
-      laser: 0,
-      option: 0,
-      shield: 0,
-    },
-    moaisDown: 0,
-    moaisDefeated: {
-      aegis: false,
-      razor: false,
-      oracle: false,
-      comet: false,
-      hive: false,
-    },
-    moaisCycleIndex: 0,
-    nextGruntAt: 60,
-    nextMoaiAt: 60 * 12,
-    finished: false,
-    finishReason: null,
-    introT: 60 * 2,
-    warningT: 0,
-    enemyCounter: 0,
-    bossCounter: 0,
-    apy: 4,
-    risk: 1,
-    lastCommitAt: -1000,
-  };
-}
-
-function pushToast(rt: Runtime, text: string, color: string) {
-  rt.toasts.unshift({ text, color, life: 90, maxLife: 90 });
-  if (rt.toasts.length > 4) rt.toasts.pop();
-}
-
-function elapsedMs(rt: Runtime) {
-  return Math.round((rt.t / 60) * 1000);
-}
-
-function commitCapsule(rt: Runtime) {
-  if (rt.bar < 0 || rt.t - rt.lastCommitAt < 30) return;
-  const slot = BAR_SLOTS[rt.bar];
-  if (!slot) return;
-  rt.barCommitted = rt.bar;
-  rt.commits[slot] += 1;
-  rt.lastCommitAt = rt.t;
-  rt.events.push({
-    kind: 'commit',
-    t: elapsedMs(rt),
-    position: rt.bar,
-    capsule: slot,
-  });
-  switch (slot) {
-    case 'speed':
-      rt.speedTier = Math.min(5, rt.speedTier + 1);
-      pushToast(rt, `+SPEED L${rt.speedTier}`, PAL.shipFlame);
-      break;
-    case 'missile':
-      rt.apy += 1;
-      rt.risk = Math.min(10, rt.risk + 1);
-      pushToast(rt, `+APY ${rt.apy}% +RISK`, PAL.ringCyan);
-      break;
-    case 'double':
-      rt.weapon = 'DOUBLE';
-      pushToast(rt, 'DOUBLE WEAPON', PAL.shipRed);
-      break;
-    case 'laser':
-      rt.weapon = 'LASER';
-      rt.apy += 2;
-      pushToast(rt, 'LASER · ALL-IN', PAL.ringCore);
-      break;
-    case 'option':
-      rt.optionCount = Math.min(2, rt.optionCount + 1);
-      rt.options.push({ ang: rt.options.length * Math.PI });
-      pushToast(rt, `+PEER OPTION (${rt.optionCount})`, PAL.shipFlame);
-      break;
-    case 'shield':
-      rt.hasShield = true;
-      rt.player.hp = Math.min(5, rt.player.hp + 1);
-      pushToast(rt, '+SHIELD +HP', PAL.ok);
-      break;
-  }
-  rt.bar = -1;
-  rt.explosions.push({
-    x: rt.player.x + 12,
-    y: rt.player.y + 4,
-    t: 0,
-    kind: 'mid',
-  });
-}
-
-function spawnGruntWave(rt: Runtime) {
-  rt.enemyCounter += 1;
-  const tradeoff = TRADEOFF_PAIRS[rt.enemyCounter % TRADEOFF_PAIRS.length];
-  const wave = 4 + ((rt.enemyCounter * 7) % 3);
-  const yBase = 30 + ((rt.enemyCounter * 31) % 80);
-  for (let i = 0; i < wave; i += 1) {
-    rt.enemies.push({
-      type: 'grunt',
-      id: `g-${rt.enemyCounter}-${i}`,
-      x: RW + 16 + i * 18,
-      y: yBase + i * 14 + Math.sin(rt.t * 0.01 + i) * 4,
-      vx: -1.1,
-      vy: 0,
-      phase: rt.t * 0.02 + i,
-      hp: 1,
-      spawnAt: rt.t,
-      tradeoffLeft: tradeoff?.left ?? 'CHOICE',
-      tradeoffRight: tradeoff?.right ?? 'OTHER',
-      capsule: tradeoff?.capsule ?? 'speed',
-    });
-  }
-}
-
-function spawnNextMoai(rt: Runtime) {
-  if (rt.moaisCycleIndex >= MOAI_CYCLE.length) return;
-  const moaiId = MOAI_CYCLE[rt.moaisCycleIndex];
-  if (!moaiId) return;
-  rt.moaisCycleIndex += 1;
-  rt.bossCounter += 1;
-  const fromTop = rt.bossCounter % 2 === 0;
-  const targetX = RW - 60 - (rt.bossCounter % 3) * 32;
-  rt.enemies.push({
-    type: 'moai',
-    id: `m-${moaiId}`,
-    x: RW + 24,
-    y: fromTop ? 14 : PLAY_H - 42,
-    vx: -0.4,
-    targetX,
-    hp: 8,
-    maxHp: 8,
-    fromTop,
-    chargeT: 0,
-    fireCool: 200,
-    moaiId,
-    spawnAt: rt.t,
-  });
-  rt.warningT = 90;
-  pushToast(rt, `WARNING · ${moaiId.toUpperCase()} MOAI`, PAL.warn);
-}
-
-function optionPos(rt: Runtime, o: Option) {
-  return {
-    x: rt.player.x + Math.cos(o.ang) * 18 - 3,
-    y: rt.player.y + Math.sin(o.ang) * 14 + 2,
-  };
-}
-
-function fireBullets(rt: Runtime) {
-  const chain = CHAINS[rt.chain];
-  const vx = chain.bulletVx;
-  if (rt.weapon === 'LASER') {
-    rt.bullets.push({
-      x: rt.player.x + 14,
-      y: rt.player.y + 4,
-      vx: vx * 1.6,
-      kind: 'laser',
-    });
-  } else if (rt.weapon === 'DOUBLE') {
-    rt.bullets.push({
-      x: rt.player.x + 14,
-      y: rt.player.y + 4,
-      vx,
-      kind: 'plain',
-    });
-    rt.bullets.push({
-      x: rt.player.x + 14,
-      y: rt.player.y + 4,
-      vx,
-      vy: -1.6,
-      kind: 'plain',
-    });
-  } else {
-    rt.bullets.push({
-      x: rt.player.x + 14,
-      y: rt.player.y + 4,
-      vx,
-      kind: 'plain',
-    });
-  }
-  for (const o of rt.options) {
-    const op = optionPos(rt, o);
-    rt.bullets.push({ x: op.x + 4, y: op.y + 2, vx, kind: 'plain' });
-  }
-}
-
-export function step(rt: Runtime, input: InputState) {
-  if (rt.finished) return;
-  rt.t += 1;
-  const chain = CHAINS[rt.chain];
-
-  if (rt.introT > 0) rt.introT -= 1;
-  if (rt.warningT > 0) rt.warningT -= 1;
-  if (rt.lagFlash > 0) rt.lagFlash -= 1;
-
-  // Movement
-  const speed = 1.1 + rt.speedTier * 0.2;
-  if (input.up) rt.player.y -= speed;
-  if (input.down) rt.player.y += speed;
-  if (input.left) rt.player.x -= speed;
-  if (input.right) rt.player.x += speed;
-  rt.player.x = Math.max(8, Math.min(RW - 28, rt.player.x));
-  rt.player.y = Math.max(8, Math.min(PLAY_H - 16, rt.player.y));
-
-  // Fire
-  if (
-    input.fire &&
-    rt.t % chain.fireCadence === 0 &&
-    rt.gasBudget > 0 &&
-    rt.introT <= 0
-  ) {
-    rt.gasBudget = Math.max(0, rt.gasBudget - chain.gasPerShot);
-    rt.txCount += 1;
-    if (Math.random() < chain.lagChance) {
-      rt.lagFlash = 30;
-    } else {
-      fireBullets(rt);
-    }
-  }
-
-  // Stars
-  for (const s of rt.stars) {
-    s.x -= s.speed * 0.018;
-    if (s.x < 0) {
-      s.x = RW;
-      s.y = Math.random() * PLAY_H;
-    }
-  }
-  rt.terrain.scroll += 0.6 * (chain.enemyVx / 1);
-
-  // Spawning
-  if (rt.t > 60 && rt.t < GAME_DURATION_FRAMES - 30) {
-    rt.nextGruntAt -= 1;
-    if (rt.nextGruntAt <= 0) {
-      spawnGruntWave(rt);
-      rt.nextGruntAt = 180;
-    }
-    rt.nextMoaiAt -= 1;
-    const liveMoai = rt.enemies.some((e) => e.type === 'moai');
-    if (rt.nextMoaiAt <= 0 && !liveMoai) {
-      spawnNextMoai(rt);
-      rt.nextMoaiAt = 60 * 18;
-    }
-  }
-
-  // Bullets
-  rt.bullets = rt.bullets.filter((b) => {
-    b.x += b.vx;
-    if (b.vy) b.y += b.vy;
-    return b.x < RW + 8;
-  });
-
-  // Enemies update
-  for (const e of rt.enemies) {
-    if (e.type === 'grunt') {
-      e.x += e.vx;
-      e.y += Math.sin(rt.t * 0.06 + e.phase) * 0.7;
-      if (
-        rt.t % 110 === Math.floor(e.phase * 13) % 110 &&
-        e.x < RW - 6 &&
-        e.x > 0
-      ) {
-        const dx = rt.player.x - e.x;
-        const dy = rt.player.y - e.y;
-        const m = Math.hypot(dx, dy) || 1;
-        rt.enemyBullets.push({
-          x: e.x,
-          y: e.y + 4,
-          vx: (dx / m) * 1.2,
-          vy: (dy / m) * 1.2,
-          life: 240,
-        });
-      }
-    } else {
-      if (e.x > e.targetX) e.x += e.vx;
-      else e.vx = 0;
-      e.fireCool -= 1;
-      if (e.fireCool === 60) e.chargeT = 60;
-      if (e.fireCool <= 0 && e.x < RW - 8) {
-        const mx = e.x + 11;
-        const my = e.fromTop ? e.y + 23 : e.y + 14;
-        const ang = Math.atan2(rt.player.y - my, rt.player.x - mx);
-        const sym =
-          TX_SYMBOLS[Math.floor(rt.t / 60) % TX_SYMBOLS.length] ?? 'TX';
-        for (let i = 0; i < 5; i += 1) {
-          rt.rings.push({
-            x: mx,
-            y: my,
-            vx: Math.cos(ang) * 1.3,
-            vy: Math.sin(ang) * 1.3,
-            life: 320,
-            born: rt.t + i * 12,
-            phase: i * 0.7,
-            sym,
-          });
-        }
-        e.fireCool = 240;
-      }
-      if (e.chargeT > 0) e.chargeT -= 1;
-    }
-  }
-
-  // Bullet vs enemy
-  for (const b of rt.bullets) {
-    for (const e of rt.enemies) {
-      const bw = e.type === 'moai' ? 24 : 12;
-      const bh = e.type === 'moai' ? 28 : 10;
-      const blen = b.kind === 'laser' ? 16 : 6;
-      if (
-        b.x < e.x + bw &&
-        b.x + blen > e.x &&
-        b.y < e.y + bh &&
-        b.y + 2 > e.y
-      ) {
-        e.hp -= b.kind === 'laser' ? 2 : 1;
-        if (b.kind !== 'laser') b.x = RW + 100;
-        rt.explosions.push({ x: b.x, y: b.y, t: 0, kind: 'spark' });
-        if (e.hp <= 0) {
-          if (e.type === 'moai') {
-            rt.score += 1500;
-            rt.moaisDown += 1;
-            rt.moaisDefeated[e.moaiId] = true;
-            rt.events.push({
-              kind: 'moaiKill',
-              t: elapsedMs(rt),
-              moaiId: e.moaiId,
-            });
-            rt.explosions.push({
-              x: e.x + 12,
-              y: e.y + 14,
-              t: 0,
-              kind: 'big',
-            });
-            rt.capsules.push({
-              x: e.x + 8,
-              y: e.y + 12,
-              vx: -0.6,
-              capsule: e.moaiId === 'hive' ? 'option' : 'shield',
-              life: 360,
-            });
-            pushToast(
-              rt,
-              `${e.moaiId.toUpperCase()} DOWN +1500`,
-              PAL.hudYellow
-            );
-          } else {
-            rt.score += 100;
-            rt.events.push({
-              kind: 'shoot',
-              t: elapsedMs(rt),
-              enemyId: e.id,
-              tradeoffLabel: e.tradeoffLeft,
-            });
-            rt.explosions.push({
-              x: e.x + 4,
-              y: e.y + 4,
-              t: 0,
-              kind: 'mid',
-            });
-            if (Math.random() < 0.45) {
-              rt.capsules.push({
-                x: e.x + 2,
-                y: e.y + 4,
-                vx: -0.6,
-                capsule: e.capsule,
-                life: 240,
-              });
-            }
-          }
-        }
-      }
-    }
-  }
-  rt.enemies = rt.enemies.filter((e) => {
-    if (e.hp <= 0) return false;
-    if (e.x < -40) {
-      if (e.type === 'grunt') {
-        rt.events.push({
-          kind: 'pass',
-          t: elapsedMs(rt),
-          enemyId: e.id,
-          tradeoffLabel: e.tradeoffRight,
-        });
-      }
-      return false;
-    }
-    return true;
-  });
-
-  // Rings
-  rt.rings = rt.rings.filter((r) => {
-    if (rt.t < r.born) return true;
-    r.x += r.vx;
-    r.y += r.vy;
-    r.life -= 1;
-    return (
-      r.life > 0 && r.x > -16 && r.x < RW + 16 && r.y > -16 && r.y < PLAY_H + 16
-    );
-  });
-
-  // Enemy bullets
-  rt.enemyBullets = rt.enemyBullets.filter((b) => {
-    b.x += b.vx;
-    b.y += b.vy;
-    b.life -= 1;
-    return (
-      b.life > 0 && b.x > -8 && b.x < RW + 8 && b.y > -8 && b.y < PLAY_H + 8
-    );
-  });
-
-  // Capsules drift + pickup
-  rt.capsules = rt.capsules.filter((c) => {
-    c.x += c.vx;
-    c.life -= 1;
-    if (Math.abs(c.x - rt.player.x) < 14 && Math.abs(c.y - rt.player.y) < 12) {
-      const next = rt.bar < 0 ? 0 : (rt.bar + 1) % BAR_SLOTS.length;
-      rt.bar = next;
-      rt.capsulesPicked[c.capsule] += 1;
-      rt.events.push({
-        kind: 'capsule',
-        t: elapsedMs(rt),
-        capsule: c.capsule,
-      });
-      rt.events.push({
-        kind: 'barAdvance',
-        t: elapsedMs(rt),
-        position: rt.bar,
-      });
-      const barLabel = BAR_SLOTS[rt.bar];
-      pushToast(
-        rt,
-        `+${SLOT_LABEL[c.capsule]} → BAR ${barLabel ? SLOT_LABEL[barLabel] : '—'}`,
-        PAL.ringCyan
-      );
-      return false;
-    }
-    return c.x > -10 && c.life > 0;
-  });
-
-  // Player vs hazards
-  if (rt.player.iframes > 0) rt.player.iframes -= 1;
-  const hit = (hx: number, hy: number, hr: number) => {
-    const dx = rt.player.x + 8 - hx;
-    const dy = rt.player.y + 5 - hy;
-    return dx * dx + dy * dy < hr * hr;
-  };
-  if (rt.player.iframes <= 0 && rt.introT <= 0) {
-    for (const r of rt.rings) {
-      if (rt.t < r.born) continue;
-      if (hit(r.x, r.y, 5)) {
-        if (rt.hasShield) {
-          rt.hasShield = false;
-          pushToast(rt, 'SHIELD ABSORBED', PAL.ringCyan);
-        } else {
-          rt.player.hp -= 1;
-          rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 1 });
-        }
-        rt.player.iframes = 60;
-        rt.explosions.push({
-          x: rt.player.x,
-          y: rt.player.y,
-          t: 0,
-          kind: 'mid',
-        });
-        break;
-      }
-    }
-    if (rt.player.iframes <= 0) {
-      for (const b of rt.enemyBullets) {
-        if (hit(b.x, b.y, 4)) {
-          if (rt.hasShield) {
-            rt.hasShield = false;
-            pushToast(rt, 'SHIELD ABSORBED', PAL.ringCyan);
-          } else {
-            rt.player.hp -= 1;
-            rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 1 });
-          }
-          rt.player.iframes = 60;
-          rt.explosions.push({
-            x: rt.player.x,
-            y: rt.player.y,
-            t: 0,
-            kind: 'mid',
-          });
-          break;
-        }
-      }
-    }
-  }
-
-  // Options orbit
-  for (const o of rt.options) o.ang += 0.06;
-
-  // Explosions
-  for (const ex of rt.explosions) ex.t += 1;
-  rt.explosions = rt.explosions.filter(
-    (ex) => ex.t < (ex.kind === 'big' ? 32 : ex.kind === 'mid' ? 16 : 6)
-  );
-
-  // Toasts
-  for (const t of rt.toasts) t.life -= 1;
-  rt.toasts = rt.toasts.filter((t) => t.life > 0);
-
-  // End conditions
-  if (rt.player.hp <= 0) {
-    rt.finished = true;
-    rt.finishReason = 'hp';
-  } else if (rt.t >= GAME_DURATION_FRAMES) {
-    rt.finished = true;
-    rt.finishReason = 'time';
-  } else if (
-    rt.moaisDown >= MOAI_CYCLE.length &&
-    rt.enemies.every((e) => e.type !== 'moai')
-  ) {
-    rt.finished = true;
-    rt.finishReason = 'cleared';
-  }
-}
 
 export function buildPlayLog(rt: Runtime, sessionId: string): PlayLog {
   return {
@@ -894,245 +742,180 @@ export function render(ctx: CanvasRenderingContext2D, rt: Runtime) {
   drawTerrainStrip(ctx, rt.terrain.ceiling, rt.terrain.scroll, false);
   drawTerrainStrip(ctx, rt.terrain.floor, rt.terrain.scroll, true);
 
-  // Capsules
-  for (const c of rt.capsules) {
-    const blink = (rt.t >> 2) % 2 === 0;
-    ctx.fillStyle = blink ? PAL.ringCyan : PAL.ringCore;
-    ctx.fillRect((c.x | 0) - 3, (c.y | 0) - 2, 7, 5);
-    ctx.fillStyle = PAL.deepBlue;
-    ctx.fillRect((c.x | 0) - 2, (c.y | 0) - 1, 5, 3);
-    pixelText(ctx, '?', (c.x | 0) - 1, (c.y | 0) - 2, PAL.ringCore);
+  // Particles behind enemies
+  for (const p of rt.particles) {
+    const alpha = Math.max(0, p.life / p.maxLife);
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = p.color;
+    ctx.fillRect(Math.round(p.x), Math.round(p.y), p.size, p.size);
+    ctx.globalAlpha = 1;
   }
 
   // Enemies
   for (const e of rt.enemies) {
     if (e.type === 'grunt') {
-      drawSprite(ctx, GRUNT, GRUNT_KEY, e.x | 0, e.y | 0);
+      // Glow ring around tutorial enemy to draw attention
+      if (e.isTutorial && rt.score === 0) {
+        ctx.fillStyle = e.color;
+        ctx.globalAlpha = 0.3 + Math.sin(rt.t * 0.2) * 0.2;
+        ctx.beginPath();
+        ctx.arc(e.x + 6, e.y + 5, 14, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+      }
+      drawSprite(ctx, GRUNT, e.spriteKey, e.x | 0, e.y | 0);
     } else {
       const key = e.chargeT > 0 ? MOAI_CHARGE_KEY : MOAI_KEY;
       drawSprite(ctx, MOAI, key, e.x | 0, e.y | 0, false, e.fromTop);
       const ratio = Math.max(0, e.hp / e.maxHp);
-      const barX = (e.x | 0) - 2;
-      const barY = (e.y | 0) - 4;
       ctx.fillStyle = PAL.deepBlue;
-      ctx.fillRect(barX, barY, 28, 2);
+      ctx.fillRect((e.x | 0) - 2, (e.y | 0) - 4, 28, 2);
       ctx.fillStyle = ratio > 0.4 ? PAL.ok : PAL.warn;
-      ctx.fillRect(barX, barY, Math.round(28 * ratio), 2);
+      ctx.fillRect((e.x | 0) - 2, (e.y | 0) - 4, Math.round(28 * ratio), 2);
     }
   }
 
-  // Player bullets
+  // Bullets
   for (const b of rt.bullets) {
-    if (b.kind === 'laser') {
-      ctx.fillStyle = PAL.ringCore;
-      ctx.fillRect(b.x | 0, b.y | 0, 16, 1);
-      ctx.fillStyle = PAL.ringCyan;
-      ctx.fillRect(b.x | 0, (b.y | 0) + 1, 16, 1);
-    } else {
-      ctx.fillStyle = PAL.bullet;
-      ctx.fillRect(b.x | 0, b.y | 0, 6, 2);
-      ctx.fillStyle = PAL.shipFlame;
-      ctx.fillRect((b.x | 0) + 4, b.y | 0, 2, 2);
-    }
+    ctx.fillStyle = PAL.bullet;
+    ctx.fillRect(b.x | 0, b.y | 0, 6, 2);
+    ctx.fillStyle = PAL.shipFlame;
+    ctx.fillRect((b.x | 0) + 4, b.y | 0, 2, 2);
   }
-
-  // Rings
-  for (const r of rt.rings) {
-    if (rt.t < r.born) continue;
-    const phase = (rt.t - r.born) * 0.18 + r.phase;
-    const radius = 4 + ((Math.sin(phase) * 0.5) | 0);
-    drawRing(ctx, r.x | 0, r.y | 0, radius, r.sym, PAL.ringCyan, PAL.ringCore);
-  }
-
-  // Enemy bullets
   for (const b of rt.enemyBullets) {
     ctx.fillStyle = PAL.ringCore;
     ctx.fillRect((b.x | 0) - 1, (b.y | 0) - 1, 3, 3);
   }
 
-  // Options
-  for (const o of rt.options) {
-    const op = optionPos(rt, o);
-    drawSprite(ctx, OPTION_SPR, OPTION_KEY, op.x | 0, op.y | 0);
-  }
-
   // Player
   if (!(rt.player.iframes > 0 && (rt.t >> 1) % 2 === 0)) {
     drawSprite(ctx, VIC_VIPER, VIC_KEY, rt.player.x | 0, rt.player.y | 0);
-    if (rt.hasShield) {
-      ctx.fillStyle = PAL.ringCyan;
-      const px = rt.player.x | 0;
-      const py = rt.player.y | 0;
-      ctx.fillRect(px + 18, py + 2, 2, 2);
-      ctx.fillRect(px + 20, py + 1, 2, 4);
-      ctx.fillRect(px + 22, py + 3, 1, 1);
+  }
+
+  // Score pops
+  for (const p of rt.scorePops) {
+    const alpha = Math.max(0, p.life);
+    ctx.globalAlpha = Math.min(1, alpha);
+    ctx.fillStyle = p.color;
+    pixelText(
+      ctx,
+      p.text,
+      (p.x | 0) - p.text.length * 3,
+      (p.y | 0) - 6,
+      p.color
+    );
+    ctx.globalAlpha = 1;
+  }
+
+  // Tutorial prompt — Mario 1-1: a single instruction at the right moment
+  if (rt.showTutorialPrompt && rt.spawnedTutorial && rt.score === 0) {
+    const flicker = (rt.t >> 4) % 2 === 0;
+    if (flicker) {
+      ctx.fillStyle = 'rgba(0, 16, 42, 0.78)';
+      ctx.fillRect(RW / 2 - 78, 30, 156, 22);
+      pixelText(ctx, 'JUST MOVE → DESTROY!', RW / 2 - 60, 38, PAL.hudYellow);
     }
   }
 
-  // Explosions
-  for (const ex of rt.explosions) {
-    drawExplosion(ctx, ex.x, ex.y, ex.t, ex.kind);
-  }
-
-  // WARNING banner
+  // WARNING banner before Moai
   if (rt.warningT > 0) {
     const flicker = (rt.warningT >> 2) % 2 === 0;
     if (flicker) {
       ctx.fillStyle = 'rgba(255, 48, 96, 0.32)';
       ctx.fillRect(0, PLAY_H / 2 - 14, RW, 28);
-      drawBigText(ctx, 'WARNING', RW / 2 - 42, PLAY_H / 2 - 7, PAL.warn);
+      drawBigText(ctx, 'DODGE!', RW / 2 - 36, PLAY_H / 2 - 7, PAL.warn);
     }
   }
 
-  // Intro banner
-  if (rt.introT > 0) {
-    ctx.fillStyle = 'rgba(0, 16, 42, 0.78)';
-    ctx.fillRect(0, PLAY_H / 2 - 18, RW, 36);
-    drawBigText(ctx, 'STAGE 1', RW / 2 - 42, PLAY_H / 2 - 14, PAL.hudYellow);
-    pixelText(
-      ctx,
-      'MOAI · WEB3 ONBOARDING',
-      RW / 2 - 66,
-      PLAY_H / 2 + 5,
-      PAL.shipWhite
-    );
+  // Damage flash overlay
+  if (rt.flashT > 0) {
+    const a = (rt.flashT / 12) * 0.4;
+    ctx.fillStyle = `rgba(255, 80, 80, ${a})`;
+    ctx.fillRect(0, 0, RW, PLAY_H);
   }
 
   drawHud(ctx, rt);
 }
 
-function drawExplosion(
-  ctx: CanvasRenderingContext2D,
-  cx: number,
-  cy: number,
-  t: number,
-  kind: Explosion['kind']
-) {
-  const max = kind === 'big' ? 22 : kind === 'mid' ? 12 : 4;
-  const r = Math.min(max, 2 + t);
-  const colors = [PAL.shipFlame, PAL.shipRed, PAL.shipFlame2, PAL.bullet];
-  const count = kind === 'big' ? 22 : kind === 'mid' ? 12 : 4;
-  for (let i = 0; i < count; i += 1) {
-    const a = (i / count) * Math.PI * 2;
-    const rr = r * (0.6 + ((i * 7) % 5) / 10);
-    const x = Math.round(cx + Math.cos(a) * rr);
-    const y = Math.round(cy + Math.sin(a) * rr);
-    const color = colors[(i + t) % 4];
-    if (color) ctx.fillStyle = color;
-    ctx.fillRect(x, y, 2, 2);
-  }
-}
-
 function drawHud(ctx: CanvasRenderingContext2D, rt: Runtime) {
-  // Top status strip (above play)
-  ctx.fillStyle = 'rgba(0, 16, 42, 0.85)';
-  ctx.fillRect(0, 0, RW, 12);
-  const timeLeft = Math.max(0, GAME_DURATION_FRAMES - rt.t);
-  const sec = Math.ceil(timeLeft / 60);
-  pixelText(ctx, `TIME ${String(sec).padStart(2, '0')}`, 4, 2, PAL.hudWhite);
-  pixelText(
-    ctx,
-    `MOAI ${rt.moaisDown}/${MOAI_CYCLE.length}`,
-    66,
-    2,
-    PAL.hudYellow
-  );
-  pixelText(ctx, `APY ${rt.apy}%`, 138, 2, PAL.shipFlame);
-  pixelText(ctx, `RISK ${rt.risk}/10`, 184, 2, PAL.warn);
-
-  // Web3 chain row
-  ctx.fillStyle = 'rgba(0, 16, 42, 0.85)';
-  ctx.fillRect(0, PLAY_H - 12, RW, 12);
-  const chain = CHAINS[rt.chain];
-  ctx.fillStyle = chain.color;
-  ctx.fillRect(2, PLAY_H - 11, 4, 10);
-  pixelText(ctx, chain.name, 9, PLAY_H - 10, chain.color);
-  pixelText(ctx, 'GAS', 80, PLAY_H - 10, PAL.hudWhite);
-  const gasW = 60;
-  ctx.fillStyle = PAL.hudGray;
-  ctx.fillRect(98, PLAY_H - 9, gasW, 5);
-  ctx.fillStyle = rt.gasBudget > 0.3 ? PAL.ok : PAL.warn;
-  ctx.fillRect(98, PLAY_H - 9, (gasW * rt.gasBudget) | 0, 5);
-  pixelText(
-    ctx,
-    `TX ${String(rt.txCount).padStart(3, '0')}`,
-    164,
-    PLAY_H - 10,
-    PAL.hudYellow
-  );
-  if (rt.lagFlash > 0) {
-    pixelText(ctx, 'TX DROPPED', RW / 2 - 30, PLAY_H - 28, PAL.warn);
+  // Top bar — vote counts (the only HUD that matters)
+  ctx.fillStyle = 'rgba(0, 16, 42, 0.92)';
+  ctx.fillRect(0, 0, RW, 14);
+  const slotW = (RW - 8) / 3;
+  for (let i = 0; i < ARCHETYPE_ORDER.length; i += 1) {
+    const archetype = ARCHETYPE_ORDER[i];
+    if (!archetype) continue;
+    const x = 4 + i * slotW;
+    const isLeader = rt.archetypePeek === archetype && rt.score > 0;
+    const color = ARCHETYPE_COLOR[archetype];
+    ctx.fillStyle = isLeader ? color : 'rgba(255,255,255,0.06)';
+    ctx.fillRect(x, 2, slotW - 4, 10);
+    if (!isLeader) {
+      ctx.fillStyle = color;
+      ctx.fillRect(x, 2, 3, 10);
+    }
+    pixelText(
+      ctx,
+      ARCHETYPE_GLYPH[archetype],
+      x + 6,
+      4,
+      isLeader ? PAL.black : color
+    );
+    pixelText(
+      ctx,
+      String(rt.votes[archetype]).padStart(2, '0'),
+      x + slotW - 18,
+      4,
+      isLeader ? PAL.black : PAL.hudWhite
+    );
   }
 
-  // Bottom HUD with lives + power bar
+  // Bottom HUD
   ctx.fillStyle = PAL.deepBlue;
   ctx.fillRect(0, PLAY_H, RW, 24);
   ctx.fillStyle = PAL.hudGray;
   ctx.fillRect(0, PLAY_H, RW, 1);
 
+  // Hull (lives)
   for (let i = 0; i < rt.player.hp; i += 1) {
     drawTinyShip(ctx, 4 + i * 9, PLAY_H + 14);
   }
 
-  const slotW = 32;
-  const startX = 36;
-  const slotY = PLAY_H + 2;
-  for (let i = 0; i < BAR_SLOTS.length; i += 1) {
-    const sx = startX + i * (slotW + 2);
-    const slotKey = BAR_SLOTS[i];
-    if (!slotKey) continue;
-    const isActive = i === rt.bar;
-    const isCommitted = rt.commits[slotKey] > 0;
-    ctx.fillStyle = isActive ? PAL.hudOrange : PAL.hudBlue;
-    ctx.fillRect(sx, slotY, slotW, 9);
-    ctx.fillStyle = isActive
-      ? PAL.hudYellow
-      : isCommitted
-        ? PAL.ok
-        : PAL.hudWhite;
-    ctx.fillRect(sx, slotY, slotW, 1);
-    ctx.fillRect(sx, slotY + 8, slotW, 1);
-    ctx.fillRect(sx, slotY, 1, 9);
-    ctx.fillRect(sx + slotW - 1, slotY, 1, 9);
-    pixelText(
-      ctx,
-      SLOT_LABEL[slotKey],
-      sx + slotW / 2 - 8,
-      slotY + 1,
-      isActive ? PAL.black : PAL.hudWhite
-    );
-    if (rt.commits[slotKey] > 0) {
-      pixelText(
-        ctx,
-        String(rt.commits[slotKey]),
-        sx + slotW - 6,
-        slotY + 1,
-        PAL.hudYellow
-      );
+  // Time + score
+  const sec = Math.max(0, Math.ceil((GAME_DURATION_FRAMES - rt.t) / 60));
+  pixelText(ctx, 'TIME', 56, PLAY_H + 6, PAL.hudWhite);
+  pixelText(ctx, String(sec).padStart(2, '0'), 82, PLAY_H + 6, PAL.hudYellow);
+  pixelText(ctx, 'SCORE', 56, PLAY_H + 16, PAL.hudWhite);
+  pixelText(
+    ctx,
+    String(rt.score).padStart(6, '0'),
+    92,
+    PLAY_H + 16,
+    PAL.hudYellow
+  );
+
+  // Arrow keys glyph (Mario 1-1 visual hint that survives only first 3s)
+  if (rt.t < TUTORIAL_FRAMES) {
+    const flicker = (rt.t >> 4) % 2 === 0;
+    if (flicker) {
+      pixelText(ctx, 'MOVE', RW - 64, PLAY_H + 6, PAL.shipWhite);
+      ctx.fillStyle = PAL.hudWhite;
+      ctx.fillRect(RW - 22, PLAY_H + 8, 4, 1);
+      ctx.fillRect(RW - 16, PLAY_H + 8, 4, 1);
+      ctx.fillRect(RW - 10, PLAY_H + 8, 4, 1);
     }
   }
 
-  // Score
-  pixelText(ctx, '1P', 4, PLAY_H + 14, PAL.hudWhite);
-  pixelText(
-    ctx,
-    String(rt.score).padStart(7, '0'),
-    18,
-    PLAY_H + 14,
-    PAL.hudYellow
-  );
-  pixelText(ctx, 'Z=COMMIT  SPACE=FIRE', RW - 124, PLAY_H + 14, PAL.shipWhite);
-
-  // Toast stack (top right)
+  // Toast strip (top-right) — only when meaningful
   for (let i = 0; i < rt.toasts.length; i += 1) {
     const toast = rt.toasts[i];
     if (!toast) continue;
     const alpha = Math.min(1, toast.life / 30);
     ctx.fillStyle = `rgba(0, 16, 42, ${0.85 * alpha})`;
-    ctx.fillRect(RW - 100, 14 + i * 9, 96, 8);
+    ctx.fillRect(RW - 100, 18 + i * 9, 96, 8);
     ctx.fillStyle = toast.color;
-    ctx.fillRect(RW - 100, 14 + i * 9, 2, 8);
-    pixelText(ctx, toast.text.slice(0, 14), RW - 96, 15 + i * 9, PAL.hudWhite);
+    ctx.fillRect(RW - 100, 18 + i * 9, 2, 8);
+    pixelText(ctx, toast.text.slice(0, 14), RW - 96, 19 + i * 9, PAL.hudWhite);
   }
 }
 
@@ -1148,12 +931,11 @@ function drawTinyShip(ctx: CanvasRenderingContext2D, x: number, y: number) {
   ctx.fillRect(x - 1, y + 3, 1, 1);
 }
 
-export function commit(rt: Runtime) {
-  commitCapsule(rt);
+// Compatibility shims (no-ops; the new design has no power-up bar)
+export function commit(_rt: Runtime) {
+  // no-op kept for callers
 }
-
 export function setChain(rt: Runtime, chain: ChainId) {
   rt.chain = chain;
 }
-
 export const TOTAL_FRAMES = GAME_DURATION_FRAMES;

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -142,6 +142,72 @@ button {
   padding: 24px;
 }
 
+.arcade-panel-clean {
+  background: linear-gradient(
+    180deg,
+    rgba(64, 224, 240, 0.04),
+    rgba(255, 209, 102, 0.03)
+  );
+}
+
+.arcade-press-start {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: max-content;
+  height: max-content;
+  padding: 14px 28px;
+  border-radius: 999px;
+  background: rgba(255, 209, 102, 0.92);
+  color: #04060f;
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 800;
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  border: 2px solid #fff;
+  cursor: pointer;
+  box-shadow: 0 0 32px rgba(255, 209, 102, 0.6);
+  animation: pressBlink 1s ease-in-out infinite;
+  z-index: 10;
+}
+
+@keyframes pressBlink {
+  0%,
+  60% {
+    opacity: 1;
+  }
+  61%,
+  100% {
+    opacity: 0.4;
+  }
+}
+
+.arcade-press-start:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  animation: none;
+}
+
+.hint-pill.subtle {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: transparent;
+  color: rgba(254, 250, 224, 0.6);
+}
+
+.arcade-tagline {
+  margin: 8px 0 0;
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(254, 250, 224, 0.6);
+}
+
+.arcade-tagline strong {
+  color: #ffd166;
+}
+
 .arcade-shell {
   display: grid;
   gap: 16px;
@@ -581,6 +647,896 @@ button {
 .hero-card .muted {
   color: rgba(254, 250, 224, 0.55);
   font-size: 0.84rem;
+}
+
+/* ===================== Landing page ===================== */
+
+.landing {
+  min-height: 100vh;
+  background: radial-gradient(
+      ellipse 1200px 600px at 80% -10%,
+      rgba(64, 224, 240, 0.08),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 800px 500px at 10% 20%,
+      rgba(255, 209, 102, 0.05),
+      transparent 60%
+    ), #04060f;
+  color: #fefae0;
+}
+
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 14px clamp(16px, 4vw, 56px);
+  background: rgba(4, 6, 15, 0.8);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.nav-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: "JetBrains Mono", monospace;
+}
+
+.brand-mark {
+  font-size: 18px;
+  font-weight: 800;
+  color: #ffd166;
+  letter-spacing: 0.06em;
+}
+
+.brand-tag {
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  color: #40e0f0;
+}
+
+.nav-links {
+  display: flex;
+  gap: 18px;
+  margin-left: auto;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.nav-links a {
+  color: rgba(254, 250, 224, 0.7);
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+
+.nav-links a:hover {
+  color: #ffd166;
+}
+
+.nav-cta {
+  appearance: none;
+  border: 1px solid #ffd166;
+  background: rgba(255, 209, 102, 0.16);
+  color: #ffd166;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.nav-cta:hover {
+  background: #ffd166;
+  color: #04060f;
+}
+
+.hero-grand {
+  padding: 56px clamp(20px, 4vw, 56px) 40px;
+  max-width: 1480px;
+  margin: 0 auto;
+  margin-bottom: 0;
+  background: transparent;
+  display: block;
+  border: none;
+  box-shadow: none;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: clamp(24px, 4vw, 56px);
+  align-items: center;
+}
+
+.hero-eyebrow {
+  display: inline-block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: #40e0f0;
+  padding: 6px 12px;
+  background: rgba(64, 224, 240, 0.08);
+  border: 1px solid rgba(64, 224, 240, 0.32);
+  border-radius: 999px;
+  margin-bottom: 20px;
+}
+
+.hero-grand h1 {
+  font-size: clamp(48px, 7vw, 88px);
+  line-height: 0.92;
+  letter-spacing: -0.04em;
+  margin: 0 0 18px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.hero-grand .hero-y {
+  color: #ffd166;
+  display: inline-block;
+}
+
+.hero-lede {
+  font-size: 17px;
+  line-height: 1.5;
+  color: rgba(254, 250, 224, 0.74);
+  max-width: 56ch;
+  margin: 0 0 24px;
+}
+
+.hero-cta {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.ghost-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 14px 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  color: #fefae0;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.04);
+  transition: background 120ms ease;
+}
+
+.ghost-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.hero-form {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  max-width: 360px;
+  margin-bottom: 18px;
+}
+
+.hero-form label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: rgba(254, 250, 224, 0.6);
+}
+
+.hero-form input {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.04);
+  color: #fefae0;
+  font-size: 14px;
+}
+
+.sponsor-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sponsor-pill {
+  display: inline-flex;
+  flex-direction: column;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-family: "JetBrains Mono", monospace;
+}
+
+.sponsor-pill strong {
+  color: #ffd166;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+}
+
+.sponsor-pill small {
+  color: rgba(254, 250, 224, 0.55);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* Hero stage: synthetic mock screen so the page has visual heft above the fold. */
+.hero-stage {
+  display: grid;
+  gap: 16px;
+}
+
+.hero-stage-frame {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, #050810 0%, #0b1224 100%);
+  padding: 20px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55), inset 0 0 0 1px
+    rgba(64, 224, 240, 0.06);
+  display: grid;
+  gap: 14px;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-arcade-banner,
+.hero-arcade-footer {
+  display: flex;
+  justify-content: space-between;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: rgba(254, 250, 224, 0.5);
+}
+
+.hero-arcade-banner span:nth-child(1) {
+  color: #7bdff2;
+}
+
+.hero-arcade-banner span:nth-child(2) {
+  color: #ff8db3;
+}
+
+.hero-arcade-banner span:nth-child(3) {
+  color: #40f070;
+}
+
+.hero-arcade-banner span:nth-child(4) {
+  color: #ff5252;
+}
+
+.hero-arcade-banner span:nth-child(5) {
+  color: #c084ff;
+}
+
+.hero-arcade-footer span {
+  color: rgba(254, 250, 224, 0.7);
+  font-weight: 700;
+}
+
+.hero-mock {
+  position: relative;
+  height: 220px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: radial-gradient(
+      ellipse 50% 60% at 80% 50%,
+      rgba(255, 82, 82, 0.18),
+      transparent 70%
+    ),
+    radial-gradient(
+      ellipse 60% 40% at 20% 70%,
+      rgba(64, 224, 240, 0.18),
+      transparent 70%
+    ), #02030a;
+}
+
+.hero-mock-stars {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(1px 1px at 12% 30%, #fff, transparent 50%),
+    radial-gradient(1px 1px at 25% 70%, #fff, transparent 50%),
+    radial-gradient(1px 1px at 60% 20%, #fff, transparent 50%),
+    radial-gradient(1px 1px at 80% 60%, #fff, transparent 50%),
+    radial-gradient(2px 2px at 45% 50%, #ffd166, transparent 50%);
+}
+
+.hero-mock-ship {
+  position: absolute;
+  left: 12%;
+  top: 50%;
+  width: 60px;
+  height: 24px;
+  background: linear-gradient(135deg, #cdebff 0%, #3070d0 50%, #142d5e 100%);
+  clip-path: polygon(100% 50%, 0 0, 0 100%);
+  filter: drop-shadow(0 0 12px rgba(64, 224, 240, 0.5));
+}
+
+.hero-mock-moai {
+  position: absolute;
+  right: 12%;
+  top: 30%;
+  width: 90px;
+  height: 110px;
+  background: linear-gradient(180deg, #c89060 0%, #704020 100%);
+  border-radius: 12px 12px 4px 4px;
+  box-shadow: inset -10px -10px 30px rgba(0, 0, 0, 0.4), 0 0 24px
+    rgba(255, 209, 102, 0.16);
+}
+
+.hero-tagline {
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  color: rgba(254, 250, 224, 0.7);
+  margin: 0;
+}
+
+.hero-tagline strong {
+  color: #ffd166;
+}
+
+/* Sections */
+
+.landing-section {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 56px clamp(16px, 4vw, 56px);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.landing-section.section-accent-cyan {
+  background: linear-gradient(180deg, transparent, rgba(64, 224, 240, 0.04));
+}
+
+.landing-section.section-accent-warn {
+  background: linear-gradient(180deg, transparent, rgba(255, 82, 82, 0.04));
+}
+
+.landing-section.section-accent-ok {
+  background: linear-gradient(180deg, transparent, rgba(64, 240, 112, 0.04));
+}
+
+.landing-section-head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: baseline;
+  margin-bottom: 24px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.landing-section-index {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  color: #40e0f0;
+  font-weight: 700;
+}
+
+.landing-section-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(254, 250, 224, 0.5);
+  display: block;
+  margin-bottom: 4px;
+}
+
+.landing-section-head h2 {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 44px);
+  letter-spacing: -0.025em;
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.lede {
+  font-size: 17px;
+  line-height: 1.55;
+  color: rgba(254, 250, 224, 0.82);
+  max-width: 70ch;
+  margin: 0 0 16px;
+}
+
+.lede em {
+  font-style: normal;
+  background: linear-gradient(
+    180deg,
+    transparent 60%,
+    rgba(255, 209, 102, 0.32) 60%
+  );
+  padding: 0 4px;
+}
+
+.problem-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: center;
+}
+
+.x-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.x-list li::before {
+  content: "✕";
+  color: #ff5252;
+  margin-right: 8px;
+  font-weight: 700;
+}
+
+.check-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.check-list li::before {
+  content: "✓";
+  color: #40f070;
+  margin-right: 8px;
+  font-weight: 700;
+}
+
+.quote-card {
+  padding: 24px 28px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-align: center;
+}
+
+.flow-row {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.flow-chip {
+  padding: 12px 18px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.flow-chip.flow-warn {
+  border-color: rgba(255, 82, 82, 0.5);
+  color: #ff8d8d;
+  background: rgba(255, 82, 82, 0.08);
+}
+
+.flow-arrow {
+  color: #40e0f0;
+  font-family: "JetBrains Mono", monospace;
+}
+
+.step-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.step-card {
+  padding: 22px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+  position: relative;
+}
+
+.step-num {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 36px;
+  font-weight: 800;
+  color: rgba(255, 209, 102, 0.32);
+  line-height: 1;
+}
+
+.step-card h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+
+.step-card p {
+  margin: 0;
+  color: rgba(254, 250, 224, 0.74);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.pipeline {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.pipeline-arrow {
+  color: #40e0f0;
+}
+
+.enemy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.enemy-card {
+  padding: 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.4);
+  display: grid;
+  gap: 6px;
+}
+
+.enemy-card header {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  font-weight: 800;
+}
+
+.enemy-card strong {
+  font-size: 16px;
+}
+
+.enemy-card p {
+  margin: 4px 0 0;
+  color: rgba(254, 250, 224, 0.68);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.moai-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 24px;
+  align-items: center;
+}
+
+.moai-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.moai-list li {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.moai-list li::before {
+  content: "▣";
+  color: #ffd166;
+  margin-right: 8px;
+}
+
+.moai-side p {
+  color: rgba(254, 250, 224, 0.78);
+  margin: 0 0 12px;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.quote-line {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: #ff8d8d;
+  border-left: 3px solid #ff8d8d;
+  padding-left: 10px;
+}
+
+.agent-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.agent-card {
+  padding: 20px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.4);
+  display: grid;
+  gap: 6px;
+}
+
+.agent-card header {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  font-weight: 800;
+}
+
+.agent-card strong {
+  font-size: 16px;
+}
+
+.agent-card em {
+  font-style: normal;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(254, 250, 224, 0.55);
+}
+
+.agent-card p {
+  margin: 6px 0 0;
+  color: rgba(254, 250, 224, 0.74);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.footnote {
+  margin: 16px 0 0;
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(254, 250, 224, 0.5);
+}
+
+.stack-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+}
+
+.stack-card {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.stack-card span {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  font-weight: 800;
+}
+
+.stack-card p {
+  margin: 8px 0 0;
+  color: rgba(254, 250, 224, 0.74);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.web3-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.web3-card {
+  padding: 22px;
+  border-radius: 14px;
+  border: 1px solid rgba(64, 224, 240, 0.32);
+  background: rgba(64, 224, 240, 0.05);
+  display: grid;
+  gap: 6px;
+}
+
+.web3-card header {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 16px;
+  font-weight: 800;
+  color: #40e0f0;
+  letter-spacing: 0.08em;
+}
+
+.web3-card small {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(254, 250, 224, 0.6);
+}
+
+.web3-card p {
+  margin: 6px 0 0;
+  color: rgba(254, 250, 224, 0.78);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.diff-table {
+  display: grid;
+  gap: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.diff-row {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 1fr;
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  align-items: center;
+}
+
+.diff-row:last-child {
+  border-bottom: none;
+}
+
+.diff-row.diff-head {
+  background: rgba(255, 255, 255, 0.04);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(254, 250, 224, 0.6);
+}
+
+.diff-metric {
+  font-weight: 700;
+}
+
+.diff-bad {
+  color: rgba(255, 141, 141, 0.85);
+}
+
+.diff-good {
+  color: #ffd166;
+  font-weight: 700;
+}
+
+.why-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.why-list li {
+  padding: 14px 18px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 16px;
+}
+
+.big-line {
+  margin: 18px 0 0;
+  font-size: clamp(20px, 3vw, 28px);
+  font-weight: 800;
+  color: #ffd166;
+  letter-spacing: -0.01em;
+}
+
+.final-cta {
+  padding: 64px clamp(16px, 4vw, 56px);
+  text-align: center;
+  background: linear-gradient(180deg, transparent, rgba(255, 209, 102, 0.06));
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.final-cta h2 {
+  font-size: clamp(28px, 5vw, 56px);
+  margin: 0 0 24px;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+}
+
+.final-cta em {
+  font-style: normal;
+  background: linear-gradient(
+    180deg,
+    transparent 60%,
+    rgba(64, 224, 240, 0.36) 60%
+  );
+  padding: 0 6px;
+  color: #40e0f0;
+}
+
+.landing-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 32px clamp(16px, 4vw, 56px);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(254, 250, 224, 0.55);
+  flex-wrap: wrap;
+}
+
+.footer-links {
+  display: flex;
+  gap: 18px;
+}
+
+.footer-links a {
+  color: rgba(254, 250, 224, 0.7);
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  color: #ffd166;
+}
+
+.arcade-anchor {
+  scroll-margin-top: 80px;
+}
+
+@media (max-width: 960px) {
+  .hero-grid,
+  .problem-grid,
+  .moai-grid,
+  .step-row,
+  .agent-grid,
+  .web3-grid {
+    grid-template-columns: 1fr;
+  }
+  .diff-row {
+    grid-template-columns: 1fr 1fr;
+  }
+  .diff-row .diff-metric {
+    grid-column: 1 / -1;
+  }
 }
 
 .arcade-summary {


### PR DESCRIPTION
## Summary

ピッチデッキ 15 パネルを React ランディングに展開、ゲームをマリオ 1-1 並みに即プレイ可能まで簡略化、README を OSS のトップページ規格に書き直した。

### Landing (\`packages/frontend/src/App.tsx\`)
- KILL THE TRADEOFFS hero、PLAY DEMO + GitHub CTA、合成 mock 画面、5 sponsor pill
- 13 セクション (Problem / Root Cause / Solution / How / Enemies / Moai / Examples / Core / Stack / Web3 Infra / Differentiation / Why Now / Vision)
- DEMO セクションに BirthArcade を埋め込み、終了後に AgentDashboard を自動表示
- 結論 CTA + Footer

### マリオ 1-1 ゲーム再設計 (\`packages/frontend/src/game/runtime.ts\` + \`BirthArcade.tsx\`)
- パワーアップバー / commit ボタン / chain selector / countdown を完全撤廃
- 自動連射 (no fire button)、移動だけが操作
- 敵は SAFE (cyan) / MID (yellow) / RISK (red) の 3 色、撃破した色が archetype に投票
- 上部 HUD は 3 つの投票カウンタ、リーダー色だけ反転 (一目で勝敗が読める)
- 最初に画面中央に slow なチュートリアル敵が出現 (Mario 1-1 の Goomba 相当)
- 0 score の間だけ「JUST MOVE → DESTROY!」が点滅、destroy で自然消滅
- BirthArcade は idle → play → debrief の 3 phase、PRESS ANY KEY で即開始

### CSS
- 商用級ランディング全セクションのレイアウト・タイポ・スポンサー pill・差分テーブル
- arcade-press-start (脈動するインサートコイン CTA)
- arcade-tagline、subtle hint pill、final-cta の見出し下線、mobile breakpoint

### README 全面書き直し
- バッジ列 + center-aligned hero
- 60 秒で何が手に入るか
- マリオ 1-1 風 How it plays
- ASCII アーキ図 + Quick Start + Multi-chain deploy + Tech stack 表
- Sponsor 統合の役割表 + Differentiation 表 + Repo layout + Roadmap + Contributing

## Test plan
- [x] make before-commit 緑 (architecture-harness 0 / lint 0 / typecheck 0 / 7 tests / build OK)
- [x] frontend bundle: 244 KB JS / 25 KB CSS / 0.4 KB HTML
- [ ] vercel deploy preview で landing が動作
- [ ] 60 秒プレイ → 3 色のうち一番倒した色の archetype が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned landing page with improved navigation and branding.
  * New archetype voting system: defeat color-coded enemies to vote for your agent archetype.
  * Simplified gameplay mechanics with directional movement and auto-firing combat.

* **Documentation**
  * Comprehensive README rewrite with updated quick-start, deployment, and tech stack information.

* **Style**
  * Enhanced UI/UX with new landing page components, buttons, and arcade interface styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->