### PR TITLE
fix(audio): BGM stop on game end + 撃破効果音

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import { BirthArcade } from './components/BirthArcade';
 import { ConnectButton } from './components/ConnectButton';
 import { Fighter } from './components/Fighter';
 import { Callout, HUDCorners, Reticle } from './components/HUD';
-import { MusicPlayer } from './components/MusicPlayer';
+import { GAME_END_EVENT, MusicPlayer } from './components/MusicPlayer';
 import type { Archetype } from './game/runtime';
 
 const A = {
@@ -218,6 +218,7 @@ export function App() {
   const { address: ownerAddress } = useAccount();
 
   async function handleComplete(playLog: PlayLog, derivedArchetype: Archetype) {
+    window.dispatchEvent(new Event(GAME_END_EVENT));
     try {
       setSubmitting(true);
       setError('');

--- a/packages/frontend/src/components/MusicPlayer.tsx
+++ b/packages/frontend/src/components/MusicPlayer.tsx
@@ -23,6 +23,8 @@ const VIS_BARS = [
   'vb-h',
 ] as const;
 
+export const GAME_END_EVENT = 'gradius:gameEnd';
+
 function createChiptuneEngine(): ChiptuneEngine {
   let ctx: AudioContext | null = null;
   let masterGain: GainNode | null = null;
@@ -1574,6 +1576,17 @@ function MusicPlayerImpl() {
     const id = setInterval(() => setPulse((p) => (p + 1) % 8), 100);
     return () => clearInterval(id);
   }, [playing]);
+
+  useEffect(() => {
+    const onGameEnd = () => {
+      if (engineRef.current?.isRunning()) {
+        engineRef.current.stop();
+        setPlaying(false);
+      }
+    };
+    window.addEventListener(GAME_END_EVENT, onGameEnd);
+    return () => window.removeEventListener(GAME_END_EVENT, onGameEnd);
+  }, []);
 
   const toggle = () => {
     if (!engineRef.current) return;

--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -7,6 +7,7 @@ import type {
 import { CHAINS, type ChainId } from './chains';
 import { drawBigText, pixelText } from './font';
 import { PAL, PLAY_H, RH, RW } from './palette';
+import { playSfx } from './sfx';
 import {
   GRUNT,
   GRUNT_KEY,
@@ -644,6 +645,7 @@ export function step(rt: Runtime, input: InputState) {
         }
         if (e.hp <= 0) {
           if (e.type === 'moai') {
+            playSfx('moai');
             const constraint = MOAI_CONSTRAINT[e.moaiId];
             rt.score += 1500;
             rt.events.push({
@@ -666,6 +668,7 @@ export function step(rt: Runtime, input: InputState) {
               life: 1.4,
             });
           } else {
+            playSfx('kill');
             // Commit the capability into the Agent policy; score scales by cost.
             rt.votes[e.archetype] += 1;
             rt.score += e.scoreOnKill;
@@ -837,12 +840,15 @@ export function step(rt: Runtime, input: InputState) {
   rt.archetypePeek = computeArchetype(rt);
 
   // End conditions
-  if (rt.player.hp <= 0) {
-    rt.finished = true;
-    rt.finishReason = 'hp';
-  } else if (rt.t >= GAME_DURATION_FRAMES) {
-    rt.finished = true;
-    rt.finishReason = 'time';
+  if (!rt.finished) {
+    if (rt.player.hp <= 0) {
+      rt.finished = true;
+      rt.finishReason = 'hp';
+      playSfx('death');
+    } else if (rt.t >= GAME_DURATION_FRAMES) {
+      rt.finished = true;
+      rt.finishReason = 'time';
+    }
   }
 }
 

--- a/packages/frontend/src/game/sfx.ts
+++ b/packages/frontend/src/game/sfx.ts
@@ -1,0 +1,116 @@
+type SfxKind = 'kill' | 'moai' | 'death' | 'shoot';
+
+let ctx: AudioContext | null = null;
+let masterGain: GainNode | null = null;
+let muted = false;
+
+function ensureCtx(): { ctx: AudioContext; out: GainNode } | null {
+  if (typeof window === 'undefined') return null;
+  if (!ctx) {
+    const Ctor =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext: typeof AudioContext })
+        .webkitAudioContext;
+    if (!Ctor) return null;
+    ctx = new Ctor();
+    masterGain = ctx.createGain();
+    masterGain.gain.value = 0.18;
+    masterGain.connect(ctx.destination);
+  }
+  if (ctx.state === 'suspended') void ctx.resume();
+  if (!masterGain) return null;
+  return { ctx, out: masterGain };
+}
+
+function playKill(c: AudioContext, out: GainNode, t: number) {
+  const osc = c.createOscillator();
+  osc.type = 'triangle';
+  osc.frequency.setValueAtTime(820, t);
+  osc.frequency.exponentialRampToValueAtTime(180, t + 0.08);
+  const g = c.createGain();
+  g.gain.setValueAtTime(0.65, t);
+  g.gain.exponentialRampToValueAtTime(0.001, t + 0.1);
+  osc.connect(g).connect(out);
+  osc.start(t);
+  osc.stop(t + 0.12);
+}
+
+function playMoai(c: AudioContext, out: GainNode, t: number) {
+  const osc = c.createOscillator();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(140, t);
+  osc.frequency.exponentialRampToValueAtTime(40, t + 0.22);
+  const g = c.createGain();
+  g.gain.setValueAtTime(0.55, t);
+  g.gain.exponentialRampToValueAtTime(0.001, t + 0.28);
+  osc.connect(g).connect(out);
+  osc.start(t);
+  osc.stop(t + 0.3);
+
+  const noiseLen = (c.sampleRate * 0.18) | 0 || 1;
+  const buf = c.createBuffer(1, noiseLen, c.sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < noiseLen; i++) {
+    data[i] = (Math.random() * 2 - 1) * (1 - i / noiseLen) ** 1.6;
+  }
+  const src = c.createBufferSource();
+  src.buffer = buf;
+  const hp = c.createBiquadFilter();
+  hp.type = 'highpass';
+  hp.frequency.value = 800;
+  const ng = c.createGain();
+  ng.gain.value = 0.4;
+  src.connect(hp).connect(ng).connect(out);
+  src.start(t);
+}
+
+function playDeath(c: AudioContext, out: GainNode, t: number) {
+  const osc = c.createOscillator();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(440, t);
+  osc.frequency.exponentialRampToValueAtTime(55, t + 0.45);
+  const g = c.createGain();
+  g.gain.setValueAtTime(0.5, t);
+  g.gain.exponentialRampToValueAtTime(0.001, t + 0.5);
+  osc.connect(g).connect(out);
+  osc.start(t);
+  osc.stop(t + 0.55);
+}
+
+function playShoot(c: AudioContext, out: GainNode, t: number) {
+  const osc = c.createOscillator();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(1500, t);
+  osc.frequency.exponentialRampToValueAtTime(900, t + 0.04);
+  const g = c.createGain();
+  g.gain.setValueAtTime(0.18, t);
+  g.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+  osc.connect(g).connect(out);
+  osc.start(t);
+  osc.stop(t + 0.06);
+}
+
+export function playSfx(kind: SfxKind): void {
+  if (muted) return;
+  const handle = ensureCtx();
+  if (!handle) return;
+  const t = handle.ctx.currentTime;
+  switch (kind) {
+    case 'kill':
+      playKill(handle.ctx, handle.out, t);
+      break;
+    case 'moai':
+      playMoai(handle.ctx, handle.out, t);
+      break;
+    case 'death':
+      playDeath(handle.ctx, handle.out, t);
+      break;
+    case 'shoot':
+      playShoot(handle.ctx, handle.out, t);
+      break;
+  }
+}
+
+export function setSfxMuted(value: boolean): void {
+  muted = value;
+}


### PR DESCRIPTION
## Summary
- グラント / Moai / 自機撃墜 / 自機ショットの 4 種類を `packages/frontend/src/game/sfx.ts` で短く Web Audio 合成
- `runtime.ts` の撃破判定 3 箇所 + 自機 hp <= 0 で `playSfx` を呼ぶ
- 終了判定に `!rt.finished` ガードを追加 (death SFX が連続発火しないように)
- `MusicPlayer` が `gradius:gameEnd` window イベントを購読、受信時に BGM 停止
- `App.tsx` `handleComplete` 冒頭で `GAME_END_EVENT` を dispatch

## Test plan
- [x] `make before-commit` (architecture-harness 0 / lint 0 / typecheck 0 / 11 tests / build OK)
- [ ] ブラウザで実際にプレイし、敵撃破時の効果音 / 60s 終了後 BGM 停止を確認

## Notes
- SFX は BGM とは独立した AudioContext。両方とも user gesture 後に初期化される (autoplay policy 対応)
- `setSfxMuted(true)` で SFX オンリーミュート可能 (将来 UI 用、現状未配線)

🤖 Generated with [Claude Code](https://claude.com/claude-code)