### PR TITLE
fix(game): 自機被弾・撃墜時の爆発描画を追加 (ダメージ感ゼロを解消)

### DIFF
--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -356,6 +356,10 @@ export interface Runtime {
   particleCounter: number;
   warningT: number;
   flashT: number;
+  /// Frames remaining in the player death animation. While > 0, the player
+  /// sprite is hidden, particles play out, and `finished` stays false so the
+  /// canvas keeps rendering the explosion. Reaches 0 → finished = true.
+  dyingT: number;
   finished: boolean;
   finishReason: 'time' | 'hp' | null;
   showTutorialPrompt: boolean;
@@ -392,6 +396,7 @@ export function createRuntime(chain: ChainId = 'ARB'): Runtime {
     particleCounter: 0,
     warningT: 0,
     flashT: 0,
+    dyingT: 0,
     finished: false,
     finishReason: null,
     showTutorialPrompt: true,
@@ -787,9 +792,11 @@ export function step(rt: Runtime, input: InputState) {
         rt.player.hp -= 1;
         rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 1 });
         rt.player.iframes = 60;
-        rt.flashT = 12;
-        spawnBurst(rt, rt.player.x, rt.player.y, '#ff5252', 14);
+        rt.flashT = 18;
+        spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ff5252', 28);
+        spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ffe66d', 12);
         pushToast(rt, `HULL ${rt.player.hp}`, PAL.warn);
+        playSfx('hit');
         break;
       }
     }
@@ -805,13 +812,15 @@ export function step(rt: Runtime, input: InputState) {
         ) {
           rt.player.hp -= e.type === 'moai' ? 2 : 1;
           rt.player.iframes = 60;
-          rt.flashT = 12;
+          rt.flashT = 18;
           rt.events.push({
             kind: 'hit',
             t: elapsedMs(rt),
             damage: e.type === 'moai' ? 2 : 1,
           });
-          spawnBurst(rt, rt.player.x, rt.player.y, '#ff5252', 16);
+          spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ff5252', 30);
+          spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ffe66d', 14);
+          playSfx('hit');
           break;
         }
       }
@@ -840,10 +849,23 @@ export function step(rt: Runtime, input: InputState) {
   rt.archetypePeek = computeArchetype(rt);
 
   // End conditions
-  if (!rt.finished) {
-    if (rt.player.hp <= 0) {
+  if (rt.dyingT > 0) {
+    rt.dyingT -= 1;
+    if (rt.dyingT <= 0) {
       rt.finished = true;
       rt.finishReason = 'hp';
+    }
+  } else if (!rt.finished) {
+    if (rt.player.hp <= 0) {
+      // Big death explosion: 3 staggered bursts so the canvas keeps rendering
+      // ~45 frames of debris before BirthArcade switches to the debrief overlay.
+      const cx = rt.player.x + 8;
+      const cy = rt.player.y + 5;
+      spawnBurst(rt, cx, cy, '#ffd166', 60);
+      spawnBurst(rt, cx, cy, '#ff5252', 50);
+      spawnBurst(rt, cx, cy, '#ffffff', 28);
+      rt.flashT = 30;
+      rt.dyingT = 45;
       playSfx('death');
     } else if (rt.t >= GAME_DURATION_FRAMES) {
       rt.finished = true;
@@ -1046,8 +1068,8 @@ export function render(ctx: CanvasRenderingContext2D, rt: Runtime) {
     ctx.fillRect((b.x | 0) - 1, (b.y | 0) - 1, 3, 3);
   }
 
-  // Player
-  if (!(rt.player.iframes > 0 && (rt.t >> 1) % 2 === 0)) {
+  // Player — hidden during the death animation so the explosion reads cleanly.
+  if (rt.dyingT <= 0 && !(rt.player.iframes > 0 && (rt.t >> 1) % 2 === 0)) {
     drawSprite(ctx, VIC_VIPER, VIC_KEY, rt.player.x | 0, rt.player.y | 0);
   }
 

--- a/packages/frontend/src/game/sfx.ts
+++ b/packages/frontend/src/game/sfx.ts
@@ -1,4 +1,4 @@
-type SfxKind = 'kill' | 'moai' | 'death' | 'shoot';
+type SfxKind = 'kill' | 'moai' | 'death' | 'shoot' | 'hit';
 
 let ctx: AudioContext | null = null;
 let masterGain: GainNode | null = null;
@@ -90,6 +90,36 @@ function playShoot(c: AudioContext, out: GainNode, t: number) {
   osc.stop(t + 0.06);
 }
 
+function playHit(c: AudioContext, out: GainNode, t: number) {
+  const noiseLen = (c.sampleRate * 0.1) | 0 || 1;
+  const buf = c.createBuffer(1, noiseLen, c.sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < noiseLen; i++) {
+    data[i] = (Math.random() * 2 - 1) * (1 - i / noiseLen) ** 1.2;
+  }
+  const src = c.createBufferSource();
+  src.buffer = buf;
+  const bp = c.createBiquadFilter();
+  bp.type = 'bandpass';
+  bp.frequency.value = 600;
+  bp.Q.value = 1.2;
+  const g = c.createGain();
+  g.gain.value = 0.55;
+  src.connect(bp).connect(g).connect(out);
+  src.start(t);
+
+  const osc = c.createOscillator();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(320, t);
+  osc.frequency.exponentialRampToValueAtTime(140, t + 0.12);
+  const og = c.createGain();
+  og.gain.setValueAtTime(0.4, t);
+  og.gain.exponentialRampToValueAtTime(0.001, t + 0.14);
+  osc.connect(og).connect(out);
+  osc.start(t);
+  osc.stop(t + 0.16);
+}
+
 export function playSfx(kind: SfxKind): void {
   if (muted) return;
   const handle = ensureCtx();
@@ -107,6 +137,9 @@ export function playSfx(kind: SfxKind): void {
       break;
     case 'shoot':
       playShoot(handle.ctx, handle.out, t);
+      break;
+    case 'hit':
+      playHit(handle.ctx, handle.out, t);
       break;
   }
 }


### PR DESCRIPTION
## 問題
自機が弾に当たって HP が 0 になった瞬間、即 \`runtime.finished = true\` にしていたため、BirthArcade が同じ tick で debrief 画面に切り替えてしまい爆発が **1 フレームも描画されない** 構造だった。プレイヤーから見ると「やられても何も起きずに突然画面が変わる」状態でダメージ感ゼロ。

非致命の被弾フィードバックも 14 パーティクル + 12 フレームの控えめな赤フラッシュだけで、SFX も無くインパクト不足。

## 修正

### 死亡アニメーション
- \`Runtime.dyingT\` (死亡フレーム猶予) を新設。hp<=0 で即 finished にせず、45 フレーム (0.75 秒) のあいだ爆発を描画してから finished にする
- 撃墜時に **60 (黄) + 50 (赤) + 28 (白) の 3 段階バースト** + flashT 30 + 既存 'death' SFX
- dyingT > 0 の間は VIC_VIPER スプライトを非表示 (爆発が前面に出る)

### 被弾フィードバック強化
- particles 14→28 (赤) + 12 (黄スパーク) の 2 色重ね
- flashT 12→18 で画面フラッシュを強化
- 新規 'hit' SFX 追加: band-pass noise + 低音 square swept (短いダメージ音)

### sfx.ts
- \`SfxKind\` に 'hit' を追加、playHit 関数を実装

## Test plan
- [x] \`make before-commit\` (architecture-harness 0 / lint 0 / typecheck 0 / 22 tests / build OK)
- [ ] ブラウザで実機プレイ:
  - 弾に当たる → 黄+赤の爆発、画面フラッシュ、ダメージ SFX
  - HP 0 → 0.75 秒の派手な 3 色爆発 → debrief 画面 (爆発が見える)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Death animation enhanced with larger, staggered particle effects and audio feedback
  * Collision impact improved with new hit sound effects and expanded visual particle effects  
  * Player sprite rendering refined during death sequences for clearer visual focus on explosion effects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->