### PR TITLE
chore: judge readiness 4 件 + 弾被弾派手化 + BGM 自動再生

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ A 60-second retro arcade shooter that doubles as the world's fastest onboarding 
 
 ---
 
+## Quick verification for prize judges
+
+30-second checklist for sponsor prize reviewers (0G / ENS / Uniswap):
+
+| What to check | Where |
+|---------------|-------|
+| Live demo (free play, ~60 s) | https://gr-dius-web3-frontend.vercel.app/ |
+| 0G iNFT contract source (ERC-721 + tokenURI, deterministic `keccak(msg.sender, playLogHash)`) | [`contracts/src/AgentForgeINFT.sol`](./contracts/src/AgentForgeINFT.sol) |
+| 0G Galileo deploy script + chain config (id 16601) | [`contracts/script/Deploy.s.sol`](./contracts/script/Deploy.s.sol), [`contracts/foundry.toml`](./contracts/foundry.toml) |
+| 0G Storage put call site (browser bundle stub today, real SDK is the next PR) | [`packages/frontend/src/web3/zerog-storage.ts`](./packages/frontend/src/web3/zerog-storage.ts) |
+| ENS Sepolia subname registration via real NameWrapper + Resolver | [`packages/frontend/src/web3/ens-register.ts`](./packages/frontend/src/web3/ens-register.ts) |
+| Uniswap v3 Sepolia first-trade execution (WETH→USDC, native-ETH wrap) | [`packages/frontend/src/web3/uniswap-swap.ts`](./packages/frontend/src/web3/uniswap-swap.ts) |
+| Forge orchestrator (`Promise.allSettled` so one failure never blocks the dashboard) | [`packages/frontend/src/web3/forge-onchain.ts`](./packages/frontend/src/web3/forge-onchain.ts) |
+| Uniswap DX feedback (required for Uniswap prize submission) | [`FEEDBACK.md`](./FEEDBACK.md) |
+| Spec + scoring rubric + Plan log | [`docs/specs/2026-04-27-web3-wiring.md`](./docs/specs/2026-04-27-web3-wiring.md), [`Plan.md`](./Plan.md) |
+
+The contract + module surface is intentionally tight (~7 frontend files, 1 contract) so judges can read the entire on-chain pipeline in under 5 minutes.
+
+---
+
 ## Why this exists
 
 > Designing AI agents today is **complex, opaque, trial-and-error**. Builders click through abstract settings, hope for the best, and ship agents nobody can explain. The UX hasn't evolved past 2010-era admin panels.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useAccount, useWalletClient } from 'wagmi';
+import { useAccount, useChainId, useWalletClient } from 'wagmi';
 import { AgentDashboard } from './components/AgentDashboard';
 import { BirthArcade } from './components/BirthArcade';
 import { ConnectButton } from './components/ConnectButton';
@@ -359,21 +359,38 @@ function StatusCell({ k, v, color }: { k: string; v: string; color?: string }) {
   );
 }
 
+const CHAIN_LABELS: Record<number, string> = {
+  11155111: 'SEPOLIA',
+  84532: 'BASE_SEPOLIA',
+  11155420: 'OP_SEPOLIA',
+  421614: 'ARB_SEPOLIA',
+  16601: '0G_GALILEO',
+};
+
 function StatusBar() {
   const [clock, setClock] = useState(() => formatUtc(new Date()));
+  const { isConnected } = useAccount();
+  const chainId = useChainId();
   useEffect(() => {
     const id = setInterval(() => setClock(formatUtc(new Date())), 1000);
     return () => clearInterval(id);
   }, []);
+  const chainLabel = isConnected
+    ? (CHAIN_LABELS[chainId] ?? `CHAIN_${chainId}`)
+    : 'OFFLINE';
   return (
     <div className="lp-status-bar" style={S.statusBar}>
       <span>
-        <span style={{ color: A.green }}>●</span> NETWORK_ONLINE ·
-        GR@DIUS_FORGE_v1.0
+        <span style={{ color: isConnected ? A.green : A.mute }}>●</span>{' '}
+        {isConnected ? 'WALLET_ONLINE' : 'WALLET_OFFLINE'} · GR@DIUS_FORGE_v1.0
       </span>
       <StatusCell k="ICAO" v="GNSH" />
       <StatusCell k="HDG" v="027°" color={A.hud} />
-      <StatusCell k="CHAIN" v="SEPOLIA" color={A.hud} />
+      <StatusCell
+        k="CHAIN"
+        v={chainLabel}
+        color={isConnected ? A.hud : A.mute}
+      />
       <StatusCell k="UTC" v={clock} color={A.green} />
       <StatusCell k="OP" v="ETHGLOBAL_TOKYO" />
       <span style={{ color: A.amber, justifySelf: 'end' }}>

--- a/packages/frontend/src/components/AgentDashboard.tsx
+++ b/packages/frontend/src/components/AgentDashboard.tsx
@@ -177,6 +177,8 @@ export function AgentDashboard({
   );
 }
 
+const WALLET_NOT_CONNECTED = 'wallet not connected';
+
 function OnChainProofPanel({
   proof,
   onFirstSwap,
@@ -186,6 +188,11 @@ function OnChainProofPanel({
   onFirstSwap?: () => void;
   swapping?: boolean;
 }) {
+  const walletMissing =
+    proof.mint.error === WALLET_NOT_CONNECTED &&
+    proof.storage.error === WALLET_NOT_CONNECTED &&
+    proof.ens.error === WALLET_NOT_CONNECTED;
+
   return (
     <section
       className="panel"
@@ -200,6 +207,26 @@ function OnChainProofPanel({
           0G Galileo iNFT · 0G Storage CID · Sepolia ENS · Sepolia Uniswap.
         </p>
       </div>
+
+      {walletMissing ? (
+        <div
+          style={{
+            marginTop: 16,
+            padding: '14px 16px',
+            border: `1px dashed ${A.amber}`,
+            color: A.amber,
+            fontSize: 12,
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+            lineHeight: 1.6,
+          }}
+        >
+          ⚡ Connect a wallet (▶ CONNECT WALLET in the nav) to mint the iNFT,
+          register the ENS subname, and execute the first Uniswap trade. Forge
+          itself is free; on-chain proof requires a Sepolia wallet with testnet
+          ETH.
+        </div>
+      ) : null}
 
       <div style={{ display: 'grid', gap: 12, marginTop: 12 }}>
         <ProofRow

--- a/packages/frontend/src/components/BirthArcade.tsx
+++ b/packages/frontend/src/components/BirthArcade.tsx
@@ -21,7 +21,9 @@ import {
   simulateTrades,
   step as stepRuntime,
 } from '../game/runtime';
+import { prewarmSfx } from '../game/sfx';
 import { VIC_KEY, VIC_VIPER, drawSprite } from '../game/sprites';
+import { GAME_START_EVENT } from './MusicPlayer';
 
 interface BirthArcadeProps {
   disabled?: boolean;
@@ -71,11 +73,15 @@ export function BirthArcade({
     runtimeRef.current = createRuntime();
     setArchetype(null);
     setTrades([]);
+    prewarmSfx();
+    window.dispatchEvent(new Event(GAME_START_EVENT));
     setPhase('play');
   }, [disabled]);
 
   const replay = useCallback(() => {
     runtimeRef.current = createRuntime();
+    prewarmSfx();
+    window.dispatchEvent(new Event(GAME_START_EVENT));
     setPhase('play');
   }, []);
 

--- a/packages/frontend/src/components/MusicPlayer.tsx
+++ b/packages/frontend/src/components/MusicPlayer.tsx
@@ -24,6 +24,7 @@ const VIS_BARS = [
 ] as const;
 
 export const GAME_END_EVENT = 'gradius:gameEnd';
+export const GAME_START_EVENT = 'gradius:gameStart';
 
 function createChiptuneEngine(): ChiptuneEngine {
   let ctx: AudioContext | null = null;
@@ -1584,8 +1585,18 @@ function MusicPlayerImpl() {
         setPlaying(false);
       }
     };
+    const onGameStart = () => {
+      if (!engineRef.current?.isRunning()) {
+        engineRef.current?.start();
+        setPlaying(true);
+      }
+    };
     window.addEventListener(GAME_END_EVENT, onGameEnd);
-    return () => window.removeEventListener(GAME_END_EVENT, onGameEnd);
+    window.addEventListener(GAME_START_EVENT, onGameStart);
+    return () => {
+      window.removeEventListener(GAME_END_EVENT, onGameEnd);
+      window.removeEventListener(GAME_START_EVENT, onGameStart);
+    };
   }, []);
 
   const toggle = () => {

--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -792,9 +792,12 @@ export function step(rt: Runtime, input: InputState) {
         rt.player.hp -= 1;
         rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 1 });
         rt.player.iframes = 60;
-        rt.flashT = 18;
-        spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ff5252', 28);
-        spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ffe66d', 12);
+        rt.flashT = 25;
+        const cx = rt.player.x + 8;
+        const cy = rt.player.y + 5;
+        spawnBurst(rt, cx, cy, '#ff5252', 50);
+        spawnBurst(rt, cx, cy, '#ffe66d', 25);
+        spawnBurst(rt, cx, cy, '#ffffff', 12);
         pushToast(rt, `HULL ${rt.player.hp}`, PAL.warn);
         playSfx('hit');
         break;
@@ -812,14 +815,18 @@ export function step(rt: Runtime, input: InputState) {
         ) {
           rt.player.hp -= e.type === 'moai' ? 2 : 1;
           rt.player.iframes = 60;
-          rt.flashT = 18;
+          rt.flashT = 25;
           rt.events.push({
             kind: 'hit',
             t: elapsedMs(rt),
             damage: e.type === 'moai' ? 2 : 1,
           });
-          spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ff5252', 30);
-          spawnBurst(rt, rt.player.x + 8, rt.player.y + 5, '#ffe66d', 14);
+          const cx = rt.player.x + 8;
+          const cy = rt.player.y + 5;
+          spawnBurst(rt, cx, cy, '#ff5252', 50);
+          spawnBurst(rt, cx, cy, '#ffe66d', 25);
+          spawnBurst(rt, cx, cy, '#ffffff', 12);
+          pushToast(rt, `HULL ${rt.player.hp}`, PAL.warn);
           playSfx('hit');
           break;
         }

--- a/packages/frontend/src/game/sfx.ts
+++ b/packages/frontend/src/game/sfx.ts
@@ -147,3 +147,18 @@ export function playSfx(kind: SfxKind): void {
 export function setSfxMuted(value: boolean): void {
   muted = value;
 }
+
+/// Force AudioContext creation + resume from a user-gesture handler so the
+/// first in-game SFX (kill / hit) is not swallowed by autoplay policy. Plays
+/// a one-sample silent tick to confirm the graph is live.
+export function prewarmSfx(): void {
+  const handle = ensureCtx();
+  if (!handle) return;
+  const t = handle.ctx.currentTime;
+  const osc = handle.ctx.createOscillator();
+  const g = handle.ctx.createGain();
+  g.gain.value = 0.0001;
+  osc.connect(g).connect(handle.out);
+  osc.start(t);
+  osc.stop(t + 0.01);
+}


### PR DESCRIPTION
## Summary
6 つの polish を 1 PR に。Vercel preview で実機確認 → merge。

### 1. README "Quick verification for prize judges"
30 秒でレビューできる verification 表 (live demo / contract / SDK 各ファイル直リンク / FEEDBACK.md / spec) を Why exists の前に追加。User feedback Persona C (0G prize 審査員) で +3.0 ROI 想定の最大インパクト項目。

### 2. StatusBar 動的 chain 表示
- 未接続: \`○ WALLET_OFFLINE · CHAIN OFFLINE\` (グレー)
- 接続済み: \`● WALLET_ONLINE · CHAIN SEPOLIA / 0G_GALILEO\` (hud 色)
- \`CHAIN_LABELS\` で 5 chain (Sepolia 系 + Galileo) ラベル化
- これまで "CHAIN: SEPOLIA" hard-coded で 0G が見えなかった

### 3. Wallet 未接続時の OnChainProof 分岐
- 4 行が全部 "wallet not connected" の場合、FAIL 4 行の代わりに amber dashed バナー「⚡ Connect a wallet to mint the iNFT...」表示
- ダッシュボードが意味不明な FAIL 4 連発になるのを解消

### 4. 敵弾被弾の爆発を派手化 (報告: 敵の弾に当たっても爆発しない)
- 弾被弾: 28+12 particles → 50+25+12 (赤・黄・白の 3 色重ね)、flashT 18 → 25
- 敵衝突: 30+14 → 50+25+12 同上
- HULL X トーストを敵衝突にも追加 (これまで弾被弾だけだった)

### 5. BGM 自動再生 (報告: なんで自分でクリックしないといけない)
- \`packages/frontend/src/game/sfx.ts\` に \`prewarmSfx()\` を追加 (silent osc で AudioContext を user gesture stack 内で resume)
- BirthArcade start/replay 内で \`prewarmSfx()\` + \`dispatchEvent(GAME_START_EVENT)\`
- MusicPlayer は \`GAME_START_EVENT\` を購読し、停止中なら engine.start() — 既存の \`GAME_END_EVENT\` (停止) と対称

## Test plan
- [x] make before-commit (architecture-harness 0 / lint 0 / typecheck 0 / 22 tests / build OK)
- [ ] 実機: PRESS ANY KEY → BGM 自動開始 + SFX が初発から鳴る
- [ ] 実機: 敵の弾に当たって派手な 3 色爆発 + flash + ダメージ SFX
- [ ] 実機: ウォレット未接続でゲームクリア → ダッシュボードに amber バナー表示
- [ ] 実機: ウォレット接続して chain 切替 → StatusBar の表示が追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)