### PR TITLE
fix: walletClient stale closure + シューティング→Agent narrative bridge

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -223,6 +223,19 @@ export function App() {
   const { address: ownerAddress } = useAccount();
   const { data: walletClient } = useWalletClient();
 
+  // Refs that always carry the freshest values so the async handleComplete
+  // (called via BirthArcade's onCompleteRef) never sees a stale capture.
+  // Without this the wallet client can be undefined at game-end even when
+  // the user is plainly connected (closure captured at game-start render).
+  const walletClientRef = useRef(walletClient);
+  const ownerAddressRef = useRef(ownerAddress);
+  useEffect(() => {
+    walletClientRef.current = walletClient;
+  }, [walletClient]);
+  useEffect(() => {
+    ownerAddressRef.current = ownerAddress;
+  }, [ownerAddress]);
+
   async function handleComplete(playLog: PlayLog, derivedArchetype: Archetype) {
     window.dispatchEvent(new Event(GAME_END_EVENT));
     try {
@@ -230,20 +243,18 @@ export function App() {
       setError('');
       const pilot = playerName.trim() || 'Pilot';
       const draft = await createAgentBirthDraft(pilot, playLog);
+      const wc = walletClientRef.current;
+      const owner = ownerAddressRef.current;
       const stored: StoredAgentBirth = {
         ...draft,
-        agent: ownerAddress
-          ? { ...draft.agent, walletAddress: ownerAddress }
-          : draft.agent,
+        agent: owner ? { ...draft.agent, walletAddress: owner } : draft.agent,
         createdAt: new Date().toISOString(),
       };
       setArchetype(derivedArchetype);
       setBirth(stored);
 
-      // Fire-and-await on-chain pipeline. allSettled inside means this
-      // resolves with success/failed per step rather than throwing.
-      if (walletClient) {
-        const result = await runOnChainForge(walletClient, stored);
+      if (wc) {
+        const result = await runOnChainForge(wc, stored);
         setProof(result);
       } else {
         setProof({
@@ -1181,6 +1192,17 @@ const ArcadeSection = forwardRef<HTMLDivElement, ArcadeSectionProps>(
           right="LIVE_DEMO"
         />
         <div style={{ padding: '24px 28px 40px' }}>
+          <p style={S.arcadeIntro}>
+            ENEMIES = AGENT MODULES. Each kill commits a capability into the
+            loadout. The color you destroy most decides the archetype. Survive
+            the Moai (production constraints). At T-00 the play log freezes →
+            <strong style={{ color: A.acid }}>
+              {' '}
+              the section below shows exactly what was forged from your reflexes
+            </strong>
+            , and (with a wallet connected) writes the iNFT, ENS subname, and
+            first Uniswap trade on testnet.
+          </p>
           <BirthArcade disabled={disabled} onComplete={onComplete} />
           {error ? <div style={S.errorBanner}>! {error}</div> : null}
           {submitting ? (
@@ -1586,6 +1608,15 @@ const S = {
     color: A.mute,
     letterSpacing: '0.2em',
     borderBottom: `1px dashed ${A.rule}`,
+  },
+  arcadeIntro: {
+    margin: '0 0 20px',
+    padding: '14px 16px',
+    border: `1px dashed ${A.rule}`,
+    color: A.body,
+    fontSize: 13,
+    lineHeight: 1.6,
+    maxWidth: 760,
   },
   errorBanner: {
     marginTop: 16,

--- a/packages/frontend/src/components/AgentDashboard.tsx
+++ b/packages/frontend/src/components/AgentDashboard.tsx
@@ -7,6 +7,9 @@ import {
   ARCHETYPE_DESC,
   ARCHETYPE_LABEL,
   type Archetype,
+  CAPABILITY_COLOR,
+  CAPABILITY_DESC,
+  CAPABILITY_LABEL,
   getAllocation,
 } from '../game/runtime';
 import type { OnChainProof, OnChainStep, TxStatus } from '../web3/types';
@@ -151,6 +154,8 @@ export function AgentDashboard({
         </div>
       </section>
 
+      <PlayToAgentPanel birth={birth} archetype={archetype} />
+
       {proof ? (
         <OnChainProofPanel
           proof={proof}
@@ -173,6 +178,139 @@ export function AgentDashboard({
           ))}
         </ol>
       </section>
+    </section>
+  );
+}
+
+type CapabilityKey = 'shield' | 'speed' | 'option' | 'laser' | 'missile';
+
+const CAP_KEYS: CapabilityKey[] = [
+  'shield',
+  'speed',
+  'option',
+  'laser',
+  'missile',
+];
+
+function tallyCommits(birth: StoredAgentBirth): Record<CapabilityKey, number> {
+  const tally: Record<CapabilityKey, number> = {
+    shield: 0,
+    speed: 0,
+    option: 0,
+    laser: 0,
+    missile: 0,
+  };
+  for (const event of birth.playLog.events) {
+    if (event.kind !== 'commit') continue;
+    if (event.capsule === 'double') continue;
+    tally[event.capsule as CapabilityKey] += 1;
+  }
+  return tally;
+}
+
+function PlayToAgentPanel({
+  birth,
+  archetype,
+}: {
+  birth: StoredAgentBirth;
+  archetype: Archetype;
+}) {
+  const tally = tallyCommits(birth);
+  const total = Object.values(tally).reduce((a, b) => a + b, 0) || 1;
+  const winner = CAP_KEYS.reduce<CapabilityKey>(
+    (best, key) => (tally[key] > tally[best] ? key : best),
+    'shield'
+  );
+  return (
+    <section
+      className="panel"
+      style={{ borderColor: A.rule, background: A.panel }}
+    >
+      <div className="panel-header">
+        <span className="eyebrow" style={{ color: A.amber }}>
+          PLAY → AGENT
+        </span>
+        <h2 style={{ color: A.ink }}>What your 60 seconds committed</h2>
+        <p style={{ color: A.mute, fontSize: 12 }}>
+          Each enemy you destroyed committed a capability into the Agent
+          loadout. The dominant capability decided the archetype below.
+        </p>
+      </div>
+      <div style={{ display: 'grid', gap: 8, marginTop: 12 }}>
+        {CAP_KEYS.map((key) => {
+          const count = tally[key];
+          const pct = (count / total) * 100;
+          const isWinner = key === winner && count > 0;
+          return (
+            <div
+              key={key}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '90px 1fr 80px 220px',
+                gap: 12,
+                alignItems: 'center',
+                fontSize: 12,
+                fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+                color: isWinner ? A.ink : A.mute,
+              }}
+            >
+              <span style={{ color: CAPABILITY_COLOR[key], fontWeight: 700 }}>
+                {CAPABILITY_LABEL[key]}
+              </span>
+              <div
+                style={{
+                  height: 6,
+                  background: '#0d1620',
+                  position: 'relative',
+                }}
+              >
+                <div
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    width: `${Math.max(pct, count > 0 ? 6 : 0)}%`,
+                    background: CAPABILITY_COLOR[key],
+                    opacity: isWinner ? 1 : 0.55,
+                  }}
+                />
+              </div>
+              <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                ×{count} ({Math.round(pct)}%)
+              </span>
+              <span style={{ color: A.mute, fontSize: 11 }}>
+                {CAPABILITY_DESC[key]}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          marginTop: 16,
+          padding: '12px 14px',
+          border: `1px solid ${A.rule}`,
+          fontSize: 12,
+          fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+          color: A.ink,
+          lineHeight: 1.6,
+        }}
+      >
+        <span style={{ color: A.mute }}>DOMINANT_CAPABILITY → </span>
+        <span
+          style={{
+            color: CAPABILITY_COLOR[winner],
+            fontWeight: 700,
+          }}
+        >
+          {CAPABILITY_LABEL[winner]}
+        </span>
+        <span style={{ color: A.mute }}> ⇒ ARCHETYPE → </span>
+        <span style={{ color: ARCHETYPE_COLOR[archetype], fontWeight: 700 }}>
+          {ARCHETYPE_LABEL[archetype]}
+        </span>
+        <span style={{ color: A.mute }}> ⇒ POLICY: </span>
+        <span style={{ color: A.ink }}>{ARCHETYPE_DESC[archetype]}</span>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## 報告 → 修正

### 1. ウォレット接続済みなのに "wallet not connected" 表示
**原因**: \`App.tsx\` の \`handleComplete\` は \`BirthArcade\` の \`onCompleteRef\` 経由で呼ばれるが、ゲーム開始時点の closure が capture される。その時 \`walletClient\` (useWalletClient の \`data\`) がまだ undefined (hydrate 前) だと、後で接続しても古い undefined を読み続ける。

**修正**: \`walletClientRef\` / \`ownerAddressRef\` を導入、\`useEffect\` で常に最新に同期、\`handleComplete\` はこれらの ref から読むことで stale closure を回避。

### 2. シューティングの意味が後段につながらない / 何が起きるのか分からない
報告: 「Agent が作られると言ってもシューティングの意味が後段につながっていない」「ゲーム後何が起きるのか全くわからない」

**修正 A — AgentDashboard \`PlayToAgentPanel\` 新設**:
- \`playLog.events\` から各 capability の commit 数を tally
- 5 行 (SHIELD / SPEED / OPTION / LASER / MISSILE) の bar chart で commit 比率 + count を表示。dominant は ink+100% opacity、それ以外は mute+55%
- 下に 1 行で derivation を明示:
  \`DOMINANT_CAPABILITY → SPEED ⇒ ARCHETYPE → BALANCED ⇒ POLICY: ...\`

**修正 B — Section 06 ARCADE 内 narrative bridge**:
ゲームに入る前に「敵 = エージェントモジュール、kill = capability commit、色の多数決 = archetype、Moai = production constraints、T-00 で play log freeze → 下のセクションが forge 内容を見せ、wallet 接続時は iNFT/ENS/Uniswap を testnet に書く」を 1 段落で説明

## Test plan
- [x] make before-commit (architecture-harness 0 / lint 0 / typecheck 0 / 22 tests / build OK)
- [ ] 実機: wallet 接続 → game over 後 OnChainProof が "wallet not connected" でなく実 mint pending/success に
- [ ] 実機: PlayToAgentPanel が play 結果と一致する数字を表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added introductory paragraph to the arcade section with corresponding styling.
  * Introduced new Play to Agent Panel analyzing gameplay events and displaying capability breakdowns.
  * Shows dominant capability with visual emphasis alongside associated archetype and policy information derived from gameplay performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->