### PR TITLE
feat(safety): シューティングを Agent 安全 default のオンボーディング教材に再フレーム

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -42,50 +42,50 @@ const A = {
 const ARCHETYPES = [
   {
     id: '01',
-    name: 'SPEED',
-    short: 'Fast but shallow',
-    body: 'Real-time reactions, snap decisions. Cheap latency. Loses depth on long-running judgments.',
-    tag: 'PINK',
+    name: 'FAST EXEC',
+    short: 'L2 / private mempool / quick rebalance',
+    body: "Without it your agent's tx times out, the price has moved, and you eat partial fills. Most agents default to mainnet and pay for it.",
+    tag: 'EXEC',
     color: '#ff8db3',
   },
   {
     id: '02',
-    name: 'LASER',
-    short: 'Accurate but slow',
-    body: 'High-precision reasoning. Pinpoint actions but burns budget per call.',
-    tag: 'RED',
+    name: 'PRECISION',
+    short: 'slippage cap / concentrated entry',
+    body: 'Without it every swap is a free lunch for sandwich bots. Default agents leave slippage at infinity — 1-3% bleed per trade.',
+    tag: 'EDGE',
     color: '#ff5252',
   },
   {
     id: '03',
-    name: 'OPTION',
-    short: 'Parallel but uncertain',
-    body: 'Spawns peer agents. Massive parallelism, coordination overhead, drift risk.',
-    tag: 'GREEN',
+    name: 'LEVERAGE',
+    short: 'margin tier / max position / hedge',
+    body: 'Default 0 = leave returns on the table. Default ∞ = liquidated on the wrong tier. The forgotten parameter that decides win or wipe.',
+    tag: 'TIER',
     color: '#40f070',
   },
   {
     id: '04',
-    name: 'SHIELD',
-    short: 'Safe but conservative',
-    body: 'Guardrails, retries, circuit breakers. Trades upside for safe operation.',
-    tag: 'CYAN',
+    name: 'SECURITY',
+    short: 'approval limit / multi-sig / allowlist',
+    body: 'Without it one phishing approve drains the wallet. Most agents ship with unlimited token approvals and a single hot key.',
+    tag: 'GUARD',
     color: '#7bdff2',
   },
   {
     id: '05',
-    name: 'MISSILE',
-    short: 'Powerful but external-reliant',
-    body: 'Tool use, third-party APIs, retrieval. Capability ceiling jumps; failure surface widens.',
-    tag: 'PURPLE',
+    name: 'ALPHA',
+    short: 'external signal / oracle / AI advisor',
+    body: 'Without it the agent trades blind on whatever the last block said. Stale-oracle losses are the most embarrassing kind.',
+    tag: 'SIGNAL',
     color: '#c084ff',
   },
   {
     id: '06',
-    name: 'MOAI',
-    short: 'The constraints you cannot shoot',
-    body: 'Gas, latency, security policy, API limits, hallucination risk. Dodge or die.',
-    tag: 'BOSS',
+    name: 'BOSSES',
+    short: 'real losses you eat if you skipped a default',
+    body: 'GAS WALL, MEV RAZOR, ORACLE DRIFT, LATENCY COMET, REGIME SHIFT. Each one punishes a missing module — ship without arming, and the boss collects.',
+    tag: 'RISK',
     color: A.hot,
   },
 ] as const;
@@ -389,7 +389,7 @@ function Nav({ onPlay }: { onPlay: () => void }) {
       </div>
       <div className="lp-nav-links" style={S.navLinks}>
         <a href="#tradeoffs" style={S.navLink}>
-          [01] Tradeoffs
+          [01] Defaults
         </a>
         <a href="#forge" style={S.navLink}>
           [02] Forge
@@ -610,18 +610,21 @@ function Hero({
         <div className="lp-hero-lower" style={S.heroLower}>
           <div>
             <h1 style={S.heroH1}>
-              KILL THE
+              ARM THE
               <br />
-              TRADEOFFS.
+              DEFAULTS
               <br />
-              <span style={S.heroH1Italic}>fly your agent.</span>
+              <span style={S.heroH1Italic}>nobody reads.</span>
             </h1>
             <p style={S.heroLede}>
-              Gr<span style={{ color: A.hud }}>@</span>dius is a 60-second
-              arcade dogfight that doubles as the world's fastest onboarding for
-              autonomous on-chain agents. Stick. Throttle. Trigger.{' '}
+              Most autonomous agents ship without slippage caps, approval
+              limits, oracle checks, leverage tiers, or fast-exec rails — the
+              defaults the docs warn about and nobody bothers to set.{' '}
               <span style={{ color: A.ink }}>
-                The agent that survives is the agent you ship.
+                Gr<span style={{ color: A.hud }}>@</span>dius is a 60-second
+                shooter that arms each one by hand. Survive the bosses (real
+                losses you'd otherwise eat) and you walk away knowing why each
+                default exists.
               </span>
             </p>
             <div
@@ -661,7 +664,7 @@ function Hero({
             <div style={S.countStrip}>
               {[
                 ['60s', 'BUILD_WINDOW'],
-                ['5+1', 'ARCHETYPES'],
+                ['5+1', 'DEFAULTS'],
                 ['$25K', 'PRIZE_TARGET'],
                 ['1', 'iNFT_PER_RUN'],
               ].map(([n, l], i) => (
@@ -816,8 +819,8 @@ function ArchetypesSection() {
   return (
     <section id="tradeoffs" style={S.section}>
       <SectionHead
-        num="§ 01 / TRADEOFFS"
-        title="Six enemies. One agent."
+        num="§ 01 / DEFAULTS"
+        title="Six modules. Six agent footguns."
         right="EACH_SHOT_IS_A_VOTE"
       />
       <div className="lp-grid-three" style={S.gridThree}>
@@ -848,9 +851,9 @@ function ArchetypesSection() {
                 style={{
                   fontSize: 10,
                   padding: '3px 8px',
-                  background: t.tag === 'BOSS' ? A.hot : 'transparent',
-                  color: t.tag === 'BOSS' ? A.bg : t.color,
-                  border: t.tag === 'BOSS' ? 'none' : `1px solid ${t.color}`,
+                  background: t.tag === 'RISK' ? A.hot : 'transparent',
+                  color: t.tag === 'RISK' ? A.bg : t.color,
+                  border: t.tag === 'RISK' ? 'none' : `1px solid ${t.color}`,
                   letterSpacing: '0.18em',
                   fontWeight: 700,
                 }}

--- a/packages/frontend/src/components/AgentDashboard.tsx
+++ b/packages/frontend/src/components/AgentDashboard.tsx
@@ -10,6 +10,7 @@ import {
   CAPABILITY_COLOR,
   CAPABILITY_DESC,
   CAPABILITY_LABEL,
+  CAPABILITY_RISK,
   getAllocation,
 } from '../game/runtime';
 import type { OnChainProof, OnChainStep, TxStatus } from '../web3/types';
@@ -155,6 +156,7 @@ export function AgentDashboard({
       </section>
 
       <PlayToAgentPanel birth={birth} archetype={archetype} />
+      <SafetyChecklistPanel birth={birth} />
 
       {proof ? (
         <OnChainProofPanel
@@ -311,6 +313,98 @@ function PlayToAgentPanel({
         <span style={{ color: A.mute }}> ⇒ POLICY: </span>
         <span style={{ color: A.ink }}>{ARCHETYPE_DESC[archetype]}</span>
       </div>
+    </section>
+  );
+}
+
+function SafetyChecklistPanel({ birth }: { birth: StoredAgentBirth }) {
+  const tally = tallyCommits(birth);
+  const armed = CAP_KEYS.filter((k) => tally[k] > 0);
+  const forgot = CAP_KEYS.filter((k) => tally[k] === 0);
+  const safetyScore = armed.length;
+  return (
+    <section
+      className="panel"
+      style={{ borderColor: A.rule, background: A.panel }}
+    >
+      <div className="panel-header">
+        <span className="eyebrow" style={{ color: A.amber }}>
+          SAFETY CHECKLIST
+        </span>
+        <h2 style={{ color: A.ink }}>{safetyScore} / 5 defaults armed</h2>
+        <p style={{ color: A.mute, fontSize: 12 }}>
+          Most autonomous agents ship with these missing. Each module you armed
+          via gameplay is one less footgun in production.
+        </p>
+      </div>
+
+      {armed.length > 0 ? (
+        <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
+          {armed.map((key) => (
+            <div
+              key={key}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '24px 130px 1fr',
+                gap: 12,
+                alignItems: 'start',
+                fontSize: 12,
+                fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+                lineHeight: 1.5,
+              }}
+            >
+              <span style={{ color: A.green, fontWeight: 700 }}>✓</span>
+              <span style={{ color: CAPABILITY_COLOR[key], fontWeight: 700 }}>
+                {CAPABILITY_LABEL[key]}
+              </span>
+              <span style={{ color: A.ink }}>{CAPABILITY_DESC[key]}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {forgot.length > 0 ? (
+        <div
+          style={{
+            marginTop: 18,
+            paddingTop: 14,
+            borderTop: `1px dashed ${A.rule}`,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 11,
+              color: A.hot,
+              letterSpacing: '0.2em',
+              marginBottom: 10,
+            }}
+          >
+            ⚠ FORGOT — Real agents commonly skip these. Risks if missing:
+          </div>
+          <div style={{ display: 'grid', gap: 10 }}>
+            {forgot.map((key) => (
+              <div
+                key={key}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '24px 130px 1fr',
+                  gap: 12,
+                  alignItems: 'start',
+                  fontSize: 12,
+                  fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+                  lineHeight: 1.5,
+                }}
+              >
+                <span style={{ color: A.hot, fontWeight: 700 }}>✗</span>
+                <span style={{ color: A.mute, fontWeight: 700 }}>
+                  {CAPABILITY_LABEL[key]}
+                </span>
+                <span style={{ color: A.mute }}>{CAPABILITY_RISK[key]}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -80,28 +80,41 @@ export const CAPABILITY_ORDER: Capability[] = [
   'missile',
 ];
 
+/// Player-facing capability names. Each enemy color = one of the agent
+/// safety / strategy defaults that real DeFi operators forget to configure.
+/// Keep these short and intuitive; longer descriptions live in the dashboard.
 export const CAPABILITY_LABEL: Record<Capability, string> = {
-  shield: 'SHIELD',
-  speed: 'SPEED',
-  option: 'OPTION',
-  laser: 'LASER',
-  missile: 'MISSILE',
+  shield: 'SECURITY',
+  speed: 'FAST EXEC',
+  option: 'LEVERAGE',
+  laser: 'PRECISION',
+  missile: 'ALPHA',
 };
 
 export const CAPABILITY_HUD_LABEL: Record<Capability, string> = {
-  shield: 'SHLD',
-  speed: 'SPD',
-  option: 'OPT',
-  laser: 'LSR',
-  missile: 'MSL',
+  shield: 'SEC',
+  speed: 'EXEC',
+  option: 'LEV',
+  laser: 'PREC',
+  missile: 'ALPHA',
 };
 
 export const CAPABILITY_DESC: Record<Capability, string> = {
-  shield: 'CIRCUIT BREAKER',
-  speed: 'L2 FAST EXEC',
-  option: 'AXL PEER NODE',
-  laser: '0G REASONING',
-  missile: 'UNISWAP ROUTER',
+  shield: 'approval limits / multi-sig / allowlist',
+  speed: 'L2 / private mempool / quick rebalance',
+  option: 'margin tier / max position / hedge',
+  laser: 'slippage cap / concentrated entry',
+  missile: 'external signal / oracle / AI advisor',
+};
+
+/// What real-world risk hits an agent that ships without this default armed.
+/// Surfaced in the dashboard "SAFETY CHECKLIST" panel and Moai damage toasts.
+export const CAPABILITY_RISK: Record<Capability, string> = {
+  shield: 'phishing / unlimited approve = full wallet drain',
+  speed: 'tx times out, price moved, partial fills',
+  option: 'liquidation on the wrong tier / left return on the table',
+  laser: 'sandwich attack, sloppy fills cost 1-3% per swap',
+  missile: 'trade on stale oracle, no edge',
 };
 
 export const CAPABILITY_COLOR: Record<Capability, string> = {
@@ -126,27 +139,27 @@ const MOAI_CONSTRAINT: Record<
 > = {
   aegis: {
     label: 'GAS WALL',
-    detail: 'caps position size',
+    detail: 'no SECURITY → 1 tx eats a month of profit',
     capability: 'shield',
   },
   razor: {
     label: 'MEV RAZOR',
-    detail: 'punishes sloppy swaps',
+    detail: 'no PRECISION → sandwiched for ~3% per swap',
     capability: 'laser',
   },
   oracle: {
     label: 'ORACLE DRIFT',
-    detail: 'forces market checks',
+    detail: 'no ALPHA → trade on stale price',
     capability: 'missile',
   },
   comet: {
     label: 'LATENCY COMET',
-    detail: 'demands fast execution',
+    detail: 'no FAST EXEC → tx times out, price moves',
     capability: 'speed',
   },
   hive: {
-    label: 'PEER DRIFT',
-    detail: 'tests AXL coordination',
+    label: 'REGIME SHIFT',
+    detail: 'no LEVERAGE management → market shifts and you stay frozen',
     capability: 'option',
   },
 };


### PR DESCRIPTION
## DNA への回帰
原案 ("退屈な議事録作成を Gradius でゲーム化") の本質に立ち戻り、Web3 agent 運用で operator が忘れがちな安全 default を 60 秒のシューティングで装備して回るオンボーディング教材として再フレーム。

## 直感ラベルへの差し替え
ユーザー指摘 (\"OPTION = レバレッジとか SHIELD = セキュリティとか\") に合わせて、技術ジャーゴンを実 DeFi 用語に。

| Old | New | 装備しないと起きること |
|---|---|---|
| SHIELD (CIRCUIT BREAKER) | **SECURITY** (approval limit / multi-sig) | phishing で全損 |
| SPEED (L2 FAST EXEC) | **FAST EXEC** | tx タイムアウト、partial fill |
| OPTION (AXL PEER NODE) | **LEVERAGE** (margin tier / max pos) | デフォ 0 = 機会損失、∞ = 清算 |
| LASER (0G REASONING) | **PRECISION** (slippage cap) | サンドイッチ ~3%/swap |
| MISSILE (UNISWAP ROUTER) | **ALPHA** (external signal / oracle) | 盲打ち |

## SafetyChecklistPanel 新設 (AgentDashboard)
プレイ後にダッシュボードで「あなたが装備したもの / 忘れたもの + 起きる被害」を提示。
- \"X / 5 defaults armed\" で進捗可視化
- ✓ ARMED 行 = 守られている default + 内容
- ✗ FORGOT 行 = 未装備 + 実際の損害例 (\`CAPABILITY_RISK\`)

## LP コピー全面書き換え
- Hero h1: \"KILL THE TRADEOFFS / fly your agent\" → \"ARM THE DEFAULTS / nobody reads\"
- Hero lede: 「ドキュメントが警告するけど誰も設定しない default を 60 秒で身体化」
- § 01 タイトル: \"Six enemies. One agent.\" → \"Six modules. Six agent footguns.\"
- ARCHETYPES データを各 capability の安全 default 説明に書き換え
- count strip \"ARCHETYPES\" → \"DEFAULTS\"、Nav リンク \"Tradeoffs\" → \"Defaults\"

## なぜこれが効くか
1. **正直**: 実 agent 運用で本当に起きる事故と直結
2. **教育的**: 「装備しないと Moai に殴られる」が「default を読み飛ばすと運用で殴られる」と一致
3. **Open Agents テーマ**: 自律 agent を安全に動かすための onboarding は ど真ん中
4. **既存技術の再利用**: コードロジックは触らず、ラベルとコピーと dashboard 1 セクションだけで物語が変わる

## Test plan
- [x] make before-commit (architecture-harness 0 / lint 0 / typecheck 0 / 22 tests / build OK)
- [ ] 実機: ゲームクリア後 SafetyChecklistPanel が表示
- [ ] 実機: 装備した capability が ✓ 行、未装備が ✗ 行に正しく振り分けられる
- [ ] 実機: ゲーム HUD の SHLD/SPD/OPT/LSR/MSL ラベルも SEC/EXEC/LEV/PREC/ALPHA に変わっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)