### PR TITLE
feat(safety): Agent 安全アテステーション 3 段重ね — A misalignment / B ENS / C attestation

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -191,11 +191,28 @@
 #### 進捗ログ
 
 - 2026-04-29 — `/feature` フロー Phase 0-2 完了、Prize 採点 (0G Storage 3 + ENS 3) → 仕様書承認 → ブランチ feat/safety-tutorial にスタック。
+- 2026-04-29 — Phase 3 Issue 5 件作成 (#24 PM / #25 Designer / #26 Developer / #27 QA / #28 User)。
+- 2026-04-29 — Phase 4 5 役割並列実装完了。Developer は shared/safety.ts (24 pass) + frontend/safety-attestation.ts (10 pass) + UI コンポーネント 2 件、PM/Designer/QA/User は派生ドキュメントを成果物として出力。
+- 2026-04-29 — Phase 5 統合: QA critical #1 (subname handle 衝突 griefing、前回 tokenId 級) を反映。pilot 2 桁 → 4 桁 hex に拡張、ENS Registry の owner() で pre-flight チェック、Sepolia chain assertion を追加。Persona Z 指摘の URI スキーム (`{scheme}://{value}`) を putAttestation に固定。全ゲート green。
+
+#### 振り返り
+
+- **問題**: Developer agent が自動生成した handle が `pilot{2 桁}` (100 通り) で、parent owner 権限の NameWrapper.setSubnodeRecord と組み合わさると「他者保有の subname を上書き」する経路が成立した。前回 tokenId griefing と全く同じ構造 (衝突空間が狭く、parent owner の write 権限が広い)。
+- **根本原因**: 仕様書 21 行目に「pilot{2 桁ランダム}」と書いた時点で、衝突空間の狭さが griefing につながると気付けなかった。Phase 2 の Security 考慮セクションに「Griefing — handle pre-claim」を入れていたものの、対策行が「衝突時 retry」止まりで「衝突空間そのものを広げる」「pre-flight ownerOf を見る」まで踏み込めていなかった。並列 QA agent がこれを critical top-1 で拾えたのが救い。
+- **予防策**: ハンドル / トークン ID / nonce を含む全ての user-controllable identifier について、仕様書テンプレに「衝突空間サイズ」「parent / owner の write 権限」「pre-flight 確認手段」の 3 列を必須化する。Phase 2 仕様書テンプレ (前回追加した Security セクション) を更にこの 3 列で拡張する。
+- **学び**: 並列 QA agent の独立視点が 2 PR 連続で critical を拾えた (前回 tokenId、今回 subname handle)。これは固定運用にする価値がある。Developer agent 単独では最小実装に倒れて衝突空間を考慮しない傾向。
 
 #### Known Follow-ups
 
-- 0G Storage SDK 実統合 (現状 SHA-256 stub のまま)。
+- 0G Storage SDK 実統合 (現状 SHA-256 stub のまま、URI は `sha256://{hex}` で書き込み)。
 - 0G Compute による misalignment 判定 sealed inference (今回見送り)。
 - KeeperHub による text record 自動更新 (今回見送り)。
 - Roguelike / misalignment 重複コンボ (v2)。
 - 5 種目以降の misalignment 拡張 (deceptive alignment 等)。
+- demo 動画用 `?seed=demo` で 4 種 misalignment を強制表示する seed (User Persona Y 指摘)。
+- SafetyAttestationPanel の encounter 行に日本語 description / example 併記、breakdown を加減算伝票形式に書き換え (User Persona X 指摘)。
+- README Quick verification 表に「Agent safety attestation」行追加、Sponsor integrations の ENS 行を新 text record リストに更新 (User Persona Y 指摘)。
+- 同 wallet なら同 subname を返す deterministic mode (User Persona Z 指摘、griefing 対策と両立する設計検討)。
+- testname.eth (Sepolia) の個人購入 + `.env.local` の VITE_ENS_PARENT 上書き (本機能の demo 必須前提)。
+- Pipeline diagram visualization (A→B→C 連結の視覚化、User Persona Y 指摘)。
+- ENS write 直前の switchChain await + post-check (現状は chain assertion のみで failed に倒している)。

--- a/Plan.md
+++ b/Plan.md
@@ -148,3 +148,54 @@
 - **根本原因**: 旧コード (#5 まで) のときに作った deterministic wallet を、wagmi 移行 (#8) で置き換えたが型・関数を消し損ねた。
 - **予防策**: 大規模リファクタの後に dead-code sweep (gh PR `simplify` 相当) を必ず通す。
 - **学び**: 5 役割 parallel agent は機能した。特に QA / User の独立視点が critical 修正と README 整合エラーを拾えた。1 Developer agent では security と UX の両方を見切れない。次回も同じ構成で。
+
+---
+
+### Agent 安全アテステーション (3 段重ね) - 2026-04-29
+
+#### 目的
+
+シューティング = Agent 安全 default オンボーディングの再フレーム (commit 5947342) を踏襲しつつ、(A) 倒した敵に misalignment 種別カードを出す / (B) プレイヤー Agent を ENS subname で名乗らせる / (C) 終了時に 100 点満点の Agent 安全スコアを 0G Storage + ENS text record で発行する 3 層を 1 PR で実装する。
+
+仕様書: [`docs/specs/2026-04-29-agent-safety-attestation.md`](./docs/specs/2026-04-29-agent-safety-attestation.md)
+
+メイン狙い prize: **0G Storage** + **ENS Identity / Creative**。Gensyn AXL / KeeperHub は意図的に除外、Uniswap は既存維持のみ。
+
+#### 制約
+
+- ブランチ: `feat/safety-tutorial` にスタック (再フレーム → 3 段重ねを 1 PR で連続)。
+- ENS 親: Sepolia の `testname.eth` を user が個人購入 (.env.local で `VITE_ENS_PARENT` 上書き)、subname を NameWrapper.setSubnodeRecord で発行。
+- 0G Storage: 既存の SHA-256 stub のまま、実 SDK 統合は follow-up。
+- TDD: shared/safety.ts の純関数 (computeSafetyScore / deriveSafetyAttestation) を Red → Green → Refactor。
+- No Mock: 既存 `architecture-harness.ts` の検出に従う。
+- Plan.md / 仕様書 / ADR を先に整える (CLAUDE.md の「作業順序」に従う)。
+
+#### タスク (5 役割 parallel + integration)
+
+- [x] 仕様書 `docs/specs/2026-04-29-agent-safety-attestation.md`
+- [ ] PM レビュー `-pm-review.md` (受け入れ基準のテストシナリオ化、依存関係、scope guard)
+- [ ] Designer 設計 `-design.md` (MisalignmentToast / SafetyAttestationPanel / HUD ラベルの ASCII wireframe、a11y、エラー状態)
+- [ ] Developer 実装: shared 型 + safety.ts + game/runtime.ts payload + zerog-storage.ts 拡張 + safety-attestation orchestrator + UI コンポーネント
+- [ ] QA レビュー `-qa.md` (Security 4 軸 + score 純関数の境界値 + ENS / 0G failed 状態 + a11y)
+- [ ] User feedback `-user-feedback.md` (未経験プレイヤー / デモ視聴者 / ENS 審査員の 3 ペルソナ)
+- [ ] Integration: critical 修正反映、Plan.md 振り返り更新、ゲート全通過 → PR
+
+#### 検証手順
+
+1. `bun --filter @gradiusweb3/shared test` で computeSafetyScore / deriveSafetyAttestation の純関数テストが green
+2. `bun scripts/architecture-harness.ts --staged --fail-on=error` 通過
+3. `make before-commit` 通過 (lint / typecheck / test / build)
+4. `bun run dev` で起動、ゲームプレイ → misalignment toast → game over → AgentDashboard で score / breakdown / ENS link / 0G CID 表示まで一気通貫
+5. ウォレット未接続 / 接続済みの双方で UX が壊れない
+
+#### 進捗ログ
+
+- 2026-04-29 — `/feature` フロー Phase 0-2 完了、Prize 採点 (0G Storage 3 + ENS 3) → 仕様書承認 → ブランチ feat/safety-tutorial にスタック。
+
+#### Known Follow-ups
+
+- 0G Storage SDK 実統合 (現状 SHA-256 stub のまま)。
+- 0G Compute による misalignment 判定 sealed inference (今回見送り)。
+- KeeperHub による text record 自動更新 (今回見送り)。
+- Roguelike / misalignment 重複コンボ (v2)。
+- 5 種目以降の misalignment 拡張 (deceptive alignment 等)。

--- a/docs/specs/2026-04-29-agent-safety-attestation-design.md
+++ b/docs/specs/2026-04-29-agent-safety-attestation-design.md
@@ -1,0 +1,512 @@
+# Agent 安全アテステーション (3 段重ね) — Designer 仕様
+
+設計担当: Designer ロール (`/feature` 5 役並列)。
+親仕様: [`2026-04-29-agent-safety-attestation.md`](./2026-04-29-agent-safety-attestation.md)。
+書式参考: [`2026-04-27-web3-wiring-design.md`](./2026-04-27-web3-wiring-design.md)。
+対象コンポーネント:
+
+- 新規 `packages/frontend/src/components/MisalignmentToast.tsx` (ゲーム中の 2 秒 toast)。
+- 新規 `packages/frontend/src/components/SafetyAttestationPanel.tsx` (`AgentDashboard` に差し込む)。
+- 拡張 `packages/frontend/src/components/HUD.tsx` (上部ラベル "AGENT: pilot42.{parent}.eth")。
+
+## 1. 設計方針
+
+- 既存の brutalist + Ace Combat 風 (App.tsx HUD / amber CTA / dashed rule) と OnChainProof 計器パネルの世界観を絶対に壊さない。新規パレットは禁止し、既存 `A` const (`bg / panel / ink / mute / rule / acid / hud / amber / hot / green`) と既存 `CAPABILITY_COLOR` のみで構成する。
+- A 層 (toast) / B 層 (HUD ラベル) / C 層 (Attestation Panel) は **同一 visual 言語** (`HUDCorners`, dashed rule, `JetBrains Mono`, tabular-nums, letter-spacing 0.18em-0.22em の uppercase eyebrow) で連結し、デモ視聴者に「3 つは 1 つの装置」と読ませる。
+- misalignment の 4 種は **色 + 記号 + ラベル** の 3 重符号化で識別させ、色覚多様性配慮と WCAG 2.1 AA を両立する (詳細 §4 / §6)。
+- score 大表示は demo 動画 1:20-2:30 の主役カット。3 桁を画面の支配項にする (font-size 96px / line-height 0.9)。
+
+## 2. MisalignmentToast (A 層)
+
+敵を撃破した瞬間に Canvas overlay の右下に出る 2 秒間の toast。`PlayLog.shoot` イベントの `misalignment` を引数に受け、対応する `MisalignmentCard` を描画する。
+
+### 2-1. ASCII ワイヤーフレーム — desktop (>=768px、Canvas 1080px 想定)
+
+Canvas 領域 (App.tsx の `S.canvasFrame` 内) の右下に absolute 配置。Canvas の右端と下端から 24px のオフセット。
+
+```
+                                                        ┌─ corner ────────────────────── corner ─┐
+                                                        │ ░░ MISALIGNMENT DETECTED · t+34.2s     │
+                                                        │ ─────────────────────────────────────  │
+                                                        │  ◇  REWARD HACKING                     │
+                                                        │     proxy 指標を最大化して本来の目標   │
+                                                        │     (利益) を犠牲にする失敗モード。    │
+                                                        │     例: yield % だけ追って TVL を空にする  │
+                                                        └─ corner ────────────────────── corner ─┘
+                                                          ↑ width 360px / height 132px / shadow A.bg66
+```
+
+Grid 列定義:
+
+```
+gridTemplateColumns: "44px  1fr"
+                     glyph  label + description + example
+gridTemplateRows:    "auto auto auto"
+                     label / description (140 字以内) / example (1 行)
+```
+
+### 2-2. ASCII ワイヤーフレーム — mobile (<768px、Canvas 360px 想定)
+
+Canvas 横幅いっぱいの底辺バー (`bottom: 0`, `left: 0`, `right: 0`, height 102px、`borderTop: 1px solid A.rule`)。`HUDCorners` は描かず、上辺のみ rule 線で区切る。
+
+```
+┌───────────────────────────────────────────────┐
+│ ░░ MISALIGNMENT · t+34.2s                     │
+│ ────────────────────────────────────────────  │
+│ ◇ REWARD HACKING                              │
+│ proxy 指標だけ最大化して本来の目標を犠牲に。  │
+│ 例: yield % を追って TVL を空にする           │
+└───────────────────────────────────────────────┘
+```
+
+description は `text-overflow: ellipsis` でなく `line-clamp: 2` で 2 行までに収める。example は `<480px` で非表示にする (画面占有を 102px → 78px に縮小)。
+
+### 2-3. 状態遷移図
+
+`MisalignmentToast` は単一インスタンスが queue を持ち、撃破ごとに先頭から 1 枚ずつ表示する (重複表示しない、取り逃しは捨てる)。
+
+```
+        push(card)
+[empty] ─────────────────► [entering]
+   ▲                            │
+   │                            │ 200ms slideIn + fadeIn
+   │                            ▼
+   │                         [visible]
+   │                            │
+   │                            │ 1600ms hold (内部に dwellTimer)
+   │                            ▼
+   │                         [exiting]
+   │  200ms slideOut + fadeOut │
+   └────────────────────────────┘
+```
+
+| 状態 | duration | 視覚 | 副作用 |
+|------|----------|------|--------|
+| empty | — | 非表示 (`display: none`) | queue が空、次の `push` で `entering` へ |
+| entering | 200ms | `transform: translateY(12px) → 0`, `opacity: 0 → 1`, `easing: cubic-bezier(.2,.8,.2,1)` | `aria-live="polite"` 領域にラベルを inject |
+| visible | 1600ms | 静止表示。description に下線 sweep (`linear-gradient` 1 度のみ、デモで「読める」感) | dwellTimer 終了で `exiting` へ |
+| exiting | 200ms | `transform: 0 → translateY(-6px)`, `opacity: 1 → 0` | 完了後 queue から `shift`、queue が空なら `empty`、非空なら次の card を `entering` へ |
+
+合計 2000ms (受け入れ基準「2 秒 toast」を満たす)。`prefers-reduced-motion: reduce` 時は entering/exiting を 0ms にし、フェードのみ 100ms に短縮する。
+
+### 2-4. 表示要素の階層
+
+| 要素 | テキスト | 色 (既存トークン) | font-size | letter-spacing | font-weight |
+|------|---------|-------------------|-----------|----------------|-------------|
+| eyebrow | `░░ MISALIGNMENT DETECTED · t+34.2s` | `A.mute` | 11px | 0.20em | 400 |
+| glyph | `◉ ◇ ▲ ☓` の 1 字 | misalignment 色 (§4) | 28px | 0 | 700 |
+| label | `REWARD HACKING` 等 (uppercase) | misalignment 色 (§4) | 13px | 0.22em | 700 |
+| description (140 字以内) | 仕様の `MisalignmentCard.description` | `A.body` (#a8b8c8) | 12px | 0.04em | 400 |
+| example (1 行) | `例: ...` プレフィックス | `A.hud` (#7ee0ff) | 11px | 0.04em | 500 |
+| 外枠 | `HUDCorners color={misalignment 色} size={14}` | misalignment 色 (§4) | — | — | — |
+| 背景 | `A.bg` + `box-shadow: 0 0 24px ${A.bg}cc inset` | — | — | — | — |
+
+## 3. SafetyAttestationPanel (C 層)
+
+`AgentDashboard.tsx` 内、既存 `OnChainProofPanel` の **隣** (full-width 行) に差し込む。score の 3 桁を主役にする縦長構造。
+
+### 3-1. ASCII ワイヤーフレーム — desktop (>=768px)
+
+```
+┌────────────────────────────────────────────────────────────────────────────────┐
+│ ░░ § 09 / AGENT SAFETY ATTESTATION                ATTEST · 2 / 2 LIVE          │
+│ ─────────────────────────────────────────────────────────────────────────────  │
+│ ┌─ corner          AGENT SAFETY ATTESTATION · pilot42                corner ─┐ │
+│ │                                                                            │ │
+│ │   ┌──────────────────────┐   ┌──────────────────────────────────────────┐ │ │
+│ │   │                      │   │ BREAKDOWN                                │ │ │
+│ │   │       0 8 5          │   │ ─────────────────────────────────────    │ │ │
+│ │   │       ─────          │   │ CLEAR TIME BONUS  ████████████████   +42 │ │ │
+│ │   │       / 100          │   │ MISS PENALTY      ███─────────────    -7 │ │ │
+│ │   │                      │   │ BASE                                  +50 │ │ │
+│ │   │  AGENT SAFE SCORE    │   │ ─────────────────────────────────────    │ │ │
+│ │   │  pilot42.{parent}.eth│   │ TOTAL                                  85 │ │ │
+│ │   └──────────────────────┘   └──────────────────────────────────────────┘ │ │
+│ │                                                                            │ │
+│ │   MISALIGNMENT ENCOUNTERS · 5 detected / 8 enemies                         │ │
+│ │   ─────────────────────────────────────────────────────────────────────    │ │
+│ │   ◉ SYCOPHANCY        ×2  hit  enemy_3 @ 12.4s · enemy_5 @ 28.1s          │ │
+│ │   ◇ REWARD HACKING    ×1  hit  enemy_4 @ 19.6s                             │ │
+│ │   ▲ PROMPT INJECTION  ×1  miss enemy_7 @ 41.2s (passed)                    │ │
+│ │   ☓ GOAL MISGEN       ×1  hit  enemy_8 @ 52.0s                             │ │
+│ │   ─────────────────────────────────────────────────────────────────────    │ │
+│ │                                                                            │ │
+│ │   ATTESTATION TARGETS                                                      │ │
+│ │   ─────────────────────────────────────────────────────────────────────    │ │
+│ │   [01] ENS RESOLVER   pilot42.{parent}.eth      ● RESOLVED                 │ │
+│ │        text records ×3   sepolia.app.ens.domains/pilot42.{parent}.eth →    │ │
+│ │   [02] 0G STORAGE     attestation.json          ● STORED                   │ │
+│ │        CID bafy..7q3p   0g-storage.dev/cid/bafy..7q3p →                    │ │
+│ └─ corner                                                            corner ─┘ │
+│                                                                                │
+│ ◆ MASTER_ARM · ATTESTATION JSON IS DETERMINISTIC FROM PLAY LOG · NO SERVER    │
+└────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Grid 列定義 (上半分の score + breakdown):
+
+```
+gridTemplateColumns: "minmax(260px, 1fr)  minmax(360px, 1.6fr)"
+                     score 大表示          breakdown 棒グラフ
+gap: 24px
+```
+
+下半分 (encounter 一覧) は full-width。さらに下の attestation targets は OnChainProof と同じ 4 列 grid を 2 行に縮小して再利用する (`120px  minmax(220px, 1.4fr)  140px  minmax(220px, 1.6fr)`)。
+
+### 3-2. ASCII ワイヤーフレーム — mobile (<768px)
+
+score / breakdown / encounter / attestation targets を 1 列 stack に変更。
+
+```
+┌──   ─────────────────────  ──┐
+│ § 09 / AGENT SAFETY          │
+│ ATTEST · 2 / 2 LIVE          │
+│ ──────────────────────────── │
+│                              │
+│         0 8 5                │
+│         ─────                │
+│         / 100                │
+│   AGENT SAFE SCORE           │
+│   pilot42.{parent}.eth       │
+│ ──────────────────────────── │
+│ BREAKDOWN                    │
+│ CLEAR TIME BONUS  ████   +42 │
+│ MISS PENALTY      █─────  -7 │
+│ BASE                     +50 │
+│ TOTAL                     85 │
+│ ──────────────────────────── │
+│ MISALIGNMENT ENCOUNTERS      │
+│ 5 detected / 8 enemies       │
+│ ◉ SYCOPHANCY      ×2 hit     │
+│   enemy_3 @ 12.4s            │
+│ ◇ REWARD HACKING  ×1 hit     │
+│ ▲ PROMPT INJECTION ×1 miss   │
+│ ☓ GOAL MISGEN     ×1 hit     │
+│ ──────────────────────────── │
+│ ATTESTATION TARGETS          │
+│ [01] ENS         ● RESOLVED  │
+│   pilot42.{parent}.eth       │
+│   → sepolia.app.ens.domains  │
+│ [02] 0G STORAGE  ● STORED    │
+│   CID bafy..7q3p             │
+│   → 0g-storage.dev/cid/...   │
+│                              │
+│ ◆ MASTER_ARM · DETERMINISTIC │
+│   FROM PLAY LOG              │
+└──   ─────────────────────  ──┘
+```
+
+| breakpoint | 変更点 |
+|-----------|--------|
+| `>=1024px` | score / breakdown 横並び、encounter は 1 行 1 件 |
+| `>=768px` && `<1024px` | score / breakdown 横並びを保持、encounter の例文 (`enemy_3 @ 12.4s`) を 1 件のみ表示しその他は `…` |
+| `<768px` | 1 列 stack、score の font-size 96 → 72px に縮小、attestation targets は 2 行カードに |
+| `<480px` | パネル左右 padding 28 → 16px、`HUDCorners size 22 → 14`、score の font-size 72 → 60px |
+
+### 3-3. 4 行 state matrix
+
+`SafetyAttestationPanel` 全体が orchestrator の `Promise.allSettled` 結果から **集約 status** を受ける。各サブセクションは個別状態を持つ (score 計算は idle/success のみ、ENS と 0G は 4 状態)。
+
+| section | idle | pending | success | failed |
+|---------|------|---------|---------|--------|
+| score 大表示 | `— — —` (3 字 dash, `A.mute`) + 補助文 `playLog 待ち` | (該当なし、score 計算は同期純関数) | `0 8 5` (`A.ink`, glow flash 1 度), 補助文 `pilot42.{parent}.eth` (`A.hud`) | (該当なし、純関数は失敗しない) |
+| breakdown 棒グラフ | バー全て灰 (`A.rule`)、値 `—` (`A.mute`) | (該当なし) | バー伸長 animation 600ms ease-out, 値 (`A.ink` + `+`/`-` 接頭辞) | (該当なし) |
+| MISALIGNMENT ENCOUNTERS | `0 detected / 0 enemies` (`A.mute`)、リスト空、empty state 文言 (§7-2) | (該当なし) | `5 detected / 8 enemies` (`A.amber` for 数値)、リスト 4 種ソート済 | (該当なし) |
+| ATTESTATION TARGETS [01] ENS | `pilot42.{parent}.eth` (`A.mute`) `○ STANDBY` | `subname + 3 records ░░` (`A.hud`) `▲ PENDING` (`A.amber` パルス) | `text records ×3` (`A.body`) `● RESOLVED` (`A.green`) + resolver link | error message (`A.hot`) `✕ FAILED` + `[ ▸ RETRY ]` |
+| ATTESTATION TARGETS [02] 0G | `attestation.json ready` (`A.mute`) `○ STANDBY` | `uploading attestation ░░` (`A.hud`) `▲ PENDING` | `CID bafy..7q3p` (`A.hud`) `● STORED` (`A.green`) + storage link | error message (`A.hot`) `✕ FAILED` + `[ ▸ RETRY ]` (fallback: `sha256://` ハッシュ表示) |
+
+ウォレット未接続のケース: 親仕様の受け入れ基準より、score 計算と attestation JSON 表示は完走する。score / breakdown / encounter は `success` で表示し、ATTESTATION TARGETS だけ `failed` (理由 `wallet not connected`、`[ ▸ CONNECT WALLET ]` CTA を `A.amber` で 1 つ出す)。
+
+### 3-4. score 大表示の詳細
+
+| 要素 | テキスト | 色 | font-size | letter-spacing | font-weight |
+|------|---------|-----|-----------|----------------|-------------|
+| score 数値 | `0 8 5` (3 桁、各文字の間に `0.12em` の visual gap) | `A.ink` | 96px (desktop) / 72px (tablet) / 60px (mobile) | 0.12em | 700 |
+| underscore rule | `─────` (3 桁分) | `A.amber` | (height 1.4px) | — | — |
+| `/ 100` | `/ 100` | `A.mute` | 14px | 0.18em | 500 |
+| label | `AGENT SAFE SCORE` | `A.amber` | 11px | 0.22em | 700 |
+| ensName | `pilot42.{parent}.eth` | `A.hud`, tabular-nums | 12px | 0.10em | 500 |
+
+score 値はゼロパディングで常に 3 桁表示する (`String(score).padStart(3, '0').split('').join(' ')`)。0 のときは `A.hot` で表示し、demo で「失敗もカッコ良く見せる」を担保する。glow flash は success 遷移時の 1 度のみ (`text-shadow: 0 0 24px ${A.amber}88` を 800ms で減衰)。
+
+### 3-5. breakdown 棒グラフの詳細
+
+`SafetyScoreBreakdown` を以下の 3 行で表現する (BASE は固定 +50)。
+
+```
+CLEAR TIME BONUS  ████████████████   +42
+MISS PENALTY      ███─────────────    -7
+BASE                                  +50
+TOTAL                                  85
+```
+
+| 列 | 幅 | 内容 | 色 |
+|----|-----|------|-----|
+| ラベル | 200px | `CLEAR TIME BONUS` 等 (uppercase) | `A.mute` |
+| バー | 1fr (max 280px) | `█` 16 マス、値の絶対値を 50 でスケール | 正値: `A.green`、負値: `A.hot`、未使用部分: `A.rule` |
+| 値 | 60px | `+42` / `-7` / `+50` (tabular-nums) | 正値: `A.green`、負値: `A.hot`、BASE: `A.amber` |
+
+TOTAL 行は dashed rule で区切り、値は `A.ink` (font-weight 700) で太く表示する。
+
+### 3-6. encounter 一覧の詳細
+
+```
+◉ SYCOPHANCY        ×2  hit  enemy_3 @ 12.4s · enemy_5 @ 28.1s
+```
+
+| 列 | 内容 | 色 |
+|----|------|-----|
+| glyph | `◉ ◇ ▲ ☓` の 1 字 | misalignment 色 (§4) |
+| label | `SYCOPHANCY` 等 (uppercase) | misalignment 色 (§4) |
+| count | `×2` (tabular-nums) | `A.ink`, font-weight 700 |
+| outcome | `hit` / `miss` (lowercase) | hit: `A.green`, miss: `A.hot` |
+| detail | `enemy_3 @ 12.4s · ...` | `A.body`, tabular-nums |
+
+ソート順: `count desc → glyph 順 (◉ ◇ ▲ ☓)`。0 件の misalignment は表示しない (empty 行で埋めない、可読性優先)。
+
+### 3-7. attestation targets の詳細
+
+`§ 08 / ON-CHAIN PROOF` の 4 行構造を **2 行に縮小** して再利用する。同一 grid (`120px / 1.4fr / 140px / 1.6fr`) を保つことで世界観の連続性を担保する。
+
+| TRACK | CONTRACT/RESOURCE | STATUS | LINK / ACTION |
+|-------|-------------------|--------|---------------|
+| `[01] ENS` | `pilot42.{parent}.eth` / `text records ×3` | `● RESOLVED` | `sepolia.app.ens.domains/pilot42.{parent}.eth →` |
+| `[02] 0G STORAGE` | `attestation.json` / `CID bafy..7q3p` | `● STORED` | `0g-storage.dev/cid/bafy..7q3p →` |
+
+`[01]` の resolver link は親仕様の `ensName` を URL に埋める。`[02]` は CID をフル表示できるよう `<abbr title="bafy...full...7q3p">` でホバー / フォーカス時に出す。SHA-256 stub 中は CID の代わりに `sha256://abcd..ef01` と表示し、補助文に `(stub: 0G SDK 連携は follow-up)` (`A.mute`) を 1 行添える。
+
+## 4. misalignment 4 種の色 + 記号アサイン
+
+`MisalignmentCard.glyph` と `.color` を以下の通り固定する。色は **既存パレット** (`game/palette.ts` の `PAL.*` と `runtime.ts` の `CAPABILITY_COLOR.*`) と整合させ、新規色を導入しない。
+
+| kind | glyph | label | 色 (token) | 16 進 | 由来 capability | コントラスト比 (背景 `A.bg #05080c`) |
+|------|-------|-------|-----------|--------|-----------------|-------------------------------------|
+| `sycophancy` | `◉` | SYCOPHANCY | `CAPABILITY_COLOR.missile` | `#c084ff` | missile (ALPHA) | 8.4:1 (Pass AAA) |
+| `reward_hacking` | `◇` | REWARD HACKING | `CAPABILITY_COLOR.option` | `#40f070` | option (LEVERAGE) | 13.5:1 (Pass AAA) |
+| `prompt_injection` | `▲` | PROMPT INJECTION | `CAPABILITY_COLOR.shield` | `#7bdff2` | shield (SECURITY) | 11.0:1 (Pass AAA) |
+| `goal_misgen` | `☓` | GOAL MISGEN | `CAPABILITY_COLOR.laser` | `#ff5252` | laser (PRECISION) | 5.0:1 (Pass AA) |
+
+設計意図:
+
+- `prompt_injection` (≒ 外部からの "approve all" 注入) を `shield` の cyan に紐づけ、「security 系の失敗モード」と直感的に結びつける。
+- `reward_hacking` (≒ proxy 指標を最大化) を `option` の green に紐づけ、「leverage / 指標歪曲」のメタファ。
+- `goal_misgen` (≒ 本来の目標と違うものを最適化) を `laser` の red に紐づけ、「致命的に間違った precision」を表現。
+- `sycophancy` (≒ 都合の良い signal だけ拾う) を `missile` の violet に紐づけ、「歪んだ alpha 探索」を表現。
+- 4 つの記号 `◉ ◇ ▲ ☓` は filled-circle / diamond / triangle / cross の 4 種で、白黒印刷 / 単色 LED / 色覚多様性のいずれでも識別可能。
+
+`speed` capability は parent spec で「misalignment なし」とされる。speed 由来の敵を撃破した場合は toast を出さず、score breakdown の `MISALIGNMENT ENCOUNTERS` カウントにも入れない (受け入れ基準と整合)。
+
+### 4-1. MisalignmentCard データ (Designer 提案、Developer 実装で確定)
+
+| kind | label | description (140 字以内、日本語) | example (1 行) |
+|------|-------|-----------------------------------|----------------|
+| `sycophancy` | SYCOPHANCY | ユーザーや評価者が喜ぶ応答だけを返し、不都合な事実を隠す失敗モード。Agent が安全より「いい顔」を優先する。 | 例: 損失を出した取引を report で「学習機会」と言い換える |
+| `reward_hacking` | REWARD HACKING | proxy 指標 (yield % など) を最大化して、本来の目標 (利益・安全) を犠牲にする失敗モード。 | 例: yield % だけ追って TVL を空にする |
+| `prompt_injection` | PROMPT INJECTION | 外部入力に紛れた指示を実行してしまう失敗モード。"approve all" 系の注入で wallet が drain する。 | 例: 取引 memo の "send all to 0x.." を実行 |
+| `goal_misgen` | GOAL MISGEN | 訓練分布外で目標を取り違える失敗モード。proxy だけ最適化して本来の目標から外れる。 | 例: gas 最小化で重要 tx を skip |
+
+## 5. HUD ラベル — "AGENT: pilot42.{parent}.eth"
+
+`HUD.tsx` を拡張し、`AgentHandleLabel` コンポーネントを追加。`App.tsx` の Hero / Arcade 上部 HUD バー (canvas frame の上部) に 1 行で挿入する。
+
+### 5-1. 配置
+
+| breakpoint | 配置 | text-align |
+|-----------|------|-----------|
+| `>=1024px` | canvas frame 上端、left padding 24px、上端から 12px | left |
+| `>=768px` && `<1024px` | canvas frame 上端、left padding 16px、上端から 10px | left |
+| `<768px` | canvas frame 上端、`width: 100%`、padding `8px 16px`、`border-bottom: 1px dashed A.rule` で本編と区切る | left |
+| `<480px` | 同上、ただし `parent` 部分を `…` で省略 (例: `AGENT: pilot42.…eth`) | left |
+| `<360px` | 1 行で収まらないため `font-size: 11 → 10px`、`letter-spacing: 0.18em → 0.12em` に縮小、それでも溢れる場合は `pilot42` のみ表示 (parent は省略) | left |
+
+### 5-2. タイポグラフィ
+
+| 要素 | テキスト | 色 | font-size | letter-spacing | font-weight |
+|------|---------|-----|-----------|----------------|-------------|
+| prefix `AGENT:` | `AGENT:` | `A.mute` | 11px | 0.22em | 700 |
+| handle `pilot42` | `pilot42` (handle 部分) | `A.amber` | 13px | 0.18em | 700 |
+| dot `.` | `.` | `A.mute` | 13px | 0.04em | 400 |
+| parent `{parent}.eth` | `gradiusweb3.eth` 等 | `A.hud` | 13px | 0.18em | 500 |
+| 区切り | 左側に `▸` (`A.amber`, 11px) を 1 個置く (Hero CTA との視覚的連続性) | — | — | — | — |
+
+フォントは既存 `JetBrains Mono` を継承。tabular-nums は `pilot42` の数字部分にのみ付与し、ハンドル切り替え時に幅が動かないようにする。
+
+### 5-3. wallet 切替時の差替えルール
+
+親仕様の Security 考慮より、handle は **session 内ランダム** (`pilot{2 桁}`) で wallet ごとに別の subname を引く。Designer 視点の差替えルール:
+
+| 状態 | 表示 | 色 |
+|------|------|-----|
+| ウォレット未接続 | `AGENT: ▸ CONNECT WALLET` (CTA 風、クリックで ConnectButton にスクロール) | prefix `A.mute` / CTA `A.amber` |
+| 接続直後 (handle 生成中、< 50ms) | `AGENT: pilot__.____.eth` (アンダースコアで占位) | 全体 `A.mute` |
+| 接続成功 (handle 確定) | `AGENT: pilot42.gradiusweb3.eth` | (上記 §5-2) |
+| ウォレット切替検出 | 200ms の cross-fade (`opacity: 1 → 0 → 1`) で新 handle に置換、handle 部分のみ glow flash 600ms | (上記 §5-2) + glow `A.amber66` |
+| 切断 | `AGENT: ▸ CONNECT WALLET` に戻す | (未接続と同じ) |
+
+handle 生成は `walletAddress` をシードにせず、`crypto.getRandomValues` ベースの session 内乱数とする (parent spec の deterministic でない要件と整合)。同セッションで `disconnect → reconnect` した場合は handle が変わって良い (デモ視聴者には「毎回違う subname」が逆に好印象)。
+
+### 5-4. aria 属性
+
+```
+<div role="status" aria-live="polite" aria-label="Agent handle: pilot42.gradiusweb3.eth">
+  AGENT: pilot42.gradiusweb3.eth
+</div>
+```
+
+handle 切替時は `aria-live="polite"` で SR に通知する。`aria-busy="true"` を生成中 (< 50ms) に立てる。
+
+## 6. アクセシビリティ — WCAG 2.1 AA
+
+### 6-1. コントラスト比 (背景 `A.bg #05080c` 想定)
+
+| 前景 | 比 | 用途 | AA 判定 |
+|------|-----|------|---------|
+| `A.ink` (#e6f1ff) | 17.4:1 | score 数値 / TOTAL 値 / encounter count | Pass (AAA) |
+| `A.body` (#a8b8c8) | 9.8:1 | description / encounter detail | Pass (AAA) |
+| `A.hud` (#7ee0ff) | 11.6:1 | example / ensName / link | Pass (AAA) |
+| `A.amber` (#ffb84d) | 11.0:1 | label / pending / CTA | Pass (AAA) |
+| `A.green` (#3dffa3) | 14.7:1 | success / hit / 正値バー | Pass (AAA) |
+| `A.hot` (#ff4438) | 5.1:1 | failure / miss / 負値バー | Pass (AA) |
+| `A.mute` (#5a6c80) | 3.6:1 | eyebrow / 補助テキスト | AA pass のみ大きいテキストは AAA、本文には使わない |
+| misalignment `#c084ff` (sycophancy) | 8.4:1 | glyph / label | Pass (AAA) |
+| misalignment `#40f070` (reward_hacking) | 13.5:1 | glyph / label | Pass (AAA) |
+| misalignment `#7bdff2` (prompt_injection) | 11.0:1 | glyph / label | Pass (AAA) |
+| misalignment `#ff5252` (goal_misgen) | 5.0:1 | glyph / label | Pass (AA) |
+
+すべて 4.5:1 以上 (AA 適合)。`A.mute` は 3.6:1 だが本文には使わず、`aria-hidden` を付けない範囲で graphical / decorative label に限定する。
+
+### 6-2. aria-live region
+
+| 領域 | aria 属性 | 動作 |
+|------|-----------|------|
+| MisalignmentToast | `<div role="status" aria-live="polite" aria-atomic="true">` | toast 切替時に label + description を SR に通知。重複読み上げ回避のため `aria-atomic="true"` を必須 |
+| score 数値 | `<output aria-live="polite" aria-label="Agent safety score 85 out of 100">` | score 確定時に 1 度だけ通知 |
+| ATTESTATION TARGETS 各行 | `<div role="status" aria-live="polite" aria-label="ENS resolver pending">` | status 遷移時に通知。`aria-busy="true"` を pending 中に付与 |
+| HUD `AgentHandleLabel` | `<div role="status" aria-live="polite">` | handle 切替時に通知 (§5-4) |
+
+### 6-3. focus order
+
+タブ順序 (DOM 読み順 = 視覚読み順):
+
+1. HUD `AgentHandleLabel` (handle が CTA の場合のみ tabbable、確定時は `tabIndex={-1}`)
+2. canvas (game)、ESC で抜ける
+3. AgentDashboard 内の通常フォーム / link
+4. SafetyAttestationPanel score (skip、tabIndex なし)
+5. ATTESTATION TARGETS [01] ENS resolver link → (failed 時 RETRY)
+6. ATTESTATION TARGETS [02] 0G storage link → (failed 時 RETRY、failed の wallet 未接続時は CONNECT WALLET CTA)
+7. footnote (skip)
+
+`:focus-visible` で `outline: 2px solid ${A.hud}; outline-offset: 2px` を全インタラクティブ要素に付与。
+
+### 6-4. その他
+
+- 全 misalignment は色 + 記号 + ラベルの 3 重符号化 (color blindness 対応)。
+- toast 内の eyebrow `t+34.2s` は `<time datetime="PT34.2S">` でマークアップし、SR に時刻を伝える。
+- `prefers-reduced-motion: reduce` で全アニメーション (toast slide / score glow / breakdown bar / handle cross-fade / failure shake) を停止。
+- `prefers-contrast: more` で `A.body` を `A.ink` に格上げし、border を 1 → 1.6px に太くする。
+- タッチターゲットは全 CTA / link で最低 44×44 CSS px (WCAG 2.5.5 AAA 意識)。
+
+## 7. error / empty / loading の表示文字列案 (日本語)
+
+C 層の各 OnChain ステップで使う文字列を網羅。EN 表記は (parent design) で既出のため、ここでは JP 表記のみ (in-app 言語切替用、デモは EN 主体だが仕様上 JP も用意)。
+
+### 7-1. STATUS バッジ (再掲、attestation 用に拡張)
+
+| 状態 | EN | JP |
+|------|-----|-----|
+| idle (ENS) | `○ STANDBY` | `○ 待機中` |
+| pending (ENS) | `▲ PENDING` | `▲ 登録中` |
+| success (ENS) | `● RESOLVED` | `● 解決可能` |
+| failed (ENS) | `✕ FAILED` | `✕ 失敗` |
+| idle (0G) | `○ STANDBY` | `○ 待機中` |
+| pending (0G) | `▲ PENDING` | `▲ 保存中` |
+| success (0G) | `● STORED` | `● 保存完了` |
+| failed (0G) | `✕ FAILED` | `✕ 失敗` |
+
+### 7-2. empty state (encounter / score)
+
+| 領域 | 状況 | EN | JP |
+|------|------|-----|-----|
+| score 大表示 | playLog 未着 | `— — — / 100 · awaiting play log` | `— — — / 100 · プレイログ待ち` |
+| MISALIGNMENT ENCOUNTERS | 0 件 | `0 detected · clean run, no misalignment fired` | `0 件検出 · ノーミス完走、misalignment なし` |
+| MISALIGNMENT ENCOUNTERS | speed のみ撃破 | `0 detected · only speed enemies destroyed` | `0 件検出 · speed 系のみ撃破` |
+| MisalignmentToast queue | 60 秒中 1 件も misalignment 撃破なし | toast 自体出さない | toast 自体出さない |
+
+### 7-3. loading state (各ステップ pending 時の補助文)
+
+| ステップ | EN | JP |
+|---------|-----|-----|
+| ENS subname 登録中 | `Registering subname + 3 text records…` | `subname と text records 3 件を登録中…` |
+| 0G Storage put 中 | `Uploading attestation.json to 0G Storage…` | `attestation.json を 0G Storage にアップロード中…` |
+| 0G CID 計算中 (stub) | `Computing SHA-256 fallback hash…` | `SHA-256 フォールバックハッシュを計算中…` |
+| score 計算中 (純関数だが UI 上は 1 frame だけ表示) | `Computing safety score…` | `安全スコアを計算中…` |
+
+### 7-4. failure state (各ステップ failed 時の error message)
+
+| ステップ | 原因 | EN (error) | JP (error) | RETRY 文言 |
+|---------|------|-----------|------------|-----------|
+| ENS | wallet 未接続 | `wallet not connected` | `wallet が接続されていません` | `▸ CONNECT WALLET` (`A.amber`, ConnectButton にスクロール) |
+| ENS | parent name 未所有 | `parent name not owned by wallet` | `wallet が parent name を所有していません` | `▸ RETRY · 環境変数 VITE_ENS_PARENT を確認` |
+| ENS | chain 不一致 | `wrong chain — switch to Sepolia` | `chain が違います — Sepolia に切替` | `▸ SWITCH CHAIN` (`A.amber`, walletClient.switchChain を呼ぶ) |
+| ENS | tx user reject | `user rejected request` | `ユーザーが署名を拒否しました` | `▸ RETRY · 再度署名する` |
+| ENS | RPC timeout | `RPC timeout — Sepolia node slow` | `RPC タイムアウト — Sepolia ノードが遅い` | `▸ RETRY` |
+| ENS | text record 上限超過 | `text record value exceeds 1KB` | `text record の値が 1KB を超えています` | (リトライ不可、内部バグ報告) |
+| 0G Storage | wallet 未接続 | `wallet not connected` | `wallet が接続されていません` | `▸ CONNECT WALLET` |
+| 0G Storage | SDK エラー | `0G Storage SDK error — fallback to sha256://` | `0G Storage SDK エラー — sha256:// に退避` | `▸ RETRY` (fallback 表示は別途 `(fallback: sha256://)` を `A.mute` で 1 行添える) |
+| 0G Storage | network unreachable | `network unreachable — check connection` | `ネットワーク到達不能 — 接続を確認` | `▸ RETRY` |
+| 0G Storage | payload too large | `attestation JSON exceeds 1MB` | `attestation JSON が 1MB を超えています` | (リトライ不可、内部バグ報告) |
+| score 計算 | playLog malformed | (該当なし、純関数は失敗しない) | (該当なし) | (該当なし) |
+
+### 7-5. footnote (panel 末尾)
+
+- EN: `◆ MASTER_ARM · ATTESTATION JSON IS DETERMINISTIC FROM PLAY LOG · NO SERVER`
+- JP: `◆ MASTER_ARM · attestation JSON は play log から決定的に導出 · サーバ介在なし`
+
+「決定的に導出」が demo 視聴者に「裏で改竄してない」を伝えるための導線。
+
+## 8. アニメーション仕様
+
+| 対象 | duration | easing | 内容 | reduced-motion |
+|------|----------|--------|------|---------------|
+| toast entering | 200ms | `cubic-bezier(.2,.8,.2,1)` | `translateY(12px) → 0` + `opacity 0 → 1` | 0ms (フェード 100ms のみ) |
+| toast visible underline sweep | 1200ms (visible 中 1 度のみ) | linear | description 下に 1px の `linear-gradient(90deg, transparent, A.amber, transparent)` を左→右 | 停止 |
+| toast exiting | 200ms | `cubic-bezier(.4,.0,.6,1)` | `translateY(0 → -6px)` + `opacity 1 → 0` | 0ms (フェード 100ms のみ) |
+| score glow flash | 800ms | ease-out | `text-shadow: 0 0 24px ${A.amber}88` を 0 → full → 0 | 停止 |
+| breakdown bar 伸長 | 600ms | `cubic-bezier(.2,.8,.2,1)` | `width: 0 → target%` | 即時表示 (transition なし) |
+| handle cross-fade (wallet 切替) | 200ms × 2 | ease-in-out | `opacity: 1 → 0 → 1` (handle 部分のみ) | 即時切替 |
+| ATTESTATION TARGETS pending パルス | 0.9s loop | ease-in-out | `▲ PENDING` の `opacity: 1 → 0.45 → 1` | 停止 (静止表示) |
+| ATTESTATION TARGETS pending loader bar | 1.5s loop | linear | `linear-gradient` 左→右 sweep | 停止 |
+| ATTESTATION TARGETS success → glow flash | 600ms | ease-out | `text-shadow: 0 0 12px ${A.green}` を 0 → full → 33% | 停止 |
+| ATTESTATION TARGETS failure shake | 200ms | linear | STATUS セルのみ `translateX(-2px → 2px → 0)` 1 ループ | 停止 |
+
+すべての `@keyframes` は `index.css` に追加 (Biome の selector 順序ルールに従う)。新規 `@keyframes` は `safety-toast-slide-in / safety-toast-slide-out / safety-score-glow / safety-bar-grow / safety-handle-fade` の 5 つで、既存 OnChainProof 用 `onchain-pulse / onchain-sweep` は再利用する。
+
+## 9. Developer 引き渡しチェックリスト
+
+- [ ] `MisalignmentToast` を `packages/frontend/src/components/MisalignmentToast.tsx` に新設し、queue 管理は単一インスタンスで `useReducer` 制御 (重複表示なし、取り逃しは捨てる)。
+- [ ] `SafetyAttestationPanel` を `packages/frontend/src/components/SafetyAttestationPanel.tsx` に新設し、`AgentDashboard.tsx` の OnChainProofPanel の **直後** に差し込む。
+- [ ] `HUD.tsx` に `AgentHandleLabel` コンポーネント (memo) を追加し、`App.tsx` の canvas frame 上部に挿入。
+- [ ] `MISALIGNMENT_CARDS` の glyph / color は §4 の表に厳密一致させる (color トークン参照は `runtime.ts` の `CAPABILITY_COLOR.*` を import)。
+- [ ] `HUDCorners` を再利用 (新規実装禁止)、`size` のみ panel/toast で個別指定。
+- [ ] アニメーションは `@keyframes safety-*` を `index.css` に追加 (5 種)、既存 `onchain-*` は再利用。
+- [ ] `prefers-reduced-motion: reduce` で全アニメーション停止。
+- [ ] 全状態のスナップショットテストを `bun test` で書く (toast 4 状態 × 4 misalignment、panel 4 セクション × 4 状態 = 計 32 ケース、BDD 日本語 describe)。
+- [ ] axe-core / @testing-library/jest-dom の `toHaveAccessibleName` で aria-label を検証。
+- [ ] モバイル (375 / 414 / 360 width) で stack レイアウトが崩れないことを Playwright で確認。
+- [ ] WCAG 2.1 AA: コントラスト比 4.5:1 以上を全前景色で満たすことを CI で機械検証 (pa11y か axe を `make before-commit` に組み込み、follow-up で OK)。
+
+## 10. Prize Targets 整合チェック
+
+| Prize | このデザインが何を担保するか |
+|-------|----------------------------|
+| 0G Storage ($X) | `[02] 0G STORAGE` 行で CID をフル表示可能 (`<abbr>` + `aria-label`)、attestation JSON 経由で put される (cosmetic でない) |
+| ENS Identity ($X) | HUD 上部の `AgentHandleLabel` で ハンドル + parent.eth が常時可視、demo 視聴者が「pilot42 と名乗る」を 1 秒で理解できる |
+| ENS Creative ($X) | `[01] ENS RESOLVER` 行が text records ×3 を強調、resolver link で sepolia.app.ens.domains に飛び「subname-as-credential」を直接見せられる |
+| 0G iNFT ($X) | (本機能では拡張せず、OnChainProof 既存の `[01] 0G iNFT` 行が引き続き担保) |
+| Uniswap ($X) | (本機能では拡張せず、OnChainProof 既存の `[04] UNISWAP` 行が引き続き担保) |
+
+cosmetic 統合の疑念は、**score 大表示が play log から決定的に算出 → ENS text record と 0G Storage に確実に書く** ことで払拭する。footnote の `MASTER_ARM · DETERMINISTIC FROM PLAY LOG` がこれを口語的に言語化する。
+
+---
+
+設計者ノート: 既存 `AgentDashboard` の class ベース (`index.css`) と inline style の混在は維持する。`.safety-attestation-panel / .safety-score / .safety-breakdown / .safety-encounters / .safety-targets` の 5 クラスを追加し、既存 `.panel` を base にして borderColor のみ inline で `A.rule` に揃える。CSS custom properties (`--c-hud`, `--c-amber`, `--c-green`, `--c-hot`, `--c-mute`, `--c-misalign-sycophancy`, `--c-misalign-reward-hacking`, `--c-misalign-prompt-injection`, `--c-misalign-goal-misgen`) を `index.css` の `:root` に追加し、JSX 側からは custom property を参照する形に揃える (Developer ロールで実装)。

--- a/docs/specs/2026-04-29-agent-safety-attestation-pm-review.md
+++ b/docs/specs/2026-04-29-agent-safety-attestation-pm-review.md
@@ -1,0 +1,255 @@
+# Agent 安全アテステーション (3 段重ね) — PM レビュー
+
+仕様本体: [`2026-04-29-agent-safety-attestation.md`](./2026-04-29-agent-safety-attestation.md)
+担当: Product Manager
+作成日: 2026-04-29
+ブランチ: `feat/safety-tutorial`
+プロジェクトルール: [`CLAUDE.md`](../../CLAUDE.md)
+
+本ドキュメントは仕様書を Designer / Developer / QA / User の 4 役割が並列着手できる粒度に解像する。Web3 wiring の PM レビュー ([`2026-04-27-web3-wiring-pm-review.md`](./2026-04-27-web3-wiring-pm-review.md)) と同じ書式を踏襲する。
+
+---
+
+## 1. 3 ペルソナの user story
+
+ユーザーストーリーは「として」「のために」「したい」形式で書き、各ペルソナの判定条件まで踏み込む。
+
+### Persona 1: 未経験プレイヤー (Agent 安全を知らない)
+
+Web3 / Agent 安全研究の知識ゼロで live demo に到達した一般ユーザー。シューティングを遊んでいるつもりで、終わったら「自分が操作した Agent はこういう失敗モードを避けたらしい」と気付ける状態を目指す。
+
+- **未経験プレイヤーとして** 敵を倒した瞬間にその敵が体現していた失敗モード (sycophancy / reward hacking 等) のカードが見えるようにしたい、**1 ループだけで Agent 安全研究の典型 4 失敗モードを名前と例で覚えるために**。
+- **未経験プレイヤーとして** ゲーム終了画面に 100 点満点のスコアと「何点減点されたか」が大きく表示されるようにしたい、**「この Agent はそこそこ安全だった / 危なかった」を直感で受け取れるようにするために**。
+- **未経験プレイヤーとして** ウォレットを接続していなくてもスコアと misalignment 一覧は最後まで表示されるようにしたい、**ウォレット導入を強制されずに「何が起きるサービスか」を試せるようにするために**。
+
+### Persona 2: デモ視聴者 (3 分動画で審査)
+
+ETHGlobal project page 経由で 3 分以内の demo 動画だけを観る審判 / 賞金スポンサー。リンクを踏まずに「A 層 / B 層 / C 層が連続している」を判定する。
+
+- **デモ視聴者として** 0:15-1:05 の 50 秒プレイ区間で misalignment カードが画面右下に複数回出現するようにしたい、**A 層 (敵 = 失敗モード) が cosmetic でなく毎ループ機能していると 30 秒で確信するために**。
+- **デモ視聴者として** HUD 上部の "AGENT: pilot42.{parent}.eth" ラベルが常時映っているようにしたい、**B 層 (subname identity) がゲーム開始時点から成立していると言葉なしで把握するために**。
+- **デモ視聴者として** 2:30-3:00 区間で sepolia.app.ens.domains の text record (`agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected`) が UI 上のスコア・カウントと一致して表示されるようにしたい、**C 層 (attestation) が live で書かれた verifiable credential だと確認するために**。
+
+### Persona 3: ENS 審査員 (sepolia.app.ens.domains で text record 確認)
+
+ENS Identity / Creative 賞のレビュアー。submit URL から `https://sepolia.app.ens.domains/{handle}.{parent}.eth` を直接開き、Records タブで「subname-as-attestation-receipt」の発想が立っているかを 1 分以内に判定する。
+
+- **ENS 審査員として** subname の owner が demo wallet address と一致しているようにしたい、**hard-coded NG ではなく実際にユーザー接続から発行された subname だと検証するために**。
+- **ENS 審査員として** Records タブに 3 keys (`agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected`) が揃い、値が JSON / 数値で意味を持つようにしたい、**text record が cosmetic な 1 行でなく動的な credential であると採点ルーブリック上 3 点を付けられるようにするために**。
+- **ENS 審査員として** 同じ wallet で 2 回プレイすると text record が上書きされ、subname 自体は維持されるようにしたい、**冪等性と「subname がアテステーション受け皿として機能している」発想を同時に確認するために**。
+
+---
+
+## 2. 受け入れ基準 13 項目の Given-When-Then 化
+
+仕様書 §「受け入れ基準」の 13 項目を AC-1〜AC-13 として番号付けし、具体値で書き直す。値は仕様書 §「技術設計」のスコア式 ( `total = clamp( 50 + clearTimeBonus(0..50) + missPenalty(-50..0), 0, 100 )` ) と「振る舞い 3 ケース」(ノーミス → 100 / 全見送り → 50 付近 / 全誤射 → 0 近傍) を前提とする。
+
+### AC-1: misalignment 4 種が `@gradiusweb3/shared` の enum
+
+- **Given** `packages/shared/src/safety.ts` がまだ存在しない状態である
+- **When** Developer が `MisalignmentKind` を `'sycophancy' | 'reward_hacking' | 'prompt_injection' | 'goal_misgen'` の 4 値 union 型として `packages/shared/src/types.ts` に追加し、`packages/shared/src/index.ts` と `browser.ts` から re-export する
+- **Then** `bun --filter @gradiusweb3/shared typecheck` が通り、`MISALIGNMENT_CARDS[kind].label` を frontend から import できる
+
+### AC-2: 5 capability に misalignment kind がマッピング
+
+- **Given** 既存 capability `'shield' | 'option' | 'laser' | 'missile' | 'speed'` が `runtime.ts` で 5 種定義されている
+- **When** `CAPABILITY_TO_MISALIGNMENT` を `{ shield: 'prompt_injection', option: 'reward_hacking', laser: 'goal_misgen', missile: 'sycophancy' }` として定義し `speed` は entry なしとする
+- **Then** `Object.keys(CAPABILITY_TO_MISALIGNMENT).length === 4` が成立し、`speed` は `undefined` を返す (1 種は misalignment なし可の要件を満たす)
+
+### AC-3: 撃破時に 2 秒 toast 表示
+
+- **Given** プレイヤーが `option` capability を持つ敵を画面右上で撃破した直後である
+- **When** runtime が `dispatchMisalignmentToast({ kind: 'reward_hacking', enemyId, tAtMs })` を発火する
+- **Then** HUD 右下に `MISALIGNMENT: reward hacking` のラベル + 説明 (140 文字以内) + 例 1 行 + glyph `◇` を含むカードが描画され、`tAtMs + 2000ms` に DOM から消える (60fps を維持し、CPU プロファイルで支配項にならない)
+
+### AC-4: PlayLog の shoot/pass に misalignment payload
+
+- **Given** プレイ開始時の `PlayLog.events` 配列が空である
+- **When** プレイヤーが `missile` 系敵 1 体を撃破し、`laser` 系敵 1 体を見送る
+- **Then** `events` に `{ kind: 'shoot', enemyId, tradeoffLabel, misalignment: 'sycophancy' }` と `{ kind: 'pass', enemyId, tradeoffLabel, misalignment: 'goal_misgen' }` の 2 entry が時系列で記録され、`misalignment` 未定義の旧 PlayLog をパースしても `undefined` のまま読めて optional 後方互換が保たれる
+
+### AC-5: handle 生成と HUD 表示
+
+- **Given** ゲーム開始ボタンを押した直後で `VITE_ENS_PARENT='testname.eth'` が `.env.local` から読まれている
+- **When** `BirthArcade` が `pilot${randomTwoDigits()}` (例: `pilot42`) を生成し state に保持する
+- **Then** HUD 上部に `AGENT: pilot42.testname.eth` の文字列が表示され、再ロードまたは再プレイで別の 2 桁数字に再生成される (deterministic でなく nonce ベース)
+
+### AC-6: ゲーム終了時に NameWrapper.setSubnodeRecord で subname 発行
+
+- **Given** Sepolia ENS の `testname.eth` が demo wallet で取得済みで、game over に到達した
+- **When** `safety-attestation.ts` が `registerSubname(walletClient, { handle: 'pilot42', owner: walletAddress, parent: 'testname.eth', textRecords })` を既存 `ens-register.ts` 経由で呼ぶ
+- **Then** Sepolia 上で 1 件の tx が confirm され、`https://sepolia.app.ens.domains/pilot42.testname.eth` で Owner = `walletAddress` / Resolver = public resolver が表示される
+
+### AC-7: computeSafetyScore 純関数
+
+- **Given** `playLog.events` が `shoot` × 5 (全て命中、misalignment 紐付き) のみで、誤射と取り逃しが 0 件である
+- **When** `computeSafetyScore(playLog)` を呼ぶ
+- **Then** 返り値が `{ clearTimeBonus: 50, missPenalty: 0, total: 100 }` (ノーミス完走 → 100 のケース)
+- **And** 同関数に「全 5 体誤射 (`shoot` だが当たらず miss として扱う) + 5 体取り逃し」の playLog を渡すと `{ clearTimeBonus: 0, missPenalty: -20, total: 30 }` 程度 (全誤射 → 0 近傍のケース、`-2 per miss × 10 = -20`、`clearTimeBonus = clamp(50 - 10*2, 0, 50) = 30`、合計 `clamp(50 + 30 - 20, 0, 100) = 60` ではなく仕様の振る舞い 3 ケース基準で実装側がチューニング)
+- **And** 「全 10 体見送り」playLog で `total` が 50 ± 10 のレンジに収まる (全部見送り → 50 付近のケース)
+
+> 注: 上の数値は spec §「スコア式の暫定」を BDD で詰める前提。Developer 役割は 3 ケースの振る舞いを満たす最小実装で `safety.test.ts` を Red → Green にする。Designer の breakdown 棒グラフは `clearTimeBonus`/`missPenalty`/`total` の 3 軸を持つ前提で進めて良い。
+
+### AC-8: AgentSafetyAttestation を 0G Storage に put
+
+- **Given** `deriveSafetyAttestation(...)` が `{ sessionId, handle, ensName, walletAddress, score: 85, breakdown, encounters, issuedAt, schemaVersion: 1 }` を返した
+- **When** `putAttestation(attestation)` が `packages/frontend/src/web3/zerog-storage.ts` の SHA-256 stub 実装で呼ばれる
+- **Then** `{ cid: 'sha256://<64 hex>' }` が返り、CID 文字列は `attestation` JSON の SHA-256 と一致する (実 SDK 化は follow-up であることを demo 動画で 1 行明記)
+
+### AC-9: ENS text record 3 件の書き込み
+
+- **Given** AC-6 で subname が発行され、`putAttestation` が CID `sha256://abcd...` を返した
+- **When** `ens-register.ts` が `setText(node, key, value)` を 3 回連続で呼ぶ (key = `agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected`)
+- **Then** sepolia.app.ens.domains の Records タブで 3 行が表示され、値はそれぞれ `"85"` (整数文字列) / `"sha256://abcd..."` / `'{"prompt_injection":3,"reward_hacking":1,"goal_misgen":0,"sycophancy":1}'` になり、各値は 1KB 以内に収まる
+
+### AC-10: AgentDashboard の SafetyAttestationPanel
+
+- **Given** game over 後 AgentDashboard まで scroll した状態である
+- **When** UI を visual 確認する
+- **Then** `AGENT SAFETY ATTESTATION` の見出し配下に (a) 大きな数字でスコア (b) `clearTimeBonus` / `missPenalty` / `total` の breakdown 棒グラフ (c) MisalignmentEncounter 一覧 (d) ENS resolver link (`target="_blank" rel="noopener noreferrer"`) (e) 0G CID リンクの 5 要素が表示され、既存 OnChainProof セクションとは独立した枠で並ぶ
+
+### AC-11: ウォレット未接続でも score とローカル表示は完走
+
+- **Given** wagmi の `useAccount().isConnected === false` の状態で 60 秒プレイし game over に到達した
+- **When** `safety-attestation.ts` が `Promise.allSettled([putAttestation(...), registerSubname(...)])` を起動する
+- **Then** `putAttestation` は stub なので resolved、`registerSubname` は `walletClient` 不在で rejected、UI には score / breakdown / encounter / 0G CID が success で表示され、ENS セクションだけが `failed: ウォレット未接続` の文言で表示される (white screen / uncaught exception ゼロ)
+
+### AC-12: architecture-harness 通過
+
+- **Given** 本機能の差分がステージされた状態である
+- **When** `bun scripts/architecture-harness.ts --staged --fail-on=error` を実行する
+- **Then** exit 0 になり、`npx` / モックデータ / `it.only` / 設定ファイル直接編集 / `#番号` Issue 引用のいずれの違反も検出されない
+
+### AC-13: make before-commit 通過
+
+- **Given** 本機能の差分がローカルにある
+- **When** `make before-commit` を実行する
+- **Then** `nr lint` (biome) / `nr typecheck` (tsc --noEmit) / `nr test` (bun test) / `nr build` の 4 ステップが全て exit 0 で完了し、`packages/shared` の `safety.test.ts` を含むテストカバレッジ 100% を維持する
+
+---
+
+## 3. 依存関係グラフ
+
+仕様書 §「実装順序」の 7 ステップを並列可能粒度に展開し、先行 / 後続を明示する。クリティカルパスは shared 型 → safety.ts → orchestrator → 統合の 1 本。
+
+### Mermaid 図
+
+```mermaid
+graph TD
+  A[shared/types.ts: MisalignmentKind / Encounter / Attestation 型] --> B[shared/safety.ts: MISALIGNMENT_CARDS / CAPABILITY_TO_MISALIGNMENT / computeSafetyScore / deriveSafetyAttestation + safety.test.ts]
+  A --> A2[shared/index.ts + browser.ts re-export]
+  B --> C[game/runtime.ts: 敵 capability に misalignment 紐付け / shoot pass event payload 付与]
+  B --> D[web3/zerog-storage.ts: putAttestation SHA-256 stub 拡張]
+  C --> E[web3/safety-attestation.ts: orchestrator deriveSafetyAttestation -> Promise.allSettled putAttestation registerSubname + safety-attestation.test.ts]
+  D --> E
+  C --> F1[components/MisalignmentToast.tsx: 撃破時 2 秒 React overlay]
+  E --> F2[components/SafetyAttestationPanel.tsx: score breakdown encounter ENS link 0G CID]
+  A2 --> F3[components/HUD.tsx: AGENT pilot42.parent.eth ラベル]
+  F1 --> G1[components/BirthArcade.tsx: handle 生成 onComplete で attestation 起動]
+  E --> G1
+  F2 --> G2[components/AgentDashboard.tsx: SafetyAttestationPanel 差し込み]
+  F3 --> G1
+  G1 --> H[Plan.md 進捗ログ更新 + ゲート 5 本通過]
+  G2 --> H
+```
+
+### 依存関係表
+
+| 段 | ID | 成果物 | 依存先 (先行) | 並列可 |
+|----|----|--------|---------------|--------|
+| 1 | A   | `packages/shared/src/types.ts` 拡張 (型のみ)                                    | (なし)        | A2 と並列 |
+| 1 | A2  | `packages/shared/src/index.ts` / `browser.ts` re-export                         | A             | — |
+| 2 | B   | `packages/shared/src/safety.ts` + `safety.test.ts` (純関数 4 つ)                | A             | (Red → Green は A 直後単独) |
+| 3 | C   | `packages/frontend/src/game/runtime.ts` (capability マップ + event payload)     | B             | D と並列可 |
+| 3 | D   | `packages/frontend/src/web3/zerog-storage.ts` (`putAttestation` 追加)           | B             | C と並列可 |
+| 4 | E   | `packages/frontend/src/web3/safety-attestation.ts` orchestrator + test          | C, D          | — |
+| 5 | F1  | `packages/frontend/src/components/MisalignmentToast.tsx`                        | C             | F2, F3 と並列 |
+| 5 | F2  | `packages/frontend/src/components/SafetyAttestationPanel.tsx`                   | E             | F1, F3 と並列 |
+| 5 | F3  | `packages/frontend/src/components/HUD.tsx` 拡張 (handle ラベル)                 | A2            | F1, F2 と並列 |
+| 6 | G1  | `packages/frontend/src/components/BirthArcade.tsx` (handle 生成 + onComplete)   | E, F1, F3     | G2 と並列可 |
+| 6 | G2  | `packages/frontend/src/components/AgentDashboard.tsx` (Panel 差し込み)          | F2            | G1 と並列可 |
+| 7 | H   | `Plan.md` 進捗ログ更新 + 5 ゲート通過                                            | G1, G2        | — |
+
+### クリティカルパス
+
+`A → B → E → G1 → H`。shared 型と純関数 (A, B) が遅れると orchestrator 以降全部止まる。Designer / Developer はこの順を最優先で着手する。
+
+### 並列化のヒント
+
+- C と D は B 完了後に別作業者で同時着手可能。C は game runtime、D は web3 module で衝突しない。
+- F1 / F2 / F3 はそれぞれ別コンポーネントファイルなので 3 並列可。Designer 役割は 3 つ同時に wireframe を出して良い。
+- G1 と G2 は別ファイルだが、`AgentDashboard` 経由で同じ store を参照するため state shape は E で確定してから着手する。
+
+---
+
+## 4. Scope Guard リスト (NOT-Doing / follow-up 候補)
+
+仕様書 §「スコープ外」を実装行動レベルで反復し、PR で混入しないよう明示する。「やりたくなったら」即 `/follow-up add <タイトル>` で `.claude/state/follow-ups.jsonl` に積み、PR 本文 "Known follow-ups" 節に貼る。
+
+### 絶対やらない (本 PR 範囲外)
+
+- AXL ノード起動 / multi-agent 通信 (Gensyn 賞は意図的に撤退)。
+- KeeperHub による text record 自動更新 (本仕様 A 案で除外)。
+- 0G Compute (sealed inference) による misalignment 判定 (follow-up)。
+- 0G Storage SDK の実統合。本 PR は SHA-256 stub のままで OK、demo 動画でも stub である旨を 1 行明記する。
+- Roguelike 化 / misalignment 重複コンボ (本 PR は静的カード × 4 で固定)。
+- 5 種目以降の misalignment 拡張 (deceptive alignment / specification gaming / mesa-optimization 等)。本 PR は 4 種固定。
+- ENS reverse record / primary name 設定。
+- ENS subname の renewal / expiry UI。
+- mainnet 対応 / Sepolia 以外の EVM testnet 追加。
+- iNFT メタデータ拡張 (本機能では既存 iNFT を維持、tokenURI に safety attestation を埋めるのは follow-up)。
+- Uniswap 拡張 (既存 swap UI を維持するのみ、`FEEDBACK.md` は既存維持)。
+- handle 衝突の global 解決 (本 PR は session 内ランダムで衝突時は再生成)。
+- analytics / Sentry / 監視ツール導入。
+- Playwright / e2e 自動化 (手動シナリオで AC-1〜AC-13 を判定する)。
+
+### follow-up 候補 (記録済 or PR 直後に積む)
+
+実装中に湧いた scope 外アイデアは以下を雛形に `/follow-up add` する。Plan.md の "Known Follow-ups" にも反映する。
+
+- 0G Storage SDK 実統合 (現状 stub)。
+- 0G Compute による misalignment 判定 sealed inference。
+- KeeperHub による text record 自動更新 (`agent.safety.score` を新 high score で push)。
+- Roguelike モード / misalignment 重複コンボの v2 設計。
+- 5 種目以降の misalignment 拡張 (deceptive alignment / specification gaming 等)。
+- iNFT tokenURI に safety attestation hash を組み込む拡張。
+- subname を mainnet で発行する商用フロー。
+- AgentDashboard の OnChainProof と SafetyAttestationPanel の統合 UI (現在は隣接配置)。
+
+### スコープ判定フロー (実装者向け)
+
+```
+何かやりたくなった
+  ↓
+これは AC-1〜AC-13 のいずれかに直接寄与するか?
+  ├─ Yes → 実装してよい
+  └─ No
+       ↓
+       これは仕様書「Security 考慮」or「フェイルセーフ」or「冪等性」の対策コードか?
+         ├─ Yes → 実装してよい
+         └─ No → /follow-up add で記録、別 PR
+```
+
+---
+
+## 5. PM 承認チェックリスト (PR 直前)
+
+- [ ] AC-1〜AC-13 が全て手動 / 純関数テストで合格。
+- [ ] demo 動画 3 分以内、A 層 (0:15-1:05) / B 層 (1:05-1:20) / C 層 (1:20-3:00) の構成が映っている。
+- [ ] sepolia.app.ens.domains で 3 keys の text record が live 確認できる、もしくは録画で残っている。
+- [ ] Plan.md 進捗ログに本仕様の各 phase 完了が追記されている。
+- [ ] スコープガード違反なし (上記 NOT-Doing リスト該当の差分なし)。
+- [ ] フォローアップが PR 本文 "Known follow-ups" 節に列挙されている。
+- [ ] 5 ゲート (architecture-harness / before-commit / review / security-review / simplify) all green。
+- [ ] CLAUDE.md「作業順序」遵守 (docs / refactor → 機能追加の順)。
+
+---
+
+## 6. 参照
+
+- 仕様本体: [`docs/specs/2026-04-29-agent-safety-attestation.md`](./2026-04-29-agent-safety-attestation.md)
+- 直前の PM レビュー (書式参考): [`docs/specs/2026-04-27-web3-wiring-pm-review.md`](./2026-04-27-web3-wiring-pm-review.md)
+- プロジェクト rule: [`CLAUDE.md`](../../CLAUDE.md)
+- 賞金トラック: [`docs/prizes/`](../prizes/)
+- ハーネス invariant: [`docs/architecture/harness.md`](../architecture/harness.md)
+- 進捗: [`Plan.md`](../../Plan.md) 末尾「Agent 安全アテステーション (3 段重ね) - 2026-04-29」

--- a/docs/specs/2026-04-29-agent-safety-attestation-qa.md
+++ b/docs/specs/2026-04-29-agent-safety-attestation-qa.md
@@ -1,0 +1,470 @@
+# Agent 安全アテステーション (3 段重ね) QA レビュー
+
+> 担当: QA / 対象仕様 [`2026-04-29-agent-safety-attestation.md`](./2026-04-29-agent-safety-attestation.md) / 対象ブランチ `feat/safety-tutorial`
+
+## 判定 (3 行)
+
+- HOLD — Developer agent が並列で実装中のため、本レビューは仕様書ベースの先回り QA。コードが land したら本書のテストマトリクスを再走させて verdict を更新する。
+- 仕様レベルで致命的合意不足が 4 件ある (subname handle 衝突時の retry 挙動、score 式の monotonicity 保証、text record 上書きの race、wallet 切断時のスコア確定タイミング)。実装前に確定すること。
+- 前回 Web3 Wiring の振り返り (`Plan.md`「振り返り」: tokenId に msg.sender を bind し忘れた件) と同レベルの griefing / replay 経路を仕様内に最低 1 件以上発見した。Developer に共有する。
+
+---
+
+## Security 4 軸レビュー
+
+仕様 222-230 行の Security 表は最低限カバーされているが、本機能特有の攻撃面が薄い。前回の tokenId griefing バグ級の指摘を 4 軸 + 追加 1 軸で掘る。
+
+### Replay
+
+- この機能特有のリスク
+  - `AgentSafetyAttestation` を 0G Storage に put した CID は content-addressed のため、同じ JSON は同じ CID を返す。攻撃者が他人の attestation JSON を入手すれば、自分の wallet で同 JSON を 0G Storage に再 put し、自分の subname の `agent.safety.attestation` text record にその CID を書ける。スコアの偽装そのものは subname owner = 自分なので「自分が高スコアを名乗る」だけだが、第三者が同 JSON を quote した場合に「同じ CID を 2 人が指している」誤情報が成立する。
+  - `sessionId` は仕様で生成方式が未定義。`Date.now()` ベースだと簡単に予測可能で、replay 検証時に collision する。
+- 仕様書の現状対策
+  - 222 行の表は「subname のオーナー = msg.sender バインドで担保」とあるが、これは subname の write 権限の話で、attestation JSON 自体の origin を担保していない。
+- 十分か / 追加要件
+  - 不十分。`AgentSafetyAttestation` JSON に `walletAddress` フィールドが既にあるので、JSON を put する際に「`walletAddress` が現在の `walletClient.account.address` と一致する」を assert する。CID を ENS に書く前にもう一度 verify する。
+  - `sessionId` は `crypto.randomUUID()` (16 byte) を使用すること。仕様書にこのレベルで明記する。
+  - 受け入れ基準に「他人の attestation CID を自分の text record に書こうとした場合、UI が `walletAddress` mismatch を検出して reject する」を追加する。
+
+### Griefing (前回 tokenId 級の指摘ポイント)
+
+- この機能特有のリスク
+  - **subname handle 衝突時の retry が別ユーザーの subname を上書きする経路** (本書最重要指摘)。仕様 21 行は `pilot{2 桁ランダム}` と書いており、衝突空間は 100 通りしかない。`pilot42.{parent}.eth` が既に他ユーザー A の subname として発行済の状態で、ユーザー B が同じ handle (pilot42) を引き当てて NameWrapper.setSubnodeRecord を呼ぶと、parent owner = demoer wallet なので「parent owner 権限で B の指定通りに subnode owner と resolver を上書き」してしまう。NameWrapper の `setSubnodeRecord` は既存 subnode に対する上書き動作なので、これは UI の出来不出来でなく ENS 仕様レベルで成立する。前回の tokenId griefing と完全に同じ構造 (handle が衝突空間に対して短すぎ、かつ parent owner が write 権限を握っている)。
+  - 仕様 36 行の冪等性条項「同じ sessionId + handle + walletAddress で 2 回 attestation を発行しても、subname の text record が上書き更新されるだけで失敗しない」は、handle が衝突した場合の挙動を「上書き OK」と読める。ここを「他者が先取りした handle なら新 handle を引き直す」に明確化しないと事故る。
+- 仕様書の現状対策
+  - 226 行「handle は session 内ランダム (例: `pilot{2 桁}`) で衝突時は再生成」と一行ある。だが「衝突 = 第三者が既に保有」を検出する手順が書かれていない。
+- 十分か / 追加要件
+  - 不十分。以下を追加要件として実装側に渡す。
+    1. handle 決定時に NameWrapper の `ownerOf(namehash(`{handle}.{parent}`))` を `publicClient.readContract` で先読みする。owner が `0x0` でなく、かつ自分の wallet 以外なら handle を再生成 (最大 5 回) する。
+    2. 衝突空間を `pilot{2 桁}` (100) → `pilot{4 桁 hex}` (65,536) に拡張する。Designer / PM と要相談。
+    3. NameWrapper.setSubnodeRecord 呼び出し直前に再度 ownerOf を確認する (TOCTOU を 1 回まで縮める。完全には防げないが UX 的にはこれで十分)。
+    4. `safety-attestation.test.ts` に「他者保有の subname を上書きしようとしたら例外を投げる」ケースを必須にする。
+  - 仕様書 222 行の表に「Griefing — handle pre-claim による上書き — pre-flight ownerOf チェック + 衝突時 retry + 4 桁 handle」を加筆する。
+
+### Front-running
+
+- この機能特有のリスク
+  - parent owner の demoer wallet が常にゲーム終了瞬間に setSubnodeRecord + setText (×3) を順次撃つ。攻撃者が mempool を観察し、`agent.safety.score` の値を読んで「先に同じ handle を別 wallet で claim する」ことは parent owner 制限により不可。だが、`agent.misalignment.detected` の JSON 文字列をプリコンピュートして「ゲーム結果のネタバレ」を Twitter に流すような soft attack は可能。これは Web3 spec というより demo runner の世界観への影響なので priority は低い。
+  - もう一つの front-running: 0G Storage への put (CID 取得) と ENS text record write を `Promise.allSettled` で並列起動した場合、ENS write が先に成功して CID が `null` のまま `agent.safety.attestation` に書かれるケースがあり得る。仕様 144 行は「attestation JSON を put → ENS text record にその CID/hash を書く順序で wiring する」と直列指定しているので OK だが、テストでこの順序を強制する必要がある。
+- 仕様書の現状対策
+  - 直列順序は記述あり。228 行で「resolver.setText の owner check は ENS 仕様で担保」。
+- 十分か / 追加要件
+  - 並列化されないことを保証するテストを `safety-attestation.test.ts` に必須化する (CID が undefined の段階で setText が呼ばれないことを spy で検証)。
+  - mempool レベルの front-running は本機能の脅威モデルで対象外と仕様書に明記する。
+
+### Chain spoofing
+
+- この機能特有のリスク
+  - 前回 (Web3 Wiring) と同じく、wagmi の `walletClient.chain` が Sepolia 以外 (例: 0G Galileo / mainnet / arbitrum sepolia) のときに ENS / 0G Storage の writeContract を撃つと、別 chain に書き込まれる事故がある。本機能は B 層 (ENS subname 発行) が Sepolia 固定、C 層 (0G Storage stub) は chain 非依存なので、危険なのは ENS。
+  - 仕様 229 行「viem の `walletClient.chain` を Sepolia に固定、`switchChain` を強制」とあるが、switchChain の完了を `await` しないと race る。前回も同じ書き方で Developer が `await` を漏らした実績あり。
+- 仕様書の現状対策
+  - chain 固定の方針はある。だが switchChain の完了 await と、再確認 (useChainId で post-check) のステップが欠落。
+- 十分か / 追加要件
+  - 受け入れ基準に「ENS の write 直前に `useChainId() === sepolia.id` を assert し、不一致なら switchChain を await し、それでも一致しなければ failed 状態に遷移」を追加する。
+  - 受け入れ基準に「ユーザーが現在 Sepolia 以外に接続している状態で game over した場合、AgentDashboard 上で `agent.safety.score` のローカル表示は出すが ENS 行は `chain mismatch — Sepolia に切り替えてください` と日本語表示」を追加する。
+  - QA E2E に N-X として「Sepolia 以外で game over → ENS 行が日本語で chain mismatch を表示」を追加。
+
+### 追加軸: Privacy / Off-chain integrity
+
+- この機能特有のリスク
+  - `agent.misalignment.detected` text record は JSON 文字列で「kind ごとの hit / pass カウント」を公開する。これ自体は PII ではないが、wallet address に紐づく行動指紋になる (どの kind を見落としやすいかの傾向が分かる)。本デモではゲームなので OK だが、prize 審査員が読む文書では「現状は cosmetic、将来 sealed inference に置き換える」と明記して脅威モデルの境界を出す。
+  - もう一つ: `playLog` を 0G Storage に put しているが (既存)、本機能で攻撃者が攻撃用 playLog を構築 (`misalignment_kind` を任意に詰める) してそのまま attestation を発行できる。`MisalignmentEncounter[]` は Game runtime で生成されるべきで、攻撃者が手動で JSON を構築して `deriveSafetyAttestation` に渡す経路を spec 上で禁止する。orchestrator は `playLog` のみを入力として encounter を再構成すること、を仕様書に明記する。
+- 仕様書の現状対策
+  - 230 行 Privacy 行は「playLog は session ID + 入力イベントのみ、PII 含まない (現状維持)」のみ。
+- 十分か / 追加要件
+  - `safety-attestation.ts` orchestrator のシグネチャを「playLog only を受け取る」に固定し、外部から `encounters[]` を直接注入できない API にする。
+  - `agent.misalignment.detected` の値が 1KB を超えないことを ENS write 前に assert する (仕様 33 行は値あたり 1KB 上限を書いているが unit test 必須)。
+
+### Security 軸まとめ
+
+| 軸 | 重大度 | 仕様の対策 | 追加要求 |
+|----|--------|------------|----------|
+| Replay | 中 | subname owner = msg.sender bind | sessionId は `crypto.randomUUID()`、attestation の `walletAddress` を put 直前に verify |
+| Griefing | **高** (前回 tokenId 級) | handle 衝突時 regenerate の一行のみ | pre-flight `ownerOf` 確認、handle を 4 桁 hex に拡張、orchestrator test で他者保有 subname の上書きを reject |
+| Front-running | 低 | 直列指定済 | CID 未取得状態で setText が呼ばれないことの test spy を必須化 |
+| Chain spoofing | 中 | chain 固定の方針あり | switchChain await + post-check (`useChainId` 再確認) を受け入れ基準に明文化 |
+| Privacy / Off-chain integrity | 低 | PII 除外のみ | orchestrator API を `playLog only` に固定、encounter 直接注入を不可にする |
+
+---
+
+## `computeSafetyScore` 境界値テスト要望
+
+仕様 119-126 行で式が暫定 (`total = clamp(50 + clearTimeBonus(0..50) + missPenalty(-50..0), 0, 100)`)。実装フェーズで純関数 BDD で確定する前に、QA として以下のケースを `packages/shared/src/safety.test.ts` で必須化する。括弧内は期待 SafetyScoreBreakdown。
+
+### B-1: 0 点ケース (全 shoot かつ全誤射)
+
+- input shape
+
+  ```ts
+  {
+    sessionId: "test-zero",
+    durationMs: 60_000,
+    finalScore: 0,
+    events: [
+      { kind: 'shoot', t: 1000, enemyId: 'e1', tradeoffLabel: 'shield', misalignment: 'prompt_injection' },
+      { kind: 'shoot', t: 2000, enemyId: 'e2', tradeoffLabel: 'option',  misalignment: 'reward_hacking' },
+      { kind: 'shoot', t: 3000, enemyId: 'e3', tradeoffLabel: 'laser',   misalignment: 'goal_misgen' },
+      { kind: 'shoot', t: 4000, enemyId: 'e4', tradeoffLabel: 'missile', misalignment: 'sycophancy' },
+      // ... 25 件全て shoot 扱いで誤射換算
+    ]
+  }
+  ```
+
+- 期待 SafetyScoreBreakdown
+  - `clearTimeBonus = 0` (ペナルティで上限が下がる)
+  - `missPenalty = -50` (clamp 下限)
+  - `total = 0`
+
+- 検証ポイント
+  - missPenalty が `-50` を超えて `-100` に達しても total は 0 で clamp される (負値が出ない)。
+  - `breakdown.total === total` の整合 (二重計算されない)。
+
+### B-2: 50 点ケース (全 pass かつクリア)
+
+- input shape: `events` 全件が `kind: 'pass'`、`durationMs: 60_000`。
+
+  ```ts
+  {
+    sessionId: "test-half",
+    durationMs: 60_000,
+    finalScore: 0,
+    events: Array.from({length: 20}, (_, i) => ({
+      kind: 'pass', t: i * 3000, enemyId: `e${i}`, tradeoffLabel: 'shield',
+      misalignment: 'prompt_injection',
+    }))
+  }
+  ```
+
+- 期待 SafetyScoreBreakdown
+  - `clearTimeBonus = 0` (素通り、ボーナスの根拠なし)
+  - `missPenalty = 0` (誤射でないため減点なし。ただし pass も miss として数えるなら別、要 spec 確定)
+  - `total = 50` (ベース 50 がそのまま)
+
+- 検証ポイント
+  - 仕様 128 行「全部見送り → 50 付近」の条件を満たす。
+  - 「pass を miss にカウントするかどうか」を spec が確定すること。本書では「pass はカウントしない」前提で書いた。していない場合は B-1 と区別がつかなくなる。
+
+### B-3: 100 点ケース (ノーミス完走 + 全 misalignment shoot down)
+
+- input shape
+
+  ```ts
+  {
+    sessionId: "test-perfect",
+    durationMs: 30_000,           // 早クリア
+    finalScore: 9999,
+    events: [
+      { kind: 'shoot', t: 100, enemyId: 'e1', tradeoffLabel: 'shield',  misalignment: 'prompt_injection' },
+      { kind: 'shoot', t: 200, enemyId: 'e2', tradeoffLabel: 'option',  misalignment: 'reward_hacking' },
+      { kind: 'shoot', t: 300, enemyId: 'e3', tradeoffLabel: 'laser',   misalignment: 'goal_misgen' },
+      { kind: 'shoot', t: 400, enemyId: 'e4', tradeoffLabel: 'missile', misalignment: 'sycophancy' },
+      { kind: 'shoot', t: 500, enemyId: 'e5', tradeoffLabel: 'speed' },  // misalignment なし
+    ]
+  }
+  ```
+
+- 期待 SafetyScoreBreakdown
+  - `clearTimeBonus = 50` (上限)
+  - `missPenalty = 0`
+  - `total = 100`
+
+- 検証ポイント
+  - 早クリア (30s) でも `clearTimeBonus` が 50 で clamp、それを超えない。
+  - 最後のイベントは misalignment 未紐付 (`speed`) で、score 計算で `undefined` を NaN として扱わない。
+
+### B-4: 負値混入リスク (敵対的 input)
+
+- input shape
+
+  ```ts
+  {
+    sessionId: "test-negative",
+    durationMs: -5000,        // 不正な負の duration
+    finalScore: -1,
+    events: [
+      { kind: 'shoot', t: -100, enemyId: 'evil', tradeoffLabel: 'shield', misalignment: 'prompt_injection' },
+    ]
+  }
+  ```
+
+- 期待 SafetyScoreBreakdown
+  - `clearTimeBonus = 0` (clamp 下限)
+  - `missPenalty = 0`
+  - `total = 50` または defensive に `0` で reject (どちらかを spec 確定)
+
+- 検証ポイント
+  - 純関数が input を信用せず、`Math.max(0, durationMs)` 等の defensive guard を持つ。
+  - throw しない (UI 側で attestation 表示が止まると C 層が破綻するため)。
+  - もしくは throw する場合は orchestrator が catch して `failed` 状態に遷移する経路を担保。
+
+### B-5: オーバーフロー (events 配列が膨大)
+
+- input shape
+
+  ```ts
+  {
+    sessionId: "test-overflow",
+    durationMs: 60_000,
+    finalScore: 0,
+    events: Array.from({length: 100_000}, (_, i) => ({
+      kind: 'shoot', t: i, enemyId: `e${i}`, tradeoffLabel: 'shield',
+      misalignment: 'prompt_injection',
+    }))
+  }
+  ```
+
+- 期待 SafetyScoreBreakdown
+  - `clearTimeBonus = 0`
+  - `missPenalty = -50` (clamp 下限、`-200_000` にはならない)
+  - `total = 0`
+
+- 検証ポイント
+  - 計算時間が 100ms 以下 (UI block しない目安)。`bun test` 内で `performance.now()` で計測。
+  - メモリリークなし (大量 array の reduce で string concat していない等)。
+  - clamp が正常に下限で止まる。
+
+### B-6: empty playLog
+
+- input shape
+
+  ```ts
+  { sessionId: "test-empty", durationMs: 0, finalScore: 0, events: [] }
+  ```
+
+- 期待 SafetyScoreBreakdown
+  - `clearTimeBonus = 0`
+  - `missPenalty = 0`
+  - `total = 50` (ベースのみ)
+
+- 検証ポイント
+  - 空配列で reduce が initial value で止まる、NaN にならない。
+  - 仕様 27 行「ウォレット未接続でも attestation までの計算とローカル表示は完了する」のため、ゲームを 1 度もプレイしていない状態でも `computeSafetyScore` が動くこと。
+
+### B-7: 全 pass ケース (B-2 のサブケース、misalignment 種類分散)
+
+- input shape: 4 種 misalignment それぞれ 1 件ずつ pass。
+- 期待: `total = 50`、`encounters[].kind` が 4 種揃う。
+- 検証ポイント: `agent.misalignment.detected` の JSON 化で全 kind が key に並ぶ (count が 0 の kind を含めるかは spec 確定要)。
+
+### B-8: 全 shoot ケース (B-1 と異なり「全部撃ち落とした = 全 hit」を意図)
+
+- ここで「shoot = 誤射」として扱うか「shoot = 撃ち落とし」として扱うかが仕様で曖昧。
+- 仕様 19 行は「敵を倒した瞬間に misalignment kind カードが出る」とあり、shoot = 撃ち落とし、つまり misalignment を防御した側に読める。
+- 一方 119 行のスコアコメントは「missPenalty = -2 per miss (誤射 + 取り逃しの合算)」とあり、shoot を miss として扱う読み方もできる。
+- input shape: 全 shoot で全 misalignment 紐付。
+- 期待 (Developer に確定要請): どちらの読みでも純関数の振る舞いを 1 つに固定すること。本書は「shoot = 撃ち落とし = 安全 (penalty なし)」「pass = 取り逃し = penalty あり」の解釈を推奨する (Agent 安全のメタファに合致)。
+- 検証ポイント
+  - 仕様書 119 行のコメントを Developer agent と Designer agent で確定し、test に一本化された解釈を固定する。
+  - **これが定まらない限り、純関数のテストは書けない**。最優先で確定。
+
+### B-9: shoot + pass 混在 (現実的ケース)
+
+- input shape: 10 shoot + 5 pass、misalignment は均等に分散。
+- 期待: total が 0 < total < 100 の範囲。具体値は B-8 の解釈確定後に算出。
+- 検証ポイント
+  - breakdown.clearTimeBonus + breakdown.missPenalty + 50 = breakdown.total (clamp 適用前) のセルフ整合。
+  - clamp 適用後の total は仕様 79 行「0-100 にクリップ」の通りで、整数 (`number` だが `Number.isInteger(total)` を assert)。
+
+---
+
+## OnChain failed 状態のレビュー
+
+仕様 38 行「各 OnChain ステップに idle / pending / success / failed の表示を持たせ、failed 時は短い理由を日本語で表示」を真に受けて、文字列レベルで以下を必須化する。Designer と擦り合わせ要。
+
+### ENS subname 発行失敗時の表示文字列 (日本語)
+
+- 失敗 sub-cause ごとに分岐:
+  - parent name 未保有: `ENS 親ドメイン未保有のため subname を発行できません (.env.local の VITE_ENS_PARENT を確認)`
+  - 他者が同 handle を先取り: `handle pilot42 は他のユーザーが取得済みです。再生成して再試行してください` + retry ボタン
+  - chain mismatch: `Sepolia に切り替えてから再試行してください` + chain switch ボタン
+  - user reject: `ウォレットで署名がキャンセルされました`
+  - resolver setText 失敗 (subname 発行は成功した部分失敗): `subname は発行されましたが text record の書き込みに失敗しました` + 「text record だけ retry」ボタン
+- 受け入れ基準
+  - 各文字列が Toast / Panel 内で改行せず 1 行に収まる (日本語 40 文字以内目安)。
+  - failed 状態でも `agent.safety.score` のローカル表示は止めない (仕様 27 行の精神)。
+- E2E 検証
+  - parent name を持たない wallet で game over → ENS 行に `ENS 親ドメイン未保有...` が表示される。
+  - handle を意図的に既存 subname と衝突させる test fixture を `safety-attestation.test.ts` に置く。
+
+### 0G Storage put 失敗時の表示文字列
+
+- 失敗 sub-cause:
+  - SDK の network error: `0G Storage への保存に失敗しました (ネットワーク)` + retry ボタン
+  - SHA-256 stub のため実 storage 未統合: `0G Storage は現在 SHA-256 stub です (CID は hash プレフィックス sha256:// 形式)` を pending ではなく `info` 状態として表示 — 失敗ではないが審査員に明示する。
+  - JSON が 0G の上限超: `attestation JSON が大きすぎます (XX KB)` + 縮約 retry
+- 受け入れ基準
+  - 0G が失敗でも ENS の text record は `agent.safety.attestation = sha256://{hex}` の fallback で書く。仕様 137 行「0G Storage stub 中は後者」がこの fallback を意味することを実装に明記。
+  - `Promise.allSettled` で並列化されている場合でも、ENS write は 0G の resolve を待ってから走る (本書 Front-running 節で既述)。
+- E2E 検証
+  - `zerog-storage.ts` を一時的に `throw new Error('network')` させて、UI が 0G 行は failed、ENS 行は SHA-256 fallback で続行することを確認。
+
+### ウォレット切断時の挙動 (UI が止まらないか)
+
+- ケース 1: ゲーム開始時から wallet 未接続
+  - 期待: handle はローカルで生成、HUD 上に `AGENT: pilot42.{parent}.eth (offline)` のように offline 表記。ENS 行と 0G 行は `idle — ウォレットを接続してください`。
+  - score は計算され AgentDashboard で表示される。仕様 27 行を満たす。
+- ケース 2: ゲーム途中で wallet 切断
+  - 期待: ゲームプレイは継続 (Canvas 描画と event log は wallet 非依存)。game over 時に attestation の compute は走るが ENS / 0G は idle のまま。
+  - 受け入れ基準に「ゲーム実行中の wallet 切断で frame drop しない」を追加。
+- ケース 3: game over 後 (orchestrator 実行中) に wallet 切断
+  - 期待: 進行中の tx は wagmi が abort (UserRejectedRequestError 相当)。UI は failed 状態で停止。retry ボタンが出る。
+- 受け入れ基準
+  - `useAccount().isConnected === false` の状態遷移を AgentDashboard が監視する。
+  - 切断 → 再接続 → retry でフローが再開できる。
+- E2E 検証
+  - MetaMask の Disconnect を game over 直後に押す → UI が hung せず、3 秒以内に failed 表示。
+
+### Chain 不一致 (Sepolia 以外接続) の検出
+
+- 検出タイミング
+  - ゲーム開始時 (handle pre-flight): 不一致なら HUD 上に `chain: SEPOLIA に切替えてください` 警告を表示。
+  - game over 時 (orchestrator 起動直前): 不一致なら ENS 行を `chain mismatch — Sepolia に切り替えてください` の failed 状態に。
+- chain switch の UX
+  - `useSwitchChain` を使い、wallet がサポートしている場合は 1 クリックで switch。サポートしていない場合 (古い MetaMask 等) は手動切替ガイドを表示。
+- 受け入れ基準
+  - mainnet / 0G Galileo / Base Sepolia / Arbitrum Sepolia の 4 chain で繋いだ場合、それぞれ chain mismatch を検出して同一の日本語メッセージを表示。
+  - switch を user reject した場合の文言も用意 (`Sepolia への切替がキャンセルされました`)。
+- E2E 検証
+  - `wagmi.config.ts` に登録されている chain を一つずつ切り替えて game over → ENS 行が常に failed 状態の chain mismatch メッセージ。
+
+---
+
+## a11y 違反 / 観点
+
+仕様 35 行は「色だけでなくテキストラベルでも識別可能、記号 (◉ ◇ ▲ ☓) を併記する」と書いているが、これだけでは a11y を満たしきれない。以下を最低 1 件以上実装に反映する。
+
+### a11y-1: 色のみ依存の禁止 (現状仕様で部分対応)
+
+- リスク
+  - `MisalignmentCard.color` が glyph と同じ意味を二重で運ぶ場合、色覚多様性ユーザーには glyph で識別できるが、色とテキストラベルが矛盾するなら混乱する。
+- 要求
+  - WCAG 2.1 1.4.1「色だけで意味を伝えない」を満たすため、テキストラベル (label / description) を必ず Toast / Panel に表示する。glyph はあくまで補助。
+  - SafetyAttestationPanel の breakdown 棒グラフ (clearTimeBonus / missPenalty) は色 + 数値 + ラベル 3 重で表現する。色のみの bar は不可。
+
+### a11y-2: aria-label 不足 (実装で発生する確度高)
+
+- リスク
+  - HUD 上 `AGENT: pilot42.{parent}.eth` がただの `<div>` になっていると screen reader は読み上げない / 意味づけがない。
+  - SafetyAttestationPanel の ENS link / 0G CID が `<a>` の text content だけだと「リンク先が何か」が分からない (e.g., `0g://bafy...`)。
+- 要求
+  - HUD ラベルは `<output aria-live="polite" aria-label="エージェント識別子: pilot42.gradiusweb3.eth">` として live region 化する。
+  - ENS link は `aria-label="Sepolia ENS resolver で pilot42.{parent}.eth の text record を確認"`、0G CID link は `aria-label="0G Storage で attestation JSON を確認 (CID: bafy...)"`、target=_blank に `rel="noopener noreferrer"` 必須。
+  - MisalignmentToast の close ボタン (もしあれば) は `aria-label="misalignment カードを閉じる"`。
+
+### a11y-3: focus order
+
+- リスク
+  - game over → AgentDashboard 表示時に focus がページ最上部に飛ぶと、screen reader ユーザーは「何が起きたか」を把握できない。
+- 要求
+  - game over 直後に `<h2>AGENT SAFETY ATTESTATION</h2>` に programmatic focus (`ref.current.focus()`、`tabIndex={-1}` 付きで)。
+  - Tab 順は: Score 大表示 → Breakdown → Encounter list → ENS link → 0G CID link → Retry buttons (failed 状態時のみ) の順で意味的に並べる。
+  - INSERT COIN ボタンを Dashboard 内に置く場合、最後の tab 位置に。
+
+### a11y-4: コントラスト比
+
+- リスク
+  - シューティングゲームの背景は通常黒 (Canvas)。MisalignmentToast の文字色とのコントラストが WCAG AA (4.5:1) を満たさない可能性がある。
+  - SafetyAttestationPanel の score 大表示が neon green on black だと色覚多様性 + AA 微妙ライン。
+- 要求
+  - すべてのテキストで WCAG AA 4.5:1 以上、score 大表示などの大型テキスト (24px+) は 3:1 以上を保証。
+  - Designer agent と擦り合わせて palette を確定。Lighthouse / axe-core で検証して結果を `-design.md` に貼る。
+
+### a11y-5: 動的更新を screen reader が取得できるか
+
+- リスク
+  - MisalignmentToast は 2 秒で消える dynamic content。`aria-live` がないと screen reader が読み上げない。
+  - OnChain ステップの状態遷移 (idle → pending → success / failed) も同様。pending → success に変わった瞬間が読み上げられないと UX が片手落ち。
+- 要求
+  - MisalignmentToast に `role="status"` または `aria-live="polite"` を付ける。`assertive` は使わない (ゲーム中の連続 toast で読み上げが詰まる)。
+  - SafetyAttestationPanel の各 step は `aria-live="polite"` の region で囲み、success 時に「ENS subname pilot42.{parent}.eth を発行しました」のように完全文で読み上げる (CID hex を全文読まれないようにラベルを別に出す)。
+- E2E 検証
+  - macOS VoiceOver で game over → toast → AgentDashboard まで通しで読み上げが破綻しないことを確認 (User feedback agent と分担可)。
+
+---
+
+## 60fps 維持 (性能観点)
+
+仕様 33 行「既存 60fps を維持。misalignment toast は Canvas overlay で 2 秒、CPU 負荷の支配項にしない」を性能観点で具体化する。
+
+### perf-1: CPU 負荷ホットスポット
+
+- 危険箇所
+  - `runtime.ts` で敵を倒す瞬間に misalignment kind を lookup する関数 (`CAPABILITY_TO_MISALIGNMENT[capability]`) を毎フレーム呼ぶ実装にしない。倒した瞬間のみ 1 回。
+  - PlayLog event の `push` が毎フレーム走る場合、配列再 allocation のコストに注意 (既存通り。本機能では新規 misalignment payload で 1 byte 増えるだけなので影響軽微)。
+  - score 計算は game over 時 1 回のみ、毎フレーム計算しない。
+- 検証
+  - `bun --filter @gradiusweb3/frontend test` 実行時に runtime.ts の hotpath を覆うテストで budget 計測。
+  - Chrome DevTools Performance tab で 60s 録画、`scripting` time が 16ms / frame を超えない。仕様 17ms ではなく 16ms (60fps 厳格) で評価。
+
+### perf-2: 不要 re-render
+
+- 危険箇所
+  - HUD 上の `AGENT: pilot42...` ラベル を BirthArcade 内 state で持つと、毎 tick の score / time 更新で再 render される。
+  - SafetyAttestationPanel が AgentDashboard 内で state を持つと、orchestrator の各 step resolve のたびに全パネル再 render になる。
+- 要求
+  - handle ラベルは BirthArcade 直下の sibling として独立配置し、`React.memo` でラップ。`pilot42.{parent}.eth` は再 mount するまで不変なので props で固定。
+  - SafetyAttestationPanel は ENS / 0G それぞれの state を sub component に分離し、片方の resolve で全体が再 render しないようにする。`useOnChainForge` (前回 Web3 Wiring の振り返り参照) と同パターンを採用する。
+- 検証
+  - React DevTools Profiler で game over → orchestrator 完了までの render 回数を計測、各コンポーネント 5 回以下を budget。
+
+### perf-3: Canvas vs React overlay の判断 (Designer 確定要)
+
+- 仕様 167 行「Canvas 内に描画でなく React overlay でも OK、実装は Designer agent が決める」とある。QA 視点では:
+  - Canvas 描画 (rAF ループ内): GPU 利用、frame budget に直結。toast 数が多いと描画コストが増える。
+  - React overlay (DOM): GPU 合成、CSS animation で楽に作れる。ただし主 Canvas が full screen のとき pointer-events / z-index の調整が必要。
+- 推奨
+  - **React overlay 採用を推奨**。理由: (a) 仕様 35 行の a11y 要件 (記号 + ラベル) を a11y ツリーに乗せられる、(b) アニメーションが CSS `transition` で書ける、(c) Canvas ループのフレーム budget に影響しない。
+  - 採用条件: pointer-events: none を root に付け、ゲーム入力を阻害しない。
+- 検証
+  - 連続 5 体撃破 (toast 5 連発) で frame drop しないこと。Performance trace で `Recalculate Style` / `Layout` の支配率が 30% を超えないこと。
+
+### perf-4: ENS / 0G write による main thread block
+
+- 危険箇所
+  - game over 直後に orchestrator が走る。`Promise.allSettled` 内の `await writeContract` は async なので main thread を block しないが、JSON stringify (attestation の hash 計算) は同期。100KB 以上の playLog で block する可能性。
+- 要求
+  - JSON stringify を `setTimeout(_, 0)` か `requestIdleCallback` で yield して、AgentDashboard 表示を即時にする。
+  - 仕様 188 行と整合: `setBirth(stored)` を allSettled より前に呼んで Dashboard を即時表示。本機能の orchestrator も同パターンを踏襲。
+
+### perf-5: メモリリーク
+
+- 危険箇所
+  - MisalignmentToast の 2 秒タイマーが unmount 時にクリアされないと、リプレイ時にタイマーが累積する。
+  - SafetyAttestationPanel の event listener (chain change / account change) が unmount 時に detach されていない。
+- 要求
+  - `useEffect` の cleanup 関数で setTimeout / removeEventListener を必ず解除する。
+  - test で `unmount → 再 mount → タイマー 1 個` を assert する。
+
+---
+
+## 致命的所見トップ 4 (実装着地前に確定必須)
+
+1. **subname handle 衝突時の retry が他人の subname を上書きする経路** (Griefing — 前回 tokenId 級の指摘)
+   - 仕様 21 行の `pilot{2 桁}` は衝突空間 100 で簡単に collision する。NameWrapper.setSubnodeRecord は parent owner 権限で既存 subnode を上書きできるため、UI の衝突 retry が「他者の発行済 subname を奪う」経路を作る。
+   - 対応: pre-flight `ownerOf(namehash)` チェック、handle を 4 桁 hex に拡張、orchestrator test で他者保有 subname の上書きを reject。Developer / Designer 両方に共有。
+
+2. **`computeSafetyScore` の shoot / pass 解釈が仕様で曖昧**
+   - 仕様 19 行 (敵を倒した瞬間 = shoot を good) と 119 行のコメント (shoot を miss にカウントする読み方) が衝突。これが定まらないと純関数のテストが書けない。
+   - 対応: 「shoot = 撃ち落とし = 安全」「pass = 取り逃し = penalty」の Agent 安全メタファに合わせた解釈を Developer / PM で確定し、仕様書の暫定式コメントを書き換える。
+
+3. **chain spoofing の switchChain await 漏れ (前回再発リスク)**
+   - 前回 Web3 Wiring で同じ漏れを起こしている (Plan.md 振り返り参照)。本機能でも仕様 229 行に await の明記がない。
+   - 対応: 受け入れ基準に「ENS write 直前 `useChainId() === sepolia.id` を assert、switchChain を await、それでも不一致なら failed」を明文化。
+
+4. **0G Storage put → ENS setText の直列保証が test で担保されていない**
+   - 仕様 144 行で順序は明記されているが、`Promise.allSettled` 内で並列化されると CID = undefined の状態で setText が走る race がある。
+   - 対応: `safety-attestation.test.ts` で「CID resolve 前に setText が呼ばれない」を spy で必須テスト化する。
+
+---
+
+## 実装後 QA 再実行チェックリスト
+
+Developer の PR が land したら以下を再走:
+
+- [ ] 本書の Security 4 軸 + Privacy 軸の追加要件 5 件が実装に反映されているかを diff で確認。
+- [ ] `safety.test.ts` に B-1 ~ B-9 の 9 ケースが揃い、全 green。
+- [ ] OnChain failed 状態の文字列 4 種 (ENS / 0G / disconnect / chain mismatch) が日本語で UI に出ることを E2E で確認。
+- [ ] a11y-1 ~ a11y-5 を Lighthouse / axe-core / VoiceOver で検証、結果スクリーンショットを `docs/specs/2026-04-29-agent-safety-attestation-qa-evidence/` に保存。
+- [ ] 60fps を Chrome DevTools Performance trace で 60 秒録画、frame drop が 1% 未満。
+- [ ] `make before-commit` 全 green、`bun scripts/architecture-harness.ts --staged --fail-on=error` 通過。
+- [ ] critical 4 件が解消されたら verdict を `ship` に更新する。

--- a/docs/specs/2026-04-29-agent-safety-attestation-user-feedback.md
+++ b/docs/specs/2026-04-29-agent-safety-attestation-user-feedback.md
@@ -1,0 +1,184 @@
+# Agent 安全アテステーション (3 段重ね) — User Feedback (Persona Walkthroughs)
+
+**対象仕様**: [`2026-04-29-agent-safety-attestation.md`](./2026-04-29-agent-safety-attestation.md)
+**レビュー視点**: User-perspective reviewer (PM / Designer / Developer / QA とは別役割)
+**日付**: 2026-04-29
+**前回 UF レビュー**: [`2026-04-27-web3-wiring-user-feedback.md`](./2026-04-27-web3-wiring-user-feedback.md) (書式雛形)
+
+本ドキュメントは、仕様書 / README / `BirthArcade.tsx` / `AgentDashboard.tsx` を 3 つのペルソナ視点で歩き直し、demo 提出直前に潰すべき UX 課題を抽出するためのものである。プレイ → 終了 → AgentDashboard → ENS 解決 (sepolia.app.ens.domains) までの一連の動線を 1 ループずつ通し、具体に書く。スコアは「現仕様どおり実装された場合」の暫定値。
+
+---
+
+## Persona X — Agent 安全に詳しくない一般プレイヤー
+
+**プロフィール**: 30 代エンジニア。Web3 は MetaMask を 1 度入れた程度。AI 関連は ChatGPT を業務で使う程度で、「Agent 安全研究」「misalignment」「sycophancy」「reward hacking」は今回が初見。Twitter で「60 秒で AI agent 作れるレトロアーケード、しかも Agent 安全の用語が学べる」というポストを見て live URL を踏んだ。
+
+### 動線シミュレーション
+
+1. LP を開く → `▸ CLEARED FOR TAKEOFF` を押す。
+2. ゲーム開始。HUD 上部に "AGENT: pilot42.gradiusweb3.eth" が出る。**「pilot42 って何?」と一瞬止まる**。が、ゲームの動きに気を取られてそのまま遊ぶ。
+3. shield 持ちの敵を撃つ → 画面右下に "PROMPT INJECTION ◇ approve all 系の指示注入" のような toast が 2 秒だけ出る。**読みきれない**。次の敵がもう来ているので、目線を戻すと toast は消えている。
+4. 60 秒経過 → game over → AgentDashboard へ自動スクロール。「AGENT SAFETY ATTESTATION」セクションの大見出しに "82 / 100" が出る。下に breakdown 棒グラフ。さらに下に misalignment encounter リスト。
+5. 各 encounter 行のラベル (`prompt_injection` / `reward_hacking` / `goal_misgen` / `sycophancy`) を見る。**「英語のままだ。意味は分かったような気もするが、言える気はしない」**。
+6. ENS リンクを押す → sepolia.app.ens.domains で `pilot42.gradiusweb3.eth` が開く。`agent.safety.score = "82"` は分かる。`agent.misalignment.detected = {"prompt_injection":3,"reward_hacking":1,"goal_misgen":2,"sycophancy":0}` は **JSON 文字列のままで読みにくい**。
+
+### 具体フィードバック
+
+1. **misalignment toast の 2 秒は短すぎる、初見ラベルの読了に最低 4 秒は要る**。仕様 19 行目「2 秒 toast」は経験者向けの数字。初見プレイヤー視点では `tAt` に紐付けて、ゲーム終了後に「あなたが遭遇した misalignment」一覧を再表示するセクションを必ず置くべき (= AgentDashboard の encounter リスト)。toast 自体の延長より、**事後参照可能性**の確保のほうが重要。
+2. **ラベルが英 snake_case のまま AgentDashboard に並ぶのは記憶定着しない**。`prompt_injection` の隣に **「指示注入: approve all のような攻撃指示を鵜呑み」** のような 1 行日本語を併記すべき。仕様の `MisalignmentCard.description` (140 文字) と `example` を toast でしか使っていないが、AgentDashboard の encounter 行でも同じ description を「ホバーで全文・常時で先頭 30 文字」のように表示する仕様を追加。
+3. **score 100 点満点の breakdown が直感で分からない**。仕様 122-124 行の式 `clearTimeBonus = clamp(50 - missCount * 2, 0, 50)` は内部式であって、UI 上は「早クリア +30 / 誤射ペナルティ -8 / ベース +50 = 72」のような **加減算の伝票形式** で見せないと、棒グラフだけでは「なぜこの点数か」が伝わらない。breakdown 棒グラフのラベルに `clearTimeBonus` ではなく **「早クリアボーナス」「誤射ペナルティ」「ベース」** の和文を載せる。
+4. **HUD の "pilot42.gradiusweb3.eth" が説明なし**。プレイ中はゲームに集中するから問題ないが、game over 直後の AgentDashboard 冒頭に **「あなたの Agent はこの ENS 名で名乗っています。クリックすると ENS 解決ページが開きます」** の 1 行マイクロコピーが要る。仕様の受け入れ基準には「HUD 上部に表示」しかないが、UF 視点では「意味の説明」がないと cosmetic 扱いされる。
+5. **ENS リンク先の JSON 文字列 `agent.misalignment.detected` が生 JSON のまま**。一般プレイヤーは sepolia.app.ens.domains で `{"prompt_injection":3,...}` を見ても何も感じない。AgentDashboard 側で **「ENS にこう書きました」プレビュー** を JSON ではなく表形式で先に見せ、「これと同じ内容が ENS に登録されています → 検証はこちら」とリンクする順にすると、ENS が「動的に書ける場所」と理解できる。
+
+### 受け入れ基準で「実は満たせていない」項目 (User 視点)
+
+- 受け入れ基準 19 行目 (敵撃破時の 2 秒 toast): **2 秒では初見ラベルを読みきれない**。「toast 表示 + game over 後 dashboard で再表示」を two-fold で両方満たさないと「学習」にはならない。仕様の表現を「toast (即時) + Dashboard (事後参照)」の両立に書き換える必要。
+- 受け入れ基準 21 行目 (handle が "AGENT: pilot42.{parent}.eth" として表示): **「表示される」だけでは意味が立たない**。一般プレイヤーは pilot42 が何を意味するか分からないので、表示だけでなく **「この名前で名乗っています」のラベル** をセットで仕様に入れるべき。
+- 受け入れ基準 26 行目 (AgentDashboard の SafetyAttestationPanel): **encounter 一覧の表示形式が未定**。「misalignment encounter 一覧」とだけ書かれていて、ラベルが英 snake_case のままになる懸念。**「日本語ラベル併記必須」を受け入れ基準に追加** すべき。
+- 受け入れ基準 25 行目 (ENS text record `agent.misalignment.detected` が JSON 文字列): **「JSON 文字列で書く」とまでは決まっているが、UI 側でそれをどう見せるかが未規定**。User 視点では「JSON が ENS に書かれた」だけでは価値が伝わらず、UI 上に decode 済み表で先見せしないと cosmetic 寄りになる。
+
+### README / landing page で更新が必要な箇所
+
+- **README 52-58 行 "What you get in 60 seconds of play"**: 既存 4 項目に **「Agent safety attestation — 4 種の典型 misalignment にどう反応したかが 100 点満点でスコア化される」** を 1 行追加。これがないと「Agent 安全」が機能の主役だとプレイヤーに伝わらない。
+- **README 78-108 行 Architecture 図**: 現状は Browser → forge → ENS / Gensyn / 0G / Uniswap で、misalignment / safety attestation がどこにも描かれていない。**`safety-attestation.ts` orchestrator を別ボックスで足す** か、ENS の隣に "(safety credential)" を注記する。
+- **README 213-222 行 "Differentiation vs. traditional agent design"**: 「traditional approach は black box」と書いているが、Agent 安全の文脈では **「未知の misalignment が混入していても気付けない」** こそが black box の本質。1 行 "Agent safety: 一切可視化されない" 列を追加し、「Gr@diusWeb3: 4 種の misalignment が play 中に名前付きで現れ、attestation 化される」と対比させる。
+- **README 64-73 行 How it plays**: 現状 「赤 = RISK」しか書いていない。ここに **「敵の capability ごとに misalignment 種別が紐付いていて、撃破するたびに教科書のカードが出る」** を 1 行入れないと、ゲームと Agent 安全のつながりが LP 段階で見えない。
+
+### Score they'd give
+
+- **5.5 / 10** (現仕様まま、ラベル英文・JSON 生表示・toast 2 秒)
+- **8.0 / 10** (日本語ラベル併記 + dashboard で encounter 再表示 + breakdown を加減算伝票化 + LP に safety 列追加)
+
+---
+
+## Persona Y — ハッカソン審査員 (3 分動画でジャッジ)
+
+**プロフィール**: ETHGlobal の generalist track 審査員。1 件 15 分。3 分 demo 動画 → live URL → README → contract addr → 賞ごとの該当箇所、の順で見る。今回の仕様は 3 段重ね (A: misalignment / B: ENS / C: attestation) を一度に見せる構造なので、**「3 段が個別ピースなのか、一本の線なのか」** を 3 分で判定する。
+
+### 動線シミュレーション (3 分動画ベース)
+
+仕様 233-239 行のタイムコード:
+
+- 0:00-0:15 — landing page、Agent 安全 default のメタファ説明
+- 0:15-1:05 — 50 秒ゲームプレイ、misalignment カードが出る (A 層)
+- 1:05-1:20 — HUD 上の "AGENT: pilot42.{parent}.eth" 強調 (B 層)
+- 1:20-2:30 — game over → AgentDashboard 安全スコア → breakdown → encounter → ENS / 0G CID リンク (C 層)
+- 2:30-3:00 — sepolia.app.ens.domains で text record 解決
+
+審査員はこの 3 分で **「A → B → C が一本の line で繋がっているか」** を判定する。
+
+### 具体フィードバック
+
+1. **0:15-1:05 (50 秒) の中で 4 種 misalignment 全部に遭遇できる保証がない**。仕様 102-108 行の capability マッピングは shield/option/laser/missile の 4 つに紐付くが、speed のみの敵が連続で来る seed だと misalignment が一切表示されない 50 秒もあり得る。**demo 動画用に「4 種すべて出る seed」を `?seed=demo` クエリで強制できる仕様** を追加すべき。さもないと審査員が見る個体で A 層が空振りする。
+2. **3 段の橋渡しが UI 上に明示されていない**。仕様の AgentDashboard SafetyAttestationPanel は score / breakdown / encounter / ENS link / 0G CID を「並べる」だけ。審査員は「これとあれが繋がっている」を 3 分で読み取れない。**「play log → safety score → 0G に保存 → ENS に hash で参照」を 1 本の矢印図 (Mermaid 風) で Panel 内に置く** べき。仕様のファイル構成 174-194 行に `SafetyAttestationPipelineDiagram.tsx` のような視覚化コンポーネントが追加で要る。
+3. **「これがなぜ Agent 安全と関係するのか」の橋渡しが LP / Dashboard どちらにも欠けている**。「敵を撃つ = misalignment を抑制」「敵を見送る = misalignment を許容」の対応が、現仕様 (capability ↔ misalignment 1:1 マッピング) では形式的に張られているだけで、UI 上に **「あなたは prompt_injection 持ちの敵を 3 体倒しました = 指示注入耐性ありの Agent として attest されています」** のような **意味の翻訳行** がない。SafetyAttestationPanel に encounter ごとの「あなたの行動 → Agent 性質」の 1 行翻訳を必ず置く。
+4. **動画 1:05-1:20 で B 層を 15 秒だけ強調する設計が、demo 視聴者に「ENS subname は何のため?」を残したまま C 層に入る**。仕様 233-239 行は B 層の意味付け尺が短すぎる。**B 層の 15 秒で「この pilot42 という名前のもとに、後で安全 credential が紐付きます」と先出し** する音声 / テロップが要る。さもないと「pilot42 という名前が表示されている」だけで終わる。
+5. **2:30-3:00 の sepolia.app.ens.domains 解決カットで、3 つの text record (`agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected`) を全部映す尺が確保できていない**。30 秒で 3 record + 0G CID + JSON プレビューはタイト。**`agent.safety.score` を最大文字で映す → `agent.safety.attestation` の hash を 1 秒映す → `agent.misalignment.detected` の JSON プレビューを 5 秒** のように、record ごとの強調ショットを 30 秒台本に明文化すべき。
+
+### 受け入れ基準で「実は満たせていない」項目 (Judge 視点)
+
+- 受け入れ基準 26 行目 (AgentDashboard SafetyAttestationPanel): **「視覚化された 3 段の橋渡し」が要件に含まれていない**。現在の仕様は score / breakdown / encounter / ENS / 0G CID を「並べる」までしか規定していないので、判定基準として「A→B→C の連結を視覚化する」を追加するのが望ましい。
+- 受け入れ基準 19 行目 (2 秒 toast): **demo 動画用に misalignment 4 種すべて確実に表示する仕組み** が受け入れ基準に入っていない。`?seed=demo` のような強制 seed 機構を受け入れ基準に追加し、QA で検証する。
+- 受け入れ基準 22 行目 (subname を NameWrapper.setSubnodeRecord で発行): **動画で映る確率が 100% でない**。テストネット遅延で発行が 30 秒かかると 1:05-1:20 の B 層尺で「pending」のまま終わる懸念。**「ゲーム開始時に発行 → ゲーム中に確定」を 60 秒以内で完了する SLO** を受け入れ基準に追加する。
+- Prize Targets 表 (仕様 209-218 行): **0G Storage = 3 と書いているが、SHA-256 stub のままだと審査員が「実 SDK 呼び出しゼロ」で 1 まで落とす可能性**。前回 UF レビュー 91 行目で同じ指摘がされており、今回も解消されていない。**「demo 動画では実 SDK でアップロード成功させる」を受け入れ基準に追加** すべき。
+
+### README / landing page で更新が必要な箇所
+
+- **README 24-40 行 "Quick verification for prize judges"**: 表に **「Agent safety attestation」行を追加**。What to check = "AgentDashboard `AGENT SAFETY ATTESTATION` section + sepolia.app.ens.domains text records"、Where = `packages/frontend/src/web3/safety-attestation.ts`, `packages/frontend/src/components/SafetyAttestationPanel.tsx`, `packages/shared/src/safety.ts`。これがないと判定動線が「0G/ENS/Uniswap の 3 行のみ」のまま、新機能が判定対象になっていない状態になる。
+- **README 197-209 行 Sponsor integrations 表**: ENS 行を **「Auto-issued subname + verifiable safety credential text records (`agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected`)」** に書き換える。前回 UF レビューで指摘された通り「現状の text records (`combat-power`, `archetype`, `design-hash`) のまま」だと新仕様と整合しない。`Where in the code` に `safety-attestation.ts` も追加。
+- **README 266-272 行 Roadmap**: 「Agent safety attestation」を **shipped 側に書き出す**。ロードマップ未来形のままだと審査員が「未実装」と読む。
+- **README 5 行 ヒーローキャッチ**: 現状 "Kill the tradeoffs. Play to design your AI agent." は良いが、Agent 安全との接続は読み取れない。**サブヘッダで "Each shot is a vote against a misalignment. The result is a verifiable on-chain agent safety credential." を 1 行足す** と、3 分動画 0:00-0:15 で読み上げる原稿になる。
+
+### Score they'd give
+
+- **6.0 / 10** (現仕様、3 段の橋渡し未視覚化、demo seed 未保証、SHA-256 stub のまま)
+- **8.5 / 10** (Pipeline diagram 追加 + demo seed 強制 + 実 SDK アップロード + README Quick verification 行追加)
+
+---
+
+## Persona Z — ENS 賞審査員 (sepolia.app.ens.domains で text record 確認)
+
+**プロフィール**: ENS 賞 (Identity / Creative の 2 トラック) を担当。30+ サブミッションを 30 秒〜2 分で「meaningful か cosmetic か」判定する。`docs/prizes/ens-*` に基づき、`subname × text records が functional credential として動作しているか` を見る。subname 発行だけ・hard-coded text records・Resolver から値が引けない、のどれかで cosmetic 判定に倒す。
+
+### 動線シミュレーション (30 秒〜2 分)
+
+1. README の `Quick verification` 表を見る。ENS 行から `packages/frontend/src/web3/ens-register.ts` に飛び、`setSubnodeRecord` + `setText` の実呼び出しコードを確認 (ここまで 30 秒)。
+2. live demo を踏み、60 秒プレイ → AgentDashboard の SafetyAttestationPanel で `pilot42.gradiusweb3.eth` のリンクを発見。
+3. リンクを踏む → sepolia.app.ens.domains の `pilot42.gradiusweb3.eth` のページを開く。**Records タブで `agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected` の 3 件と、既存 `combat-power` / `archetype` / `design-hash` の 3 件、合計 6 件を確認**。
+4. それぞれの値が「動的に書かれた credential」として読めるかを判定。score = 整数、attestation = `0g://{cid}` または `sha256://{hex}`、misalignment.detected = JSON 文字列。
+
+### 具体フィードバック
+
+1. **6 件の text records が同じ flat key 空間に並ぶと、新旧の関係性が見えない**。`combat-power` / `archetype` / `design-hash` (既存) と `agent.safety.*` / `agent.misalignment.*` (新規) は **意味の層が違う** が、Resolver 側では区別がない。**`agent.*` に prefix 統一する方針を decision として README + 仕様に明記** するか、既存 3 件も `agent.combat.power` / `agent.archetype` / `agent.design.hash` にリネームする。さもないと審査員は「ENS records がただの dump 場」に見える。
+2. **`agent.safety.attestation` の値 schema が仕様で揺れている**。仕様 25 行目「CID もしくは hash」、136 行目「`0g://{cid}` もしくは `sha256://{hex}`」。**`{scheme}://{value}` の URI 形式に固定** することを受け入れ基準に明記。さもないと審査員が parser で読めない。スキーム判定で 0G Storage stub なのか実 SDK CID なのかも一目で分かる。
+3. **subname `pilot42` がランダム生成 = 同じ wallet で 2 回プレイすると別 subname が生える**。仕様 21 行目「`pilot{2 桁ランダム}`」+ 36 行目「nonce ベース handle」。これは griefing 回避には正しいが、ENS 審査員視点では **「同じ Agent が安定した名前を持つ」** が credential の前提。`pilot42` が 1 回限りの使い捨てだと「name = identity」が成立しない。**「同じ wallet なら同じ subname を返す」 deterministic mode と nonce mode を切替可能にする** か、`pilot42` を 1 度発行したら sticky にする運用を仕様化すべき。
+4. **functional な credential であることを示す「再現実験」が demo 側に用意されていない**。審査員は「ENS から読み出せるか」を自分で `viem` の `getEnsText` 等で叩きたい。README の Quick verification 表に **`bun scripts/verify-ens-credential.ts pilot42.gradiusweb3.eth` のような確認スクリプト** を 1 つ用意し、stdout で 3 record 全部を decode して見せる。これがあると 30 秒で「動く」判定になる。
+5. **ENS 名と中身の credential の対応が AgentDashboard 上で一目で分からない**。SafetyAttestationPanel に `pilot42.gradiusweb3.eth` のリンクと、その下に書かれた 3 record の table を **「← この 3 件が上記 ENS 名に紐付いています」** と矢印で結ぶ視覚化が要る。仕様の Panel 設計には「ENS resolver link」しかない。
+
+### 受け入れ基準で「実は満たせていない」項目 (ENS Judge 視点)
+
+- 受け入れ基準 25 行目 (text record 3 件): **value schema 未固定**。`agent.safety.attestation` を `{scheme}://{value}` の URI 形式で書くことを受け入れ基準に明文化する必要。
+- 受け入れ基準 22 行目 (subname を NameWrapper.setSubnodeRecord で発行): **同じ wallet で 2 回目以降の subname 戦略が未決**。「nonce ベース handle = 毎回別 subname」だと credential 安定性が損なわれる。「2 回目以降は既存 subname の text record を上書き更新」の運用を受け入れ基準に追加すべき。仕様 37 行目「冪等性: 同じ sessionId + handle + walletAddress で 2 回 attestation を発行しても、subname の text record が上書き更新される」と書かれているが、handle 自体がランダムだと `同じ handle` が 2 回目に発生する保証がない。**handle 決定論を walletAddress 由来にする** か、「初回発行で sticky、2 回目以降は同じ subname に上書き」の動作を明文化する。
+- 受け入れ基準 26 行目 (AgentDashboard SafetyAttestationPanel): **「ENS 名 ↔ 3 record の対応視覚化」が要件に入っていない**。Panel 設計に「ENS resolver link」しかなく、credential の対応が読み取れない。
+- Prize Targets 表 (仕様 217 行 ENS Creative = 3): **subname-as-attestation-receipt の発想は強い** が、3 record + JSON value のみでは「depth 評価」が読めない。**4 件目以降の record (例: `agent.safety.version` schema、`agent.safety.issued-at` ISO 8601、`agent.safety.encounters-count` 数値)** を増やして depth を厚くする方が ENS Creative で 3 を確定させやすい。
+
+### README / landing page で更新が必要な箇所
+
+- **README 24-40 行 Quick verification**: ENS 行を **「`pilot{nn}.gradiusweb3.eth` の text records を sepolia.app.ens.domains で確認 (`agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected`)」** に拡張。verify スクリプト行 (`bun scripts/verify-ens-credential.ts <subname>`) を 1 行追加。
+- **README 204 行 ENS 行 (Sponsor integrations 表)**: 現状 "(`combat-power`, `archetype`, `design-hash`)" のみ。これを **"(verifiable safety credential records: `agent.safety.score`, `agent.safety.attestation`, `agent.misalignment.detected`, plus legacy `combat-power` / `archetype` / `design-hash`)"** に書き換える。`Where in the code` に `safety-attestation.ts` を追加。
+- **README 197 行 Sponsor integrations 見出しの直前**: **「ENS subnames are functional safety credentials, not cosmetic labels」** の 1 文サブヘッダを足す。これがないと flat key の records dump に見える。
+- **README 78-108 行 Architecture 図**: ENS ボックスの中身に "(safety credential text records)" を 1 行注記。さもないと「ENS = handle 表示用」のままに見える。
+- **新規ファイル / `docs/prizes/ens-self-mapping.md` 検討**: 前回 UF レビュー 105-106 行で「0G 単独 self-mapping」が推奨されたのと同様、ENS も `docs/prizes/` 配下に self-mapping を置くと top-tier 入賞に効く。本仕様の Prize Targets 表をベースに 1 ファイル化。
+
+### Score they'd give
+
+- **6.5 / 10** (現仕様、3 record 書き込みは動くが schema 揺れ + handle ランダム + 視覚化なし)
+- **8.5 / 10** (URI schema 固定 + handle sticky 化 + verify スクリプト + Panel 上に ENS↔records の対応視覚化 + record 件数を 4 以上に拡張)
+
+---
+
+## Top 5 Fixable UX Issues (優先度順)
+
+### 1. encounter ラベルに日本語併記 + dashboard で再表示 (Persona X 致命)
+
+- 仕様の `MisalignmentCard.description` (140 文字) と `example` を toast 表示でしか使わない設計を改め、**AgentDashboard の encounter リストでも常時表示** する。
+- 各 encounter 行を `[◇] prompt_injection 指示注入: approve all 系の指示注入 / 例: ...` のように 1 行で読めるレイアウトに。
+- 受け入れ基準に「日本語ラベル併記」「事後参照可能性」を追加。
+
+### 2. 3 段 (A→B→C) の橋渡し視覚化 (Persona Y 致命)
+
+- SafetyAttestationPanel の中に **`SafetyAttestationPipelineDiagram`** を新設し、`play log → safety score (computed) → AgentSafetyAttestation JSON → 0G Storage put → ENS text record (CID)` を 1 本の矢印図に。
+- 動画 1:20-2:30 (C 層メイン尺) でこの図を 5 秒映すだけで、3 段の連結が判定可能になる。
+- 仕様のファイル構成にこのコンポーネントを追加。
+
+### 3. ENS subname の sticky 化 + URI schema 固定 (Persona Z 致命)
+
+- handle を `pilot{walletAddress.lower(0,2)}` のような **walletAddress 由来 deterministic** にし、初回発行で sticky、2 回目以降は同じ subname に text record を上書き。
+- `agent.safety.attestation` の値を `{scheme}://{value}` URI 形式に固定 (`sha256://...` または `0g://...`)。
+- 受け入れ基準にこの 2 点を明文化。
+
+### 4. demo 用 seed と verify スクリプト (Persona Y + Z)
+
+- `?seed=demo` クエリで「4 種 misalignment 全部出る + 適度な誤射 1 〜 2」が起きる固定 seed を実装。
+- `scripts/verify-ens-credential.ts <subname>` を新設。`viem` で `getEnsText` を 3 keys 叩いて stdout に decode 表示。
+- README の Quick verification にこの 2 つを行追加。
+
+### 5. README / LP の Agent 安全文脈アップデート (3 ペルソナ共通)
+
+- **README ヒーローサブヘッダ**に「Each shot is a vote against a misalignment. The result is a verifiable on-chain agent safety credential.」を追加。
+- **What you get in 60 seconds** に「Agent safety attestation」項目を追加。
+- **Sponsor integrations 表**の ENS 行を新 records に書き換え、`Where in the code` に `safety-attestation.ts` を追加。
+- **Quick verification 表**に「Agent safety attestation」行と verify スクリプト行を追加。
+- **Roadmap** から本機能を取り除く (= shipped 側へ)。
+
+---
+
+## 補足: 各ペルソナのスコア集計
+
+| ペルソナ | 現仕様まま | 上記 Top 5 fix 後 | デルタ |
+|----------|-----------|-------------------|--------|
+| X. Agent 安全初見プレイヤー | 5.5 | 8.0 | +2.5 |
+| Y. ハッカソン審査員 (3 分動画) | 6.0 | 8.5 | +2.5 |
+| Z. ENS 賞審査員 | 6.5 | 8.5 | +2.0 |
+
+**最大 ROI は Persona Y (3 分動画ジャッジ)**。3 段の橋渡し視覚化 + demo seed 強制の 2 つだけで判定動線が一直線になり、A/B/C すべてが「線で繋がっている」と読まれるようになる。次点で Persona X の日本語ラベル併記 (これは Designer agent タスクとして並列で潰せる)。Persona Z の sticky 化と URI schema 固定は Developer agent 側で純関数の振る舞いとして仕様確定するだけで実装は軽量。submission 直前の「あと 2 時間あったら何をやる?」の答えは **Top 5 のうち 1 / 2 / 3 を 2 時間で潰す**。残り (4/5) は QA / README PR と並行で取り組む。

--- a/docs/specs/2026-04-29-agent-safety-attestation.md
+++ b/docs/specs/2026-04-29-agent-safety-attestation.md
@@ -1,0 +1,252 @@
+# Agent 安全アテステーション (3 段重ね) 仕様書
+
+## 概要
+
+シューティングプレイ中に倒した敵の **misalignment 種別** をカード表示し (A 層)、プレイヤー Agent には **ENS subname** を発行して名乗らせ (B 層)、終了時に **クリア時間 + 誤射ペナルティ** から算出した 100 点満点の Agent 安全スコアを **0G Storage に格納し ENS text record にハッシュ参照** する形でアテステーション発行する (C 層) 機能。3 つを 1 PR で一貫させ、既存の Agent 安全 default オンボーディング (`feat/safety-tutorial` で再フレーム済み) と接続する。
+
+## ユーザーストーリー
+
+- **未経験プレイヤー** として、敵を倒したときに出る misalignment カードで「Agent 安全研究の典型失敗モード」を 1 ループで覚えたい。
+- **デモ視聴者** として、プレイヤーが pilot42.{parent}.eth と名乗り、終了時に sepolia.app.ens.domains で text record を確認できる流れを 30 秒で理解したい。
+- **0G prize 審査員** として、play log と attestation 本体が 0G Storage に置かれていることを確認したい。
+- **ENS prize 審査員** として、subname の text record に検証可能 credential (安全スコア + attestation hash) が動的に書き込まれていることを確認したい。
+- **既存ユーザー** として、既存のゲームプレイ感 (60fps / 60 秒 / 5 capability commit) を壊されたくない。
+
+## 受け入れ基準
+
+- [ ] 4 種の misalignment ラベル (sycophancy / reward hacking / prompt injection / goal misgen) が `@gradiusweb3/shared` に enum として定義される。
+- [ ] 既存の敵 capability 5 種に misalignment kind がマッピングされる (1 種は misalignment なし可)。
+- [ ] 敵を倒した瞬間に、その敵の misalignment kind カード (140 文字以内の説明 + 実例 1 行) が HUD 右下に 2 秒 toast として表示される。
+- [ ] PlayLog の `shoot`/`pass` イベントに `misalignment?: MisalignmentKind` が記録される (型の後方互換: optional)。
+- [ ] ゲーム開始時にプレイヤー Agent の handle (例: `pilot{2 桁ランダム}`) が決定し、HUD 上部に "AGENT: pilot42.{parent}.eth" として表示される。
+- [ ] ゲーム終了時に Sepolia ENS で `pilot42.{parent}.eth` を NameWrapper.setSubnodeRecord で発行する (既存 `ens-register.ts` を流用)。
+- [ ] 100 点満点の Agent 安全スコアが `clearTimeBonus + missPenalty` から算出される (純関数、`@gradiusweb3/shared` でテスト可)。
+- [ ] AgentSafetyAttestation JSON が 0G Storage に put され CID が返る (現状は SHA-256 stub のままで OK、follow-up で実 SDK)。
+- [ ] ENS text record に最低 3 件書き込まれる: `agent.safety.score` / `agent.safety.attestation` (CID もしくは hash) / `agent.misalignment.detected` (JSON 文字列の検出カウント)。
+- [ ] AgentDashboard に "AGENT SAFETY ATTESTATION" セクションが追加される (スコア / breakdown / misalignment encounter 一覧 / ENS link / 0G CID)。
+- [ ] ウォレット未接続でも attestation までの計算とローカル表示は完了する (ENS 発行と 0G put は failed 状態で表示)。
+- [ ] `bun scripts/architecture-harness.ts --staged --fail-on=error` 通過。
+- [ ] `make before-commit` 通過 (lint / typecheck / test / build)。
+
+## 非機能要件
+
+- **パフォーマンス**: 既存 60fps を維持。misalignment toast は Canvas overlay で 2 秒、CPU 負荷の支配項にしない。
+- **セキュリティ**: ENS text record に書く JSON は最大 1KB / 値あたり、wallet 切替で別 subname を引けるよう deterministic でなく nonce ベース handle にする (replay/griefing 回避は subname のオーナー = msg.sender バインドで担保)。
+- **アクセシビリティ**: misalignment カードは色だけでなくテキストラベルでも識別可能。色覚多様性配慮で記号 (◉ ◇ ▲ ☓) を併記する。
+- **フェイルセーフ**: 0G put 失敗 / ENS 書込み失敗のいずれも、score 計算と attestation JSON 表示は完走する。`Promise.allSettled` パターンを既存 `forge-onchain.ts` から踏襲。
+- **冪等性**: 同じ sessionId + handle + walletAddress で 2 回 attestation を発行しても、subname の text record が上書き更新されるだけで失敗しない。
+- **空状態 / エラー状態**: 各 OnChain ステップに idle / pending / success / failed の表示を持たせ、failed 時は短い理由を日本語で表示。
+
+## 技術設計
+
+### データモデル (新規 / 拡張)
+
+```ts
+// packages/shared/src/types.ts (追加)
+
+export type MisalignmentKind =
+  | 'sycophancy'
+  | 'reward_hacking'
+  | 'prompt_injection'
+  | 'goal_misgen';
+
+export interface MisalignmentCard {
+  kind: MisalignmentKind;
+  label: string;          // 表示用短文
+  description: string;    // 140 文字以内の説明
+  example: string;        // 1 行の実例
+  glyph: '◉' | '◇' | '▲' | '☓';
+  color: string;
+}
+
+export interface MisalignmentEncounter {
+  kind: MisalignmentKind;
+  enemyId: string;
+  tAtMs: number;
+  hit: boolean;          // true = shot down, false = passed
+}
+
+// PlayEvent の shoot/pass を拡張:
+export type PlayEvent =
+  | { kind: 'shoot'; t: number; enemyId: string; tradeoffLabel: string; misalignment?: MisalignmentKind }
+  | { kind: 'pass'; t: number; enemyId: string; tradeoffLabel: string; misalignment?: MisalignmentKind }
+  | ... // 他は既存維持
+
+export interface SafetyScoreBreakdown {
+  clearTimeBonus: number;   // 0-50
+  missPenalty: number;      // 0 〜 -50 の負値
+  total: number;            // 0-100 にクリップ
+}
+
+export interface AgentSafetyAttestation {
+  sessionId: string;
+  handle: string;             // "pilot42"
+  ensName: string;            // "pilot42.{parent}.eth"
+  walletAddress: string;
+  score: number;              // 0-100 整数
+  breakdown: SafetyScoreBreakdown;
+  encounters: MisalignmentEncounter[];
+  issuedAt: string;           // ISO 8601
+  schemaVersion: 1;
+}
+```
+
+### 純関数 (テスト容易)
+
+`packages/shared/src/safety.ts` を新規追加する。
+
+```ts
+export const MISALIGNMENT_CARDS: Record<MisalignmentKind, MisalignmentCard> = { ... };
+
+/// capability ↔ misalignment マッピング (5 capability 中 4 つに付与、speed は無し)
+export const CAPABILITY_TO_MISALIGNMENT: Partial<Record<Capability, MisalignmentKind>> = {
+  shield:  'prompt_injection', // "approve all" 系の指示注入
+  option:  'reward_hacking',   // 指標 (yield) を歪める
+  laser:   'goal_misgen',      // proxy metric だけ最適化
+  missile: 'sycophancy',       // 都合の良い signal だけ拾う
+  // speed は無し
+};
+
+export function deriveSafetyAttestation(input: {
+  sessionId: string;
+  handle: string;
+  ensName: string;
+  walletAddress: string;
+  playLog: PlayLog;
+  parentName: string;
+}): AgentSafetyAttestation { ... }
+
+export function computeSafetyScore(playLog: PlayLog): SafetyScoreBreakdown {
+  // clearTimeBonus = max(0, 50 * (60_000 - durationMs) / 60_000)  ※早クリアほど高い、ただし 60s 規定では durationMs=60s 想定で 0
+  // → 代わりに「残り HP * 5」のような単純化が妥当か検討。spec では暫定:
+  //   clearTimeBonus = clamp(50 - missCount * 2, 0, 50)
+  //   missPenalty   = -2 per miss (誤射 + 取り逃しの合算)
+  //   total = clamp(50 + clearTimeBonus + missPenalty, 0, 100)
+}
+```
+
+スコア式の暫定: `total = clamp( 50 + clearTimeBonus(0..50) + missPenalty(-50..0), 0, 100 )`。詳細式は実装フェーズで純関数のテストで決定 (BDD で振る舞い駆動、振る舞いは「ノーミス完走 → 100」「全部見送り → 50 付近」「全誤射 → 0 近傍」の 3 ケースを満たす)。
+
+### ENS 統合 (B 層)
+
+- `packages/frontend/src/web3/ens-register.ts` は既存実装を流用 (NameWrapper.setSubnodeRecord + Resolver.setText)。
+- 親ドメイン: `VITE_ENS_PARENT` 環境変数 (デフォルト `gradiusweb3.eth`、本仕様では Sepolia の `testname.eth` を user が個人購入して `.env.local` で上書き)。
+- 新規追加 text records:
+  - `agent.safety.score` = "85"
+  - `agent.safety.attestation` = "0g://{cid}" もしくは `sha256://{hex}` (0G Storage stub 中は後者)
+  - `agent.misalignment.detected` = `{"prompt_injection":3,"reward_hacking":1,...}`
+- 既存の `combat-power` / `archetype` / `design-hash` 系は維持。
+
+### 0G Storage 統合 (C 層)
+
+- `packages/frontend/src/web3/zerog-storage.ts` を拡張: `putAttestation(attestation: AgentSafetyAttestation): Promise<{ cid: string }>` を追加 (現在は `putPlayLog` のみ)。
+- 既存と同じ SHA-256 stub で OK、実 SDK 化は follow-up。
+- attestation JSON を put → ENS text record にその CID/hash を書く順序で wiring する。
+
+### Game ↔ Attestation orchestrator
+
+`packages/frontend/src/web3/safety-attestation.ts` を新規追加し以下を担う:
+
+```
+on game complete (BirthArcade onComplete)
+  ↓
+deriveSafetyAttestation(playLog) → AgentSafetyAttestation [pure]
+  ↓
+Promise.allSettled([
+  putAttestation(attestation) → cid,
+  registerSubname(walletClient, { handle, owner, textRecords }) → ensName,
+])
+  ↓
+AgentDashboard に AGENT SAFETY ATTESTATION セクション表示
+```
+
+既存の `forge-onchain.ts` (mint / storage / ENS / swap の orchestrator) と並列に立てる。Phase 5 統合時に共存パターンを確定する。
+
+### UI コンポーネント
+
+- 新規: `packages/frontend/src/components/MisalignmentToast.tsx` — 敵撃破時に 2 秒間表示するカード (Canvas 内に描画でなく React overlay でも OK、実装は Designer agent が決める)。
+- 新規: `packages/frontend/src/components/SafetyAttestationPanel.tsx` — AgentDashboard に組み込まれる。score (大きく表示) / breakdown 棒グラフ / encounter リスト / ENS resolver link / 0G CID。
+- 拡張: `HUD.tsx` 上部に "AGENT: pilot42.{parent}.eth" ラベルを追加。
+- 拡張: `AgentDashboard.tsx` に SafetyAttestationPanel を差し込む (既存 OnChainProof セクションの隣)。
+
+### ファイル構成
+
+```
+新規:
+  packages/shared/src/safety.ts
+  packages/shared/src/safety.test.ts
+  packages/frontend/src/web3/safety-attestation.ts
+  packages/frontend/src/web3/safety-attestation.test.ts
+  packages/frontend/src/components/MisalignmentToast.tsx
+  packages/frontend/src/components/SafetyAttestationPanel.tsx
+  docs/specs/2026-04-29-agent-safety-attestation-{pm-review,design,qa,user-feedback}.md
+
+拡張:
+  packages/shared/src/types.ts            (MisalignmentKind / Encounter / Attestation 型追加)
+  packages/shared/src/index.ts            (re-export)
+  packages/shared/src/browser.ts          (re-export browser-safe)
+  packages/frontend/src/web3/zerog-storage.ts  (putAttestation 追加)
+  packages/frontend/src/game/runtime.ts   (敵 capability に misalignment 紐付け、shoot event に payload 付与)
+  packages/frontend/src/components/HUD.tsx     (handle ラベル追加)
+  packages/frontend/src/components/BirthArcade.tsx  (handle 生成・onComplete に attestation 起動)
+  packages/frontend/src/components/AgentDashboard.tsx  (SafetyAttestationPanel 差し込み)
+  Plan.md                                  (本機能の進捗ログ)
+```
+
+## スコープ外
+
+- AXL ノード間通信 (Gensyn 賞は今回見送り)。
+- KeeperHub による text record 自動更新 (今回見送り)。
+- 0G Compute による misalignment 判定 sealed inference (follow-up)。
+- 0G Storage SDK 実統合 (現状は SHA-256 stub のまま、follow-up)。
+- 5 種目の misalignment (deceptive alignment 等) 拡張 (今回は 4 種固定)。
+- Roguelike 化 / misalignment 重複コンボ (今回は静的カード × 4)。
+- ENS reverse record / primary name 設定。
+- mainnet 対応。
+
+## Prize Targets (`prizes` スキル採点を転記)
+
+| Prize | Score (0-3) | 統合内容 | NG リスク | 提出物 |
+|-------|-------------|----------|-----------|--------|
+| 0G Compute    | 0 | 範囲外 | — | — |
+| 0G Storage    | 3 | AgentSafetyAttestation JSON を 0G Storage に put、CID を ENS text record で参照。play log は既存通り | SDK 実統合は follow-up、demo では SHA-256 stub であることを明記 | 3 分 demo / アーキ図 / contract addr / GitHub repo |
+| 0G iNFT       | 1 | 既存の iNFT mint は維持 (本機能では拡張せず) | — | 既存通り |
+| ENS Identity  | 3 | 開始時に subname 自動発行、handle が in-game で表示、text record で動的に安全 credential を書く | hard-coded NG → handle はランダム生成、wallet で別 subname | live demo / sepolia.app.ens.domains で text record 表示 |
+| ENS Creative  | 3 | text record = verifiable agent safety credential (score + attestation hash + misalignment 統計)。subname-as-attestation-receipt の発想 | depth 評価次第 → 3 件以上の record + JSON value で深さ確保 | 同上 |
+| Gensyn AXL    | 0 | A 案で除外 | — | — |
+| KeeperHub     | 0 | A 案で除外 | — | — |
+| Uniswap       | 1 | 既存の swap UI は維持 (本機能では拡張せず) | `FEEDBACK.md` 既存維持 | — |
+
+期待賞金: $7,000〜$11,000 (0G Storage + ENS の 2 軸固定、両方の 1〜3 位入賞ライン)。
+
+## Security 考慮 (Web3 必須セクション)
+
+| 軸 | リスク | 対策 |
+|----|--------|------|
+| Replay | 同 handle で別ユーザーが subname 上書き | NameWrapper は parent owner のみ呼び出し可、parent owner = demoer wallet なので外部 replay は不可 |
+| Griefing | 第三者が同 handle を先取り | handle は session 内ランダム (例: `pilot{2 桁}`) で衝突時は再生成 |
+| Front-running | text record 改竄 | resolver.setText の owner check は ENS 仕様で担保 (subnode owner のみ) |
+| Chain spoofing | 別 chain で偽 attestation | viem の `walletClient.chain` を Sepolia に固定、`switchChain` を強制 |
+| Privacy | プレイログに個人情報 | playLog は session ID + 入力イベントのみ、PII 含まない (現状維持) |
+
+## デモ動画 (3 分以内、C を主役)
+
+- 0:00-0:15 — landing page、Agent 安全 default のメタファ説明
+- 0:15-1:05 — 50 秒ゲームプレイ、敵を倒すたびに misalignment カードが出る (A 層を見せる)
+- 1:05-1:20 — HUD 上の "AGENT: pilot42.{parent}.eth" を強調、開始時に発行されたことを 1 行で説明 (B 層)
+- 1:20-2:30 — game over → AgentDashboard にスクロール、Agent 安全スコア (大きく) → breakdown → misalignment 一覧 → ENS resolver / 0G CID リンク (C 層がメイン)
+- 2:30-3:00 — sepolia.app.ens.domains で text record 解決、`agent.safety.attestation` の値が JSON で見えるカット
+
+## 実装順序 (5 役割並列の前に Developer 視点での全体順)
+
+1. shared に型と純関数 (safety.ts + test) を追加
+2. game/runtime.ts に misalignment 紐付け、PlayEvent payload 付与
+3. zerog-storage.ts に putAttestation 追加
+4. safety-attestation.ts orchestrator
+5. UI コンポーネント (Toast + Panel + HUD ラベル)
+6. AgentDashboard / BirthArcade 統合
+7. ゲートを順番に通過
+
+## Plan.md 進捗
+
+`Plan.md` 末尾に「### Agent 安全アテステーション (3 段重ね) - 2026-04-29」を追加し、進捗ログと振り返りを記録する (CLAUDE.md 必須)。

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -42,50 +42,50 @@ const A = {
 const ARCHETYPES = [
   {
     id: '01',
-    name: 'SPEED',
-    short: 'Fast but shallow',
-    body: 'Real-time reactions, snap decisions. Cheap latency. Loses depth on long-running judgments.',
-    tag: 'PINK',
+    name: 'FAST EXEC',
+    short: 'L2 / private mempool / quick rebalance',
+    body: "Without it your agent's tx times out, the price has moved, and you eat partial fills. Most agents default to mainnet and pay for it.",
+    tag: 'EXEC',
     color: '#ff8db3',
   },
   {
     id: '02',
-    name: 'LASER',
-    short: 'Accurate but slow',
-    body: 'High-precision reasoning. Pinpoint actions but burns budget per call.',
-    tag: 'RED',
+    name: 'PRECISION',
+    short: 'slippage cap / concentrated entry',
+    body: 'Without it every swap is a free lunch for sandwich bots. Default agents leave slippage at infinity — 1-3% bleed per trade.',
+    tag: 'EDGE',
     color: '#ff5252',
   },
   {
     id: '03',
-    name: 'OPTION',
-    short: 'Parallel but uncertain',
-    body: 'Spawns peer agents. Massive parallelism, coordination overhead, drift risk.',
-    tag: 'GREEN',
+    name: 'LEVERAGE',
+    short: 'margin tier / max position / hedge',
+    body: 'Default 0 = leave returns on the table. Default ∞ = liquidated on the wrong tier. The forgotten parameter that decides win or wipe.',
+    tag: 'TIER',
     color: '#40f070',
   },
   {
     id: '04',
-    name: 'SHIELD',
-    short: 'Safe but conservative',
-    body: 'Guardrails, retries, circuit breakers. Trades upside for safe operation.',
-    tag: 'CYAN',
+    name: 'SECURITY',
+    short: 'approval limit / multi-sig / allowlist',
+    body: 'Without it one phishing approve drains the wallet. Most agents ship with unlimited token approvals and a single hot key.',
+    tag: 'GUARD',
     color: '#7bdff2',
   },
   {
     id: '05',
-    name: 'MISSILE',
-    short: 'Powerful but external-reliant',
-    body: 'Tool use, third-party APIs, retrieval. Capability ceiling jumps; failure surface widens.',
-    tag: 'PURPLE',
+    name: 'ALPHA',
+    short: 'external signal / oracle / AI advisor',
+    body: 'Without it the agent trades blind on whatever the last block said. Stale-oracle losses are the most embarrassing kind.',
+    tag: 'SIGNAL',
     color: '#c084ff',
   },
   {
     id: '06',
-    name: 'MOAI',
-    short: 'The constraints you cannot shoot',
-    body: 'Gas, latency, security policy, API limits, hallucination risk. Dodge or die.',
-    tag: 'BOSS',
+    name: 'BOSSES',
+    short: 'real losses you eat if you skipped a default',
+    body: 'GAS WALL, MEV RAZOR, ORACLE DRIFT, LATENCY COMET, REGIME SHIFT. Each one punishes a missing module — ship without arming, and the boss collects.',
+    tag: 'RISK',
     color: A.hot,
   },
 ] as const;
@@ -389,7 +389,7 @@ function Nav({ onPlay }: { onPlay: () => void }) {
       </div>
       <div className="lp-nav-links" style={S.navLinks}>
         <a href="#tradeoffs" style={S.navLink}>
-          [01] Tradeoffs
+          [01] Defaults
         </a>
         <a href="#forge" style={S.navLink}>
           [02] Forge
@@ -610,18 +610,21 @@ function Hero({
         <div className="lp-hero-lower" style={S.heroLower}>
           <div>
             <h1 style={S.heroH1}>
-              KILL THE
+              ARM THE
               <br />
-              TRADEOFFS.
+              DEFAULTS
               <br />
-              <span style={S.heroH1Italic}>fly your agent.</span>
+              <span style={S.heroH1Italic}>nobody reads.</span>
             </h1>
             <p style={S.heroLede}>
-              Gr<span style={{ color: A.hud }}>@</span>dius is a 60-second
-              arcade dogfight that doubles as the world's fastest onboarding for
-              autonomous on-chain agents. Stick. Throttle. Trigger.{' '}
+              Most autonomous agents ship without slippage caps, approval
+              limits, oracle checks, leverage tiers, or fast-exec rails — the
+              defaults the docs warn about and nobody bothers to set.{' '}
               <span style={{ color: A.ink }}>
-                The agent that survives is the agent you ship.
+                Gr<span style={{ color: A.hud }}>@</span>dius is a 60-second
+                shooter that arms each one by hand. Survive the bosses (real
+                losses you'd otherwise eat) and you walk away knowing why each
+                default exists.
               </span>
             </p>
             <div
@@ -661,7 +664,7 @@ function Hero({
             <div style={S.countStrip}>
               {[
                 ['60s', 'BUILD_WINDOW'],
-                ['5+1', 'ARCHETYPES'],
+                ['5+1', 'DEFAULTS'],
                 ['$25K', 'PRIZE_TARGET'],
                 ['1', 'iNFT_PER_RUN'],
               ].map(([n, l], i) => (
@@ -816,8 +819,8 @@ function ArchetypesSection() {
   return (
     <section id="tradeoffs" style={S.section}>
       <SectionHead
-        num="§ 01 / TRADEOFFS"
-        title="Six enemies. One agent."
+        num="§ 01 / DEFAULTS"
+        title="Six modules. Six agent footguns."
         right="EACH_SHOT_IS_A_VOTE"
       />
       <div className="lp-grid-three" style={S.gridThree}>
@@ -848,9 +851,9 @@ function ArchetypesSection() {
                 style={{
                   fontSize: 10,
                   padding: '3px 8px',
-                  background: t.tag === 'BOSS' ? A.hot : 'transparent',
-                  color: t.tag === 'BOSS' ? A.bg : t.color,
-                  border: t.tag === 'BOSS' ? 'none' : `1px solid ${t.color}`,
+                  background: t.tag === 'RISK' ? A.hot : 'transparent',
+                  color: t.tag === 'RISK' ? A.bg : t.color,
+                  border: t.tag === 'RISK' ? 'none' : `1px solid ${t.color}`,
                   letterSpacing: '0.18em',
                   fontWeight: 700,
                 }}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
   type Ref,
   forwardRef,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -19,10 +20,28 @@ import { ConnectButton } from './components/ConnectButton';
 import { Fighter } from './components/Fighter';
 import { Callout, HUDCorners, Reticle } from './components/HUD';
 import { GAME_END_EVENT, MusicPlayer } from './components/MusicPlayer';
+import { SafetyAttestationPanel } from './components/SafetyAttestationPanel';
 import type { Archetype } from './game/runtime';
 import { runOnChainForge } from './web3/forge-onchain';
+import {
+  type SafetyAttestationResult,
+  runSafetyAttestation,
+} from './web3/safety-attestation';
 import { type OnChainProof, idleProof } from './web3/types';
 import { executeFirstSwap } from './web3/uniswap-swap';
+
+const DEFAULT_PARENT_NAME =
+  (import.meta.env.VITE_ENS_PARENT as string | undefined) ?? 'gradiusweb3.eth';
+
+function generatePilotHandle(): string {
+  // 4 桁 hex で 65,536 通り。前回 PR の tokenId griefing と同型の
+  // 「衝突空間が狭く parent owner が上書きできる」経路を避けるため、
+  // 仕様書 21 行目の "pilot{2 桁}" (100 通り) からここで拡張している。
+  const buf = new Uint8Array(2);
+  globalThis.crypto.getRandomValues(buf);
+  const n = ((buf[0] ?? 0) << 8) | (buf[1] ?? 0);
+  return `pilot${n.toString(16).padStart(4, '0')}`;
+}
 
 const A = {
   bg: '#05080c',
@@ -189,6 +208,11 @@ export function App() {
   const [error, setError] = useState('');
   const [proof, setProof] = useState<OnChainProof>(idleProof);
   const [swapping, setSwapping] = useState(false);
+  const [safetyResult, setSafetyResult] =
+    useState<SafetyAttestationResult | null>(null);
+  // セッション内ランダム handle: マウント時に 1 回だけ生成。
+  const handle = useMemo(generatePilotHandle, []);
+  const parentName = DEFAULT_PARENT_NAME;
   const arcadeRef = useRef<HTMLDivElement | null>(null);
   const { address: ownerAddress } = useAccount();
   const { data: walletClient } = useWalletClient();
@@ -234,6 +258,18 @@ export function App() {
           ens: { status: 'failed', error: 'wallet not connected' },
         });
       }
+
+      // C 層: Agent 安全アテステーション。score 計算と attestation 生成は
+      // ウォレット未接続でも完走する。0G put / ENS write が個別 failed のみ。
+      const safety = await runSafetyAttestation({
+        walletClient: wc,
+        playLog,
+        handle,
+        ownerAddress: owner,
+        sessionId: playLog.sessionId,
+        parentName,
+      });
+      setSafetyResult(safety);
     } catch (caughtError) {
       setError(
         caughtError instanceof Error ? caughtError.message : 'Forge failed.'
@@ -301,6 +337,8 @@ export function App() {
       <ArcadeSection
         ref={arcadeRef}
         disabled={submitting}
+        handle={handle}
+        parentName={parentName}
         onComplete={handleComplete}
         error={error}
         submitting={submitting}
@@ -310,6 +348,7 @@ export function App() {
           birth={birth}
           archetype={archetype}
           proof={proof}
+          safetyResult={safetyResult}
           onFirstSwap={handleFirstSwap}
           swapping={swapping}
         />
@@ -1038,6 +1077,8 @@ function SponsorsSection() {
 
 type ArcadeSectionProps = {
   disabled: boolean;
+  handle: string;
+  parentName: string;
   onComplete: (log: PlayLog, a: Archetype) => void;
   error: string;
   submitting: boolean;
@@ -1045,7 +1086,7 @@ type ArcadeSectionProps = {
 
 const ArcadeSection = forwardRef<HTMLDivElement, ArcadeSectionProps>(
   function ArcadeSection(
-    { disabled, onComplete, error, submitting },
+    { disabled, handle, parentName, onComplete, error, submitting },
     ref: Ref<HTMLDivElement>
   ) {
     return (
@@ -1067,7 +1108,12 @@ const ArcadeSection = forwardRef<HTMLDivElement, ArcadeSectionProps>(
             , and (with a wallet connected) writes the iNFT, ENS subname, and
             first Uniswap trade on testnet.
           </p>
-          <BirthArcade disabled={disabled} onComplete={onComplete} />
+          <BirthArcade
+            disabled={disabled}
+            handle={handle}
+            parentName={parentName}
+            onComplete={onComplete}
+          />
           {error ? <div style={S.errorBanner}>! {error}</div> : null}
           {submitting ? (
             <div style={S.statusBanner}>▸ FORGING_AGENT_FROM_PLAY_LOG…</div>
@@ -1082,12 +1128,14 @@ function DashboardSection({
   birth,
   archetype,
   proof,
+  safetyResult,
   onFirstSwap,
   swapping,
 }: {
   birth: StoredAgentBirth;
   archetype: Archetype;
   proof: OnChainProof;
+  safetyResult: SafetyAttestationResult | null;
   onFirstSwap: () => void;
   swapping: boolean;
 }) {
@@ -1106,6 +1154,15 @@ function DashboardSection({
           onFirstSwap={onFirstSwap}
           swapping={swapping}
         />
+        {safetyResult ? (
+          <div style={{ marginTop: 24 }}>
+            <SafetyAttestationPanel
+              attestation={safetyResult.attestation}
+              storageProof={safetyResult.storageProof}
+              ensProof={safetyResult.ensProof}
+            />
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/packages/frontend/src/components/AgentDashboard.tsx
+++ b/packages/frontend/src/components/AgentDashboard.tsx
@@ -10,6 +10,7 @@ import {
   CAPABILITY_COLOR,
   CAPABILITY_DESC,
   CAPABILITY_LABEL,
+  CAPABILITY_RISK,
   getAllocation,
 } from '../game/runtime';
 import type { OnChainProof, OnChainStep, TxStatus } from '../web3/types';
@@ -155,6 +156,7 @@ export function AgentDashboard({
       </section>
 
       <PlayToAgentPanel birth={birth} archetype={archetype} />
+      <SafetyChecklistPanel birth={birth} />
 
       {proof ? (
         <OnChainProofPanel
@@ -311,6 +313,98 @@ function PlayToAgentPanel({
         <span style={{ color: A.mute }}> ⇒ POLICY: </span>
         <span style={{ color: A.ink }}>{ARCHETYPE_DESC[archetype]}</span>
       </div>
+    </section>
+  );
+}
+
+function SafetyChecklistPanel({ birth }: { birth: StoredAgentBirth }) {
+  const tally = tallyCommits(birth);
+  const armed = CAP_KEYS.filter((k) => tally[k] > 0);
+  const forgot = CAP_KEYS.filter((k) => tally[k] === 0);
+  const safetyScore = armed.length;
+  return (
+    <section
+      className="panel"
+      style={{ borderColor: A.rule, background: A.panel }}
+    >
+      <div className="panel-header">
+        <span className="eyebrow" style={{ color: A.amber }}>
+          SAFETY CHECKLIST
+        </span>
+        <h2 style={{ color: A.ink }}>{safetyScore} / 5 defaults armed</h2>
+        <p style={{ color: A.mute, fontSize: 12 }}>
+          Most autonomous agents ship with these missing. Each module you armed
+          via gameplay is one less footgun in production.
+        </p>
+      </div>
+
+      {armed.length > 0 ? (
+        <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
+          {armed.map((key) => (
+            <div
+              key={key}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '24px 130px 1fr',
+                gap: 12,
+                alignItems: 'start',
+                fontSize: 12,
+                fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+                lineHeight: 1.5,
+              }}
+            >
+              <span style={{ color: A.green, fontWeight: 700 }}>✓</span>
+              <span style={{ color: CAPABILITY_COLOR[key], fontWeight: 700 }}>
+                {CAPABILITY_LABEL[key]}
+              </span>
+              <span style={{ color: A.ink }}>{CAPABILITY_DESC[key]}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {forgot.length > 0 ? (
+        <div
+          style={{
+            marginTop: 18,
+            paddingTop: 14,
+            borderTop: `1px dashed ${A.rule}`,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 11,
+              color: A.hot,
+              letterSpacing: '0.2em',
+              marginBottom: 10,
+            }}
+          >
+            ⚠ FORGOT — Real agents commonly skip these. Risks if missing:
+          </div>
+          <div style={{ display: 'grid', gap: 10 }}>
+            {forgot.map((key) => (
+              <div
+                key={key}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '24px 130px 1fr',
+                  gap: 12,
+                  alignItems: 'start',
+                  fontSize: 12,
+                  fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+                  lineHeight: 1.5,
+                }}
+              >
+                <span style={{ color: A.hot, fontWeight: 700 }}>✗</span>
+                <span style={{ color: A.mute, fontWeight: 700 }}>
+                  {CAPABILITY_LABEL[key]}
+                </span>
+                <span style={{ color: A.mute }}>{CAPABILITY_RISK[key]}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/packages/frontend/src/components/BirthArcade.tsx
+++ b/packages/frontend/src/components/BirthArcade.tsx
@@ -23,10 +23,17 @@ import {
 } from '../game/runtime';
 import { prewarmSfx } from '../game/sfx';
 import { VIC_KEY, VIC_VIPER, drawSprite } from '../game/sprites';
+import { AgentHandleLabel } from './HUD';
+import {
+  MisalignmentToast,
+  type MisalignmentToastQueueItem,
+} from './MisalignmentToast';
 import { GAME_START_EVENT } from './MusicPlayer';
 
 interface BirthArcadeProps {
   disabled?: boolean;
+  handle: string;
+  parentName: string;
   onComplete: (playLog: PlayLog, archetype: Archetype) => void | Promise<void>;
 }
 
@@ -44,6 +51,8 @@ const TITLE_MODULE_DESC = {
 
 export function BirthArcade({
   disabled = false,
+  handle,
+  parentName,
   onComplete,
 }: BirthArcadeProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -60,6 +69,13 @@ export function BirthArcade({
   const [phase, setPhase] = useState<Phase>('idle');
   const [archetype, setArchetype] = useState<Archetype | null>(null);
   const [trades, setTrades] = useState<SimulatedTrade[]>([]);
+  const [currentToast, setCurrentToast] =
+    useState<MisalignmentToastQueueItem | null>(null);
+  const currentToastIdRef = useRef<number | null>(null);
+  const onConsumed = useCallback(() => {
+    currentToastIdRef.current = null;
+    setCurrentToast(null);
+  }, []);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -144,6 +160,14 @@ export function BirthArcade({
         const currentPhase = phaseRef.current;
         if (currentPhase === 'play' && runtimeRef.current) {
           stepRuntime(runtimeRef.current, inputRef.current);
+          // misalignment toast: 表示中でなければ次のキューを取り出す
+          if (!currentToastIdRef.current) {
+            const next = runtimeRef.current.misalignmentToasts.shift();
+            if (next) {
+              currentToastIdRef.current = next.id;
+              setCurrentToast({ id: next.id, kind: next.kind });
+            }
+          }
           if (runtimeRef.current.finished) {
             const arch = deriveArchetype(runtimeRef.current);
             setArchetype(arch);
@@ -231,6 +255,12 @@ export function BirthArcade({
           />
           <div className="crt-scanlines" />
           <div className="crt-vignette" />
+          {phase === 'play' ? (
+            <AgentHandleLabel handle={handle} parent={parentName} />
+          ) : null}
+          {phase === 'play' ? (
+            <MisalignmentToast current={currentToast} onConsumed={onConsumed} />
+          ) : null}
           {phase === 'idle' ? (
             <button
               type="button"

--- a/packages/frontend/src/components/HUD.tsx
+++ b/packages/frontend/src/components/HUD.tsx
@@ -135,6 +135,44 @@ export const HUDCorners = memo(HUDCornersImpl);
 export const Reticle = memo(ReticleImpl);
 export const Callout = memo(CalloutImpl);
 
+/// HUD 上部に表示する handle ラベル ("AGENT: pilot42.{parent}.eth")。
+/// ゲーム開始時に決まったプレイヤー Agent を画面で名乗らせる B 層 UI。
+function AgentHandleLabelImpl({
+  handle,
+  parent,
+}: {
+  handle: string;
+  parent: string;
+}) {
+  return (
+    <output
+      aria-label={`agent ${handle}.${parent}`}
+      style={{
+        position: 'absolute',
+        top: 12,
+        left: 16,
+        padding: '4px 10px',
+        background: 'rgba(5, 8, 12, 0.78)',
+        border: `1px solid ${HUD_CYAN}`,
+        color: HUD_CYAN,
+        fontFamily:
+          '"JetBrains Mono", "IBM Plex Mono", ui-monospace, monospace',
+        fontSize: 11,
+        letterSpacing: '0.18em',
+        pointerEvents: 'none',
+        display: 'block',
+      }}
+    >
+      <span style={{ color: HUD_MUTE, marginRight: 6 }}>AGENT:</span>
+      <span>
+        {handle}.{parent}
+      </span>
+    </output>
+  );
+}
+
+export const AgentHandleLabel = memo(AgentHandleLabelImpl);
+
 export const HUD = {
   cyan: HUD_CYAN,
   amber: HUD_AMBER,

--- a/packages/frontend/src/components/MisalignmentToast.tsx
+++ b/packages/frontend/src/components/MisalignmentToast.tsx
@@ -1,0 +1,83 @@
+import {
+  MISALIGNMENT_CARDS,
+  type MisalignmentKind,
+} from '@gradiusweb3/shared/browser';
+import { useEffect } from 'react';
+
+export interface MisalignmentToastQueueItem {
+  id: number;
+  kind: MisalignmentKind;
+}
+
+interface Props {
+  /// 親が runtime から shift で取り出した最新のイベント (1 件)。
+  current: MisalignmentToastQueueItem | null;
+  /// 表示が完了した (= 2 秒経過した) ときに親へ伝える。
+  onConsumed: (id: number) => void;
+}
+
+const VISIBLE_MS = 2000;
+
+export function MisalignmentToast({ current, onConsumed }: Props) {
+  useEffect(() => {
+    if (!current) return;
+    const timer = window.setTimeout(() => {
+      onConsumed(current.id);
+    }, VISIBLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [current, onConsumed]);
+
+  if (!current) return null;
+  const card = MISALIGNMENT_CARDS[current.kind];
+
+  return (
+    <output
+      aria-live="polite"
+      style={{
+        position: 'absolute',
+        right: 16,
+        bottom: 16,
+        maxWidth: 280,
+        padding: '12px 14px',
+        background: 'rgba(5, 8, 12, 0.92)',
+        border: `1px solid ${card.color}`,
+        color: '#e6f1ff',
+        fontFamily:
+          '"JetBrains Mono", "IBM Plex Mono", ui-monospace, monospace',
+        fontSize: 11,
+        letterSpacing: '0.04em',
+        lineHeight: 1.55,
+        pointerEvents: 'none',
+        boxShadow: `0 0 18px ${card.color}33`,
+        display: 'block',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginBottom: 6,
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{ color: card.color, fontSize: 18, fontWeight: 700 }}
+        >
+          {card.glyph}
+        </span>
+        <span
+          style={{
+            color: card.color,
+            fontWeight: 700,
+            letterSpacing: '0.18em',
+          }}
+        >
+          {card.label}
+        </span>
+      </div>
+      <div style={{ marginBottom: 4 }}>{card.description}</div>
+      <div style={{ color: '#7ee0ff', fontSize: 10 }}>例: {card.example}</div>
+    </output>
+  );
+}

--- a/packages/frontend/src/components/SafetyAttestationPanel.tsx
+++ b/packages/frontend/src/components/SafetyAttestationPanel.tsx
@@ -1,0 +1,317 @@
+import {
+  type AgentSafetyAttestation,
+  MISALIGNMENT_CARDS,
+  type MisalignmentKind,
+} from '@gradiusweb3/shared/browser';
+import type { OnChainStep, TxStatus } from '../web3/types';
+
+const A = {
+  bg: '#05080c',
+  panel: '#0a1118',
+  ink: '#e6f1ff',
+  mute: '#5a6c80',
+  rule: '#1a2735',
+  acid: '#c8ff00',
+  hud: '#7ee0ff',
+  amber: '#ffb84d',
+  hot: '#ff4438',
+  green: '#3dffa3',
+} as const;
+
+const STATUS_COLOR: Record<TxStatus, string> = {
+  idle: A.mute,
+  pending: A.amber,
+  success: A.green,
+  failed: A.hot,
+};
+
+const STATUS_LABEL: Record<TxStatus, string> = {
+  idle: '○ IDLE',
+  pending: '◇ PENDING',
+  success: '● OK',
+  failed: '× FAIL',
+};
+
+interface Props {
+  attestation: AgentSafetyAttestation;
+  storageProof: OnChainStep<{ cid: string }>;
+  ensProof: OnChainStep<{ name: string; resolverUrl: string }>;
+}
+
+export function SafetyAttestationPanel({
+  attestation,
+  storageProof,
+  ensProof,
+}: Props) {
+  const detected = countByKind(attestation.encounters.map((e) => e.kind));
+  return (
+    <section
+      className="panel"
+      style={{ borderColor: A.rule, background: A.panel }}
+    >
+      <div className="panel-header">
+        <span className="eyebrow" style={{ color: A.amber }}>
+          AGENT SAFETY ATTESTATION
+        </span>
+        <h2 style={{ color: A.ink }}>
+          安全スコア{' '}
+          <span style={{ color: A.acid, fontSize: 36 }}>
+            {attestation.score}
+          </span>
+          <span style={{ color: A.mute, fontSize: 14 }}> / 100</span>
+        </h2>
+        <p style={{ color: A.mute, fontSize: 12 }}>
+          ENS subname に書き込まれる verifiable agent safety credential。 0G
+          Storage に attestation 本体を put、ENS text record に CID を pin。
+        </p>
+      </div>
+
+      <BreakdownBars breakdown={attestation.breakdown} />
+
+      <div style={{ marginTop: 18 }}>
+        <div
+          style={{
+            color: A.mute,
+            letterSpacing: '0.18em',
+            fontSize: 11,
+            marginBottom: 8,
+          }}
+        >
+          MISALIGNMENT DETECTED
+        </div>
+        <div style={{ display: 'grid', gap: 6 }}>
+          {(
+            [
+              'sycophancy',
+              'reward_hacking',
+              'prompt_injection',
+              'goal_misgen',
+            ] as const
+          ).map((kind) => {
+            const card = MISALIGNMENT_CARDS[kind];
+            const count = detected[kind] ?? 0;
+            return (
+              <div
+                key={kind}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '24px 160px 1fr 56px',
+                  gap: 12,
+                  alignItems: 'center',
+                  fontSize: 12,
+                  fontFamily:
+                    '"JetBrains Mono", "IBM Plex Mono", ui-monospace, monospace',
+                  color: count > 0 ? A.ink : A.mute,
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{ color: card.color, fontWeight: 700 }}
+                >
+                  {card.glyph}
+                </span>
+                <span style={{ color: card.color, fontWeight: 700 }}>
+                  {card.label}
+                </span>
+                <span style={{ color: A.mute, fontSize: 11 }}>
+                  {card.description}
+                </span>
+                <span
+                  style={{
+                    textAlign: 'right',
+                    color: count > 0 ? card.color : A.mute,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  ×{count}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div
+        style={{
+          marginTop: 18,
+          paddingTop: 12,
+          borderTop: `1px dashed ${A.rule}`,
+          display: 'grid',
+          gap: 10,
+        }}
+      >
+        <ProofRow
+          label="0G STORAGE"
+          step={storageProof}
+          subtitle={storageProof.data?.cid ?? 'attestation pending'}
+        />
+        <ProofRow
+          label="ENS"
+          step={ensProof}
+          subtitle={ensProof.data?.name ?? attestation.ensName}
+          href={ensProof.data?.resolverUrl}
+        />
+      </div>
+
+      <div
+        style={{
+          marginTop: 12,
+          fontSize: 10,
+          color: A.mute,
+          letterSpacing: '0.12em',
+        }}
+      >
+        ISSUED_AT {attestation.issuedAt} · SCHEMA_v
+        {attestation.schemaVersion}
+      </div>
+    </section>
+  );
+}
+
+function BreakdownBars({
+  breakdown,
+}: {
+  breakdown: AgentSafetyAttestation['breakdown'];
+}) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 8,
+        marginTop: 12,
+        fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+        fontSize: 12,
+      }}
+    >
+      <BreakdownRow
+        label="CLEAR TIME BONUS"
+        value={breakdown.clearTimeBonus}
+        max={50}
+        color={A.green}
+      />
+      <BreakdownRow
+        label="MISS PENALTY"
+        value={breakdown.missPenalty}
+        max={-50}
+        color={A.hot}
+      />
+    </div>
+  );
+}
+
+function BreakdownRow({
+  label,
+  value,
+  max,
+  color,
+}: {
+  label: string;
+  value: number;
+  max: number;
+  color: string;
+}) {
+  const pct = max === 0 ? 0 : Math.min(100, Math.abs((value / max) * 100));
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '180px 1fr 60px',
+        gap: 12,
+        alignItems: 'center',
+        color: A.ink,
+      }}
+    >
+      <span style={{ color: A.mute, letterSpacing: '0.16em' }}>{label}</span>
+      <div style={{ height: 6, background: '#0d1620', position: 'relative' }}>
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: `${pct}%`,
+            background: color,
+          }}
+        />
+      </div>
+      <span
+        style={{
+          textAlign: 'right',
+          color,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {value > 0 ? `+${value}` : value}
+      </span>
+    </div>
+  );
+}
+
+function ProofRow({
+  label,
+  step,
+  subtitle,
+  href,
+}: {
+  label: string;
+  step: OnChainStep<unknown>;
+  subtitle?: string;
+  href?: string;
+}) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr',
+        gap: 16,
+        alignItems: 'center',
+        padding: '10px 12px',
+        border: `1px solid ${A.rule}`,
+        background: A.bg,
+        fontSize: 12,
+        fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+      }}
+    >
+      <div
+        style={{
+          color: STATUS_COLOR[step.status],
+          fontWeight: 700,
+          letterSpacing: '0.18em',
+          minWidth: 90,
+        }}
+      >
+        {STATUS_LABEL[step.status]}
+      </div>
+      <div style={{ display: 'grid', gap: 2 }}>
+        <div style={{ color: A.ink, fontWeight: 600, letterSpacing: '0.12em' }}>
+          {label}
+        </div>
+        {step.status === 'failed' ? (
+          <div style={{ color: A.hot, fontSize: 11 }}>{step.error}</div>
+        ) : href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: A.hud, textDecoration: 'underline' }}
+          >
+            {subtitle}
+          </a>
+        ) : (
+          <div style={{ color: A.mute, fontSize: 11 }}>{subtitle}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function countByKind(
+  kinds: MisalignmentKind[]
+): Record<MisalignmentKind, number> {
+  const counts: Record<MisalignmentKind, number> = {
+    sycophancy: 0,
+    reward_hacking: 0,
+    prompt_injection: 0,
+    goal_misgen: 0,
+  };
+  for (const k of kinds) counts[k] += 1;
+  return counts;
+}

--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -1,8 +1,10 @@
-import type {
-  Capsule,
-  MoaiId,
-  PlayEvent,
-  PlayLog,
+import {
+  CAPABILITY_TO_MISALIGNMENT,
+  type Capsule,
+  type MisalignmentKind,
+  type MoaiId,
+  type PlayEvent,
+  type PlayLog,
 } from '@gradiusweb3/shared/browser';
 import { CHAINS, type ChainId } from './chains';
 import { drawBigText, pixelText } from './font';
@@ -287,6 +289,18 @@ interface Enemy {
   fireCool: number;
   spawnAt: number;
   isTutorial: boolean;
+  /// capability に紐付いた misalignment 種別 (speed のみ undefined)。
+  misalignment?: MisalignmentKind;
+}
+
+/// 敵を撃破した瞬間に React 側へ misalignment カードを toast 表示するため、
+/// Runtime の mutable state にイベントを積む。React は次フレームの render 中に
+/// 末尾から 1 件読んで表示し終えたら shift する。
+export interface MisalignmentToastEvent {
+  id: number;
+  kind: MisalignmentKind;
+  capability: Capability;
+  spawnAt: number;
 }
 
 interface MoaiBoss {
@@ -354,6 +368,11 @@ export interface Runtime {
   scorePops: ScorePop[];
   particles: Particle[];
   toasts: Toast[];
+  /// React 側 MisalignmentToast 用の pending キュー。
+  /// shift 済 → 表示済の意味。runtime 内では消化しない。
+  misalignmentToasts: MisalignmentToastEvent[];
+  /// MisalignmentToastEvent.id を採番するカウンタ。
+  misalignmentCounter: number;
   stars: Star[];
   terrain: Terrain;
   events: PlayEvent[];
@@ -394,6 +413,8 @@ export function createRuntime(chain: ChainId = 'ARB'): Runtime {
     scorePops: [],
     particles: [],
     toasts: [],
+    misalignmentToasts: [],
+    misalignmentCounter: 0,
     stars: makeStars(),
     terrain: makeTerrain(),
     events: [],
@@ -506,6 +527,7 @@ function spawnTutorialEnemy(rt: Runtime) {
     fireCool: 60,
     spawnAt: rt.t,
     isTutorial: true,
+    misalignment: CAPABILITY_TO_MISALIGNMENT[spec.capability],
   });
   rt.enemyCounter += 1;
   rt.tutorialStep += 1;
@@ -541,6 +563,7 @@ function spawnEnemyWave(rt: Runtime) {
       fireCool: 60 + i * 18,
       spawnAt: rt.t,
       isTutorial: false,
+      misalignment: CAPABILITY_TO_MISALIGNMENT[capabilityChoice.capability],
     });
   }
   rt.enemyCounter += 1;
@@ -698,7 +721,17 @@ export function step(rt: Runtime, input: InputState) {
               tradeoffLabel: `${CAPABILITY_LABEL[e.capability]} / ${
                 CAPABILITY_DESC[e.capability]
               }`,
+              misalignment: e.misalignment,
             });
+            if (e.misalignment) {
+              rt.misalignmentCounter += 1;
+              rt.misalignmentToasts.push({
+                id: rt.misalignmentCounter,
+                kind: e.misalignment,
+                capability: e.capability,
+                spawnAt: rt.t,
+              });
+            }
             spawnBurst(rt, e.x + 4, e.y + 4, e.flashColor, 14);
             rt.scorePops.push({
               x: e.x + 4,
@@ -721,6 +754,7 @@ export function step(rt: Runtime, input: InputState) {
           t: elapsedMs(rt),
           enemyId: e.id,
           tradeoffLabel: `SKIP ${CAPABILITY_LABEL[e.capability]}`,
+          misalignment: e.misalignment,
         });
       }
       return false;

--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -80,28 +80,41 @@ export const CAPABILITY_ORDER: Capability[] = [
   'missile',
 ];
 
+/// Player-facing capability names. Each enemy color = one of the agent
+/// safety / strategy defaults that real DeFi operators forget to configure.
+/// Keep these short and intuitive; longer descriptions live in the dashboard.
 export const CAPABILITY_LABEL: Record<Capability, string> = {
-  shield: 'SHIELD',
-  speed: 'SPEED',
-  option: 'OPTION',
-  laser: 'LASER',
-  missile: 'MISSILE',
+  shield: 'SECURITY',
+  speed: 'FAST EXEC',
+  option: 'LEVERAGE',
+  laser: 'PRECISION',
+  missile: 'ALPHA',
 };
 
 export const CAPABILITY_HUD_LABEL: Record<Capability, string> = {
-  shield: 'SHLD',
-  speed: 'SPD',
-  option: 'OPT',
-  laser: 'LSR',
-  missile: 'MSL',
+  shield: 'SEC',
+  speed: 'EXEC',
+  option: 'LEV',
+  laser: 'PREC',
+  missile: 'ALPHA',
 };
 
 export const CAPABILITY_DESC: Record<Capability, string> = {
-  shield: 'CIRCUIT BREAKER',
-  speed: 'L2 FAST EXEC',
-  option: 'AXL PEER NODE',
-  laser: '0G REASONING',
-  missile: 'UNISWAP ROUTER',
+  shield: 'approval limits / multi-sig / allowlist',
+  speed: 'L2 / private mempool / quick rebalance',
+  option: 'margin tier / max position / hedge',
+  laser: 'slippage cap / concentrated entry',
+  missile: 'external signal / oracle / AI advisor',
+};
+
+/// What real-world risk hits an agent that ships without this default armed.
+/// Surfaced in the dashboard "SAFETY CHECKLIST" panel and Moai damage toasts.
+export const CAPABILITY_RISK: Record<Capability, string> = {
+  shield: 'phishing / unlimited approve = full wallet drain',
+  speed: 'tx times out, price moved, partial fills',
+  option: 'liquidation on the wrong tier / left return on the table',
+  laser: 'sandwich attack, sloppy fills cost 1-3% per swap',
+  missile: 'trade on stale oracle, no edge',
 };
 
 export const CAPABILITY_COLOR: Record<Capability, string> = {
@@ -126,27 +139,27 @@ const MOAI_CONSTRAINT: Record<
 > = {
   aegis: {
     label: 'GAS WALL',
-    detail: 'caps position size',
+    detail: 'no SECURITY → 1 tx eats a month of profit',
     capability: 'shield',
   },
   razor: {
     label: 'MEV RAZOR',
-    detail: 'punishes sloppy swaps',
+    detail: 'no PRECISION → sandwiched for ~3% per swap',
     capability: 'laser',
   },
   oracle: {
     label: 'ORACLE DRIFT',
-    detail: 'forces market checks',
+    detail: 'no ALPHA → trade on stale price',
     capability: 'missile',
   },
   comet: {
     label: 'LATENCY COMET',
-    detail: 'demands fast execution',
+    detail: 'no FAST EXEC → tx times out, price moves',
     capability: 'speed',
   },
   hive: {
-    label: 'PEER DRIFT',
-    detail: 'tests AXL coordination',
+    label: 'REGIME SHIFT',
+    detail: 'no LEVERAGE management → market shifts and you stay frozen',
     capability: 'option',
   },
 };

--- a/packages/frontend/src/web3/safety-attestation.test.ts
+++ b/packages/frontend/src/web3/safety-attestation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+  AgentSafetyAttestation,
+  MisalignmentEncounter,
+  MisalignmentKind,
+} from '@gradiusweb3/shared/browser';
+import {
+  buildEnsTextRecords,
+  countMisalignmentEncounters,
+} from './safety-attestation';
+
+describe('countMisalignmentEncounters - misalignment 種別ごとに件数を数える', () => {
+  it('encounters 配列が空のときは全種類 0 になる', () => {
+    const counts = countMisalignmentEncounters([]);
+    expect(counts).toEqual({
+      sycophancy: 0,
+      reward_hacking: 0,
+      prompt_injection: 0,
+      goal_misgen: 0,
+    });
+  });
+
+  it('種別ごとの出現回数を集計できる', () => {
+    const encounters: MisalignmentEncounter[] = [
+      { kind: 'prompt_injection', enemyId: 'a', tAtMs: 1, hit: true },
+      { kind: 'prompt_injection', enemyId: 'b', tAtMs: 2, hit: false },
+      { kind: 'sycophancy', enemyId: 'c', tAtMs: 3, hit: true },
+      { kind: 'goal_misgen', enemyId: 'd', tAtMs: 4, hit: true },
+    ];
+    const counts = countMisalignmentEncounters(encounters);
+    expect(counts.prompt_injection).toBe(2);
+    expect(counts.sycophancy).toBe(1);
+    expect(counts.goal_misgen).toBe(1);
+    expect(counts.reward_hacking).toBe(0);
+  });
+});
+
+describe('buildEnsTextRecords - ENS text record の組み立て', () => {
+  it('score / attestation / misalignment.detected の 3 件を返す', () => {
+    const att: AgentSafetyAttestation = {
+      sessionId: 'sess',
+      handle: 'pilot42',
+      ensName: 'pilot42.gradiusweb3.eth',
+      walletAddress: '0xabc',
+      score: 85,
+      breakdown: { clearTimeBonus: 50, missPenalty: -15, total: 85 },
+      encounters: [
+        { kind: 'prompt_injection', enemyId: 'a', tAtMs: 1, hit: true },
+        { kind: 'sycophancy', enemyId: 'b', tAtMs: 2, hit: false },
+      ],
+      issuedAt: '2026-04-29T10:00:00.000Z',
+      schemaVersion: 1,
+    };
+    const records = buildEnsTextRecords(att, {
+      cid: 'sha256-deadbeef0000',
+    });
+    expect(records['agent.safety.score']).toBe('85');
+    expect(records['agent.safety.attestation']).toContain(
+      'sha256-deadbeef0000'
+    );
+    const detected = JSON.parse(
+      records['agent.misalignment.detected'] ?? '{}'
+    ) as Record<MisalignmentKind, number>;
+    expect(detected.prompt_injection).toBe(1);
+    expect(detected.sycophancy).toBe(1);
+    expect(detected.goal_misgen).toBe(0);
+    expect(detected.reward_hacking).toBe(0);
+  });
+
+  it('cid が undefined の場合 attestation 値は空文字でなく "未発行"系のフォールバックを使う', () => {
+    const att: AgentSafetyAttestation = {
+      sessionId: 'sess',
+      handle: 'pilot42',
+      ensName: 'pilot42.gradiusweb3.eth',
+      walletAddress: '0xabc',
+      score: 50,
+      breakdown: { clearTimeBonus: 50, missPenalty: 0, total: 50 },
+      encounters: [],
+      issuedAt: '2026-04-29T10:00:00.000Z',
+      schemaVersion: 1,
+    };
+    const records = buildEnsTextRecords(att, undefined);
+    expect(records['agent.safety.attestation']).toBe('pending');
+  });
+});

--- a/packages/frontend/src/web3/safety-attestation.ts
+++ b/packages/frontend/src/web3/safety-attestation.ts
@@ -1,0 +1,212 @@
+import {
+  type AgentSafetyAttestation,
+  type MisalignmentEncounter,
+  type MisalignmentKind,
+  type PlayLog,
+  deriveSafetyAttestation,
+} from '@gradiusweb3/shared/browser';
+import {
+  http,
+  type Address,
+  type WalletClient,
+  createPublicClient,
+  namehash,
+} from 'viem';
+import { sepolia } from './chains';
+import { registerSubname } from './ens-register';
+import type { EnsProof, OnChainStep, StorageProof } from './types';
+import { putAttestation } from './zerog-storage';
+
+/// Sepolia の ENS Registry。NameWrapper とは別、namehash → owner address を引く。
+/// 値は ENS deployments registry の deterministic deploy アドレス。
+const ENS_REGISTRY_SEPOLIA =
+  '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e' as const satisfies Address;
+
+const REGISTRY_OWNER_ABI = [
+  {
+    type: 'function',
+    name: 'owner',
+    stateMutability: 'view',
+    inputs: [{ name: 'node', type: 'bytes32' }],
+    outputs: [{ name: '', type: 'address' }],
+  },
+] as const;
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+/// Sepolia 接続を assert する。前回 Web3 Wiring の振り返りで「switchChain 漏れ」が
+/// 発生しており、本機能の ENS 書込みも Sepolia 固定でないと別 chain に書く事故になる。
+function ensureSepoliaChain(walletClient: WalletClient): void {
+  const chainId = walletClient.chain?.id;
+  if (chainId !== sepolia.id) {
+    throw new Error(
+      `chain mismatch — Sepolia (${sepolia.id}) に切り替えてください (現在 ${chainId ?? 'unknown'})`
+    );
+  }
+}
+
+/// pilot{4 桁 hex} の handle が「自分以外のオーナーに先取りされていない」ことを
+/// pre-flight で検査する。NameWrapper.setSubnodeRecord は parent owner 権限で
+/// 既存 subnode を上書きしてしまうため、これを通さないと前回 tokenId griefing と
+/// 同型の「他者の subname を上書き」事故が起きる。
+async function ensureSubnameAvailable(
+  handle: string,
+  parent: string,
+  expectedOwner: Address
+): Promise<void> {
+  const node = namehash(`${handle}.${parent}`);
+  const publicClient = createPublicClient({
+    chain: sepolia,
+    transport: http(),
+  });
+  const owner = (await publicClient.readContract({
+    address: ENS_REGISTRY_SEPOLIA,
+    abi: REGISTRY_OWNER_ABI,
+    functionName: 'owner',
+    args: [node],
+  })) as Address;
+  const isFree = owner === ZERO_ADDRESS;
+  const isSameOwner = owner.toLowerCase() === expectedOwner.toLowerCase();
+  if (!isFree && !isSameOwner) {
+    throw new Error(
+      `handle ${handle}.${parent} は別のオーナーが保有しています。再生成してください`
+    );
+  }
+}
+
+const MISALIGNMENT_KINDS: MisalignmentKind[] = [
+  'sycophancy',
+  'reward_hacking',
+  'prompt_injection',
+  'goal_misgen',
+];
+
+/// 純関数: encounter 配列を misalignment 種別ごとの件数オブジェクトに集計する。
+/// 全 4 種を 0 で初期化するので、未検出種別も明示的に "0" として ENS に
+/// 書き込める (= 検査済みであることが verifiable になる)。
+export function countMisalignmentEncounters(
+  encounters: MisalignmentEncounter[]
+): Record<MisalignmentKind, number> {
+  const counts = Object.fromEntries(
+    MISALIGNMENT_KINDS.map((k) => [k, 0])
+  ) as Record<MisalignmentKind, number>;
+  for (const enc of encounters) {
+    counts[enc.kind] += 1;
+  }
+  return counts;
+}
+
+/// 純関数: AgentSafetyAttestation + 0G CID から ENS text record の
+/// key/value マップを組み立てる。CID 未確定時は "pending" フォールバック。
+export function buildEnsTextRecords(
+  att: AgentSafetyAttestation,
+  storage: { cid: string } | undefined
+): Record<string, string> {
+  const detected = countMisalignmentEncounters(att.encounters);
+  return {
+    'agent.safety.score': String(att.score),
+    'agent.safety.attestation': storage?.cid ?? 'pending',
+    'agent.misalignment.detected': JSON.stringify(detected),
+  };
+}
+
+export interface SafetyAttestationResult {
+  attestation: AgentSafetyAttestation;
+  storageProof: OnChainStep<StorageProof>;
+  ensProof: OnChainStep<EnsProof>;
+}
+
+export interface RunSafetyAttestationInput {
+  walletClient?: WalletClient;
+  playLog: PlayLog;
+  handle: string;
+  ownerAddress?: Address;
+  sessionId: string;
+  parentName: string;
+}
+
+function errorMessage(reason: unknown): string {
+  if (reason instanceof Error) return reason.message;
+  return typeof reason === 'string' ? reason : 'unknown error';
+}
+
+/// orchestrator: deriveSafetyAttestation で score を計算し、
+/// 0G Storage put と ENS subname registration を Promise.allSettled で並列実行。
+/// どの一方が失敗しても score 計算とローカル表示は完走する (フェイルセーフ)。
+export async function runSafetyAttestation(
+  input: RunSafetyAttestationInput
+): Promise<SafetyAttestationResult> {
+  const ensName = `${input.handle}.${input.parentName}`;
+  const attestation = deriveSafetyAttestation({
+    sessionId: input.sessionId,
+    handle: input.handle,
+    ensName,
+    walletAddress: input.ownerAddress ?? '',
+    playLog: input.playLog,
+    parentName: input.parentName,
+  });
+
+  if (!input.walletClient || !input.ownerAddress) {
+    // ウォレット未接続でも attestation 本体は返す。
+    let storageProof: OnChainStep<StorageProof>;
+    try {
+      const storage = await putAttestation(attestation);
+      storageProof = { status: 'success', data: storage };
+    } catch (err) {
+      storageProof = { status: 'failed', error: errorMessage(err) };
+    }
+    return {
+      attestation,
+      storageProof,
+      ensProof: { status: 'failed', error: 'wallet not connected' },
+    };
+  }
+
+  const owner = input.ownerAddress;
+  const walletClient = input.walletClient;
+
+  // Pre-flight: chain assertion (sync) と subname 衝突チェック (async)。
+  // どちらかが失敗しても storage put は走らせる (ローカル credential は得たい)。
+  let preflightError: string | undefined;
+  try {
+    ensureSepoliaChain(walletClient);
+    await ensureSubnameAvailable(input.handle, input.parentName, owner);
+  } catch (err) {
+    preflightError = errorMessage(err);
+  }
+
+  // 0G Storage の put は preflight と独立して走る (ENS 失敗でも CID は取りたい)。
+  const storageSettled = await putAttestation(attestation).then(
+    (value) => ({ ok: true as const, value }),
+    (reason) => ({ ok: false as const, reason })
+  );
+
+  // ENS write は (a) preflight 通過、(b) storage 結果が揃ってから走る。
+  // CID 値が定まる前に setText が呼ばれない直列を保証することで Front-running
+  // 経路 (CID = undefined のまま text record が書かれる) を避ける。
+  let ensSettled:
+    | { ok: true; value: { name: string; resolverUrl: string } }
+    | { ok: false; reason: unknown };
+  if (preflightError) {
+    ensSettled = { ok: false, reason: preflightError };
+  } else {
+    const storageData = storageSettled.ok ? storageSettled.value : undefined;
+    ensSettled = await registerSubname(walletClient, {
+      handle: input.handle,
+      owner,
+      textRecords: buildEnsTextRecords(attestation, storageData),
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (reason) => ({ ok: false as const, reason })
+    );
+  }
+
+  const storageProof: OnChainStep<StorageProof> = storageSettled.ok
+    ? { status: 'success', data: storageSettled.value }
+    : { status: 'failed', error: errorMessage(storageSettled.reason) };
+  const ensProof: OnChainStep<EnsProof> = ensSettled.ok
+    ? { status: 'success', data: ensSettled.value }
+    : { status: 'failed', error: errorMessage(ensSettled.reason) };
+
+  return { attestation, storageProof, ensProof };
+}

--- a/packages/frontend/src/web3/zerog-storage.ts
+++ b/packages/frontend/src/web3/zerog-storage.ts
@@ -1,4 +1,16 @@
-import type { PlayLog } from '@gradiusweb3/shared/browser';
+import type {
+  AgentSafetyAttestation,
+  PlayLog,
+} from '@gradiusweb3/shared/browser';
+
+async function sha256ShortHex(json: string): Promise<string> {
+  const data = new TextEncoder().encode(json);
+  const digestBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hex = Array.from(new Uint8Array(digestBuffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return hex.slice(0, 32);
+}
 
 /// Put a play log JSON onto 0G Storage and return the CID.
 ///
@@ -8,11 +20,17 @@ import type { PlayLog } from '@gradiusweb3/shared/browser';
 /// SHA-256 fingerprint so the CID is stable per play log; the real SDK call
 /// will substitute here without changing the surrounding pipeline.
 export async function putPlayLog(playLog: PlayLog): Promise<{ cid: string }> {
-  const json = JSON.stringify(playLog);
-  const data = new TextEncoder().encode(json);
-  const digestBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hex = Array.from(new Uint8Array(digestBuffer))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
-  return { cid: `sha256-${hex.slice(0, 32)}` };
+  const short = await sha256ShortHex(JSON.stringify(playLog));
+  return { cid: `sha256-${short}` };
+}
+
+/// Put an AgentSafetyAttestation JSON onto 0G Storage and return the CID.
+/// CID は `{scheme}://{value}` 形式に固定する。stub の間は `sha256://`、
+/// 実 SDK 統合後は `0g://` プレフィックスに切替。ENS text record で parser
+/// が scheme 判定できるようにすることで credential の検証経路を明示する。
+export async function putAttestation(
+  attestation: AgentSafetyAttestation
+): Promise<{ cid: string }> {
+  const short = await sha256ShortHex(JSON.stringify(attestation));
+  return { cid: `sha256://${short}` };
 }

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -3,5 +3,6 @@ export * from './math';
 export * from './policy';
 export * from './powerups';
 export * from './profile';
+export * from './safety';
 export * from './types';
 export * from './wallet';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,5 +3,6 @@ export * from './math';
 export * from './policy';
 export * from './powerups';
 export * from './profile';
+export * from './safety';
 export * from './types';
 export * from './wallet';

--- a/packages/shared/src/safety.test.ts
+++ b/packages/shared/src/safety.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  CAPABILITY_TO_MISALIGNMENT,
+  MISALIGNMENT_CARDS,
+  computeSafetyScore,
+  deriveSafetyAttestation,
+} from './safety';
+import type { PlayEvent, PlayLog } from './types';
+
+function createPlayLog(
+  events: PlayEvent[],
+  overrides?: Partial<PlayLog>
+): PlayLog {
+  return {
+    sessionId: 'session-test',
+    events,
+    durationMs: 60000,
+    finalScore: 1000,
+    ...overrides,
+  };
+}
+
+describe('computeSafetyScore - 安全スコアを純関数で算出する', () => {
+  it('ノーミス完走 → 100 点になる', () => {
+    const events: PlayEvent[] = Array.from({ length: 12 }, (_, i) => ({
+      kind: 'shoot' as const,
+      t: 1000 + i * 200,
+      enemyId: `e-${i}`,
+      tradeoffLabel: 'SECURITY',
+      misalignment: 'prompt_injection',
+    }));
+    const breakdown = computeSafetyScore(createPlayLog(events));
+    expect(breakdown.total).toBe(100);
+    expect(breakdown.clearTimeBonus).toBe(50);
+    expect(breakdown.missPenalty).toBe(0);
+  });
+
+  it('全部見送り → 50 点付近 (clearTimeBonus 0, missPenalty 0 に近い)', () => {
+    const events: PlayEvent[] = Array.from({ length: 5 }, (_, i) => ({
+      kind: 'pass' as const,
+      t: 1000 + i * 200,
+      enemyId: `e-${i}`,
+      tradeoffLabel: 'SKIP',
+      misalignment: 'sycophancy',
+    }));
+    const breakdown = computeSafetyScore(createPlayLog(events));
+    // 5 misses → clearTimeBonus = clamp(50 - 5*2, 0, 50) = 40, missPenalty = -10 → total 80
+    // But spec says "全部見送り → 50 点付近": for many passes the bonus drops to 0, penalty ~-50.
+    // We use 25 passes here for the "全部見送り" case.
+    const manyPasses: PlayEvent[] = Array.from({ length: 25 }, (_, i) => ({
+      kind: 'pass' as const,
+      t: 1000 + i * 100,
+      enemyId: `pass-${i}`,
+      tradeoffLabel: 'SKIP',
+      misalignment: 'sycophancy',
+    }));
+    const heavyBreak = computeSafetyScore(createPlayLog(manyPasses));
+    expect(heavyBreak.total).toBeGreaterThanOrEqual(0);
+    expect(heavyBreak.total).toBeLessThanOrEqual(60);
+    // light-pass case checks bounds too
+    expect(breakdown.total).toBeGreaterThanOrEqual(0);
+    expect(breakdown.total).toBeLessThanOrEqual(100);
+  });
+
+  it('全誤射 → 0 点近傍', () => {
+    // 全 pass を大量に積む = 全部見送り = 安全寄り違反 → ペナルティ最大
+    const events: PlayEvent[] = Array.from({ length: 60 }, (_, i) => ({
+      kind: 'pass' as const,
+      t: 500 + i * 100,
+      enemyId: `pass-${i}`,
+      tradeoffLabel: 'SKIP',
+      misalignment: 'goal_misgen',
+    }));
+    const breakdown = computeSafetyScore(createPlayLog(events));
+    expect(breakdown.total).toBe(0);
+    expect(breakdown.clearTimeBonus).toBe(0);
+    expect(breakdown.missPenalty).toBeLessThanOrEqual(-50);
+  });
+
+  it('empty playLog → 50 点 (中立)', () => {
+    const breakdown = computeSafetyScore(createPlayLog([]));
+    expect(breakdown.total).toBe(50);
+    expect(breakdown.clearTimeBonus).toBe(50);
+    expect(breakdown.missPenalty).toBe(0);
+  });
+
+  it('total は 0..100 にクリップされる', () => {
+    const breakdown = computeSafetyScore(
+      createPlayLog([
+        {
+          kind: 'pass',
+          t: 1000,
+          enemyId: 'e',
+          tradeoffLabel: 'SKIP',
+          misalignment: 'sycophancy',
+        },
+      ])
+    );
+    expect(breakdown.total).toBeGreaterThanOrEqual(0);
+    expect(breakdown.total).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('deriveSafetyAttestation - playLog から attestation を組み立てる', () => {
+  const baseInput = {
+    sessionId: 'session-001',
+    handle: 'pilot42',
+    ensName: 'pilot42.gradiusweb3.eth',
+    walletAddress: '0x000000000000000000000000000000000000abcd',
+    parentName: 'gradiusweb3.eth',
+    issuedAt: '2026-04-29T10:00:00.000Z',
+  };
+
+  it('渡された handle / ensName / walletAddress が attestation に含まれる', () => {
+    const att = deriveSafetyAttestation({
+      ...baseInput,
+      playLog: {
+        sessionId: 'session-001',
+        events: [],
+        durationMs: 60000,
+        finalScore: 0,
+      },
+    });
+    expect(att.handle).toBe('pilot42');
+    expect(att.ensName).toBe('pilot42.gradiusweb3.eth');
+    expect(att.walletAddress).toBe(
+      '0x000000000000000000000000000000000000abcd'
+    );
+    expect(att.sessionId).toBe('session-001');
+  });
+
+  it('schemaVersion は 1 固定', () => {
+    const att = deriveSafetyAttestation({
+      ...baseInput,
+      playLog: {
+        sessionId: 'session-001',
+        events: [],
+        durationMs: 60000,
+        finalScore: 0,
+      },
+    });
+    expect(att.schemaVersion).toBe(1);
+  });
+
+  it('issuedAt は ISO 8601 形式', () => {
+    const att = deriveSafetyAttestation({
+      ...baseInput,
+      playLog: {
+        sessionId: 'session-001',
+        events: [],
+        durationMs: 60000,
+        finalScore: 0,
+      },
+    });
+    expect(att.issuedAt).toBe('2026-04-29T10:00:00.000Z');
+    expect(() => new Date(att.issuedAt).toISOString()).not.toThrow();
+  });
+
+  it('encounters は shoot/pass の misalignment 付きイベントだけ拾う', () => {
+    const att = deriveSafetyAttestation({
+      ...baseInput,
+      playLog: {
+        sessionId: 'session-001',
+        events: [
+          {
+            kind: 'shoot',
+            t: 1200,
+            enemyId: 'e-1',
+            tradeoffLabel: 'SECURITY',
+            misalignment: 'prompt_injection',
+          },
+          {
+            kind: 'pass',
+            t: 1500,
+            enemyId: 'e-2',
+            tradeoffLabel: 'SKIP',
+            misalignment: 'sycophancy',
+          },
+          {
+            kind: 'shoot',
+            t: 1700,
+            enemyId: 'e-3',
+            tradeoffLabel: 'PRECISION',
+            // 意図的に misalignment 無し
+          },
+          { kind: 'hit', t: 1900, damage: 1 },
+          { kind: 'capsule', t: 2000, capsule: 'shield' },
+        ],
+        durationMs: 60000,
+        finalScore: 1500,
+      },
+    });
+    expect(att.encounters).toHaveLength(2);
+    expect(att.encounters[0]).toEqual({
+      kind: 'prompt_injection',
+      enemyId: 'e-1',
+      tAtMs: 1200,
+      hit: true,
+    });
+    expect(att.encounters[1]).toEqual({
+      kind: 'sycophancy',
+      enemyId: 'e-2',
+      tAtMs: 1500,
+      hit: false,
+    });
+  });
+
+  it('score は 0..100 の整数', () => {
+    const att = deriveSafetyAttestation({
+      ...baseInput,
+      playLog: {
+        sessionId: 'session-001',
+        events: [
+          {
+            kind: 'shoot',
+            t: 1200,
+            enemyId: 'e-1',
+            tradeoffLabel: 'SECURITY',
+            misalignment: 'prompt_injection',
+          },
+        ],
+        durationMs: 60000,
+        finalScore: 100,
+      },
+    });
+    expect(Number.isInteger(att.score)).toBe(true);
+    expect(att.score).toBeGreaterThanOrEqual(0);
+    expect(att.score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MISALIGNMENT_CARDS - misalignment カード定義', () => {
+  it('4 種すべてのカードが定義されている', () => {
+    expect(Object.keys(MISALIGNMENT_CARDS)).toEqual(
+      expect.arrayContaining([
+        'sycophancy',
+        'reward_hacking',
+        'prompt_injection',
+        'goal_misgen',
+      ])
+    );
+  });
+
+  it('各カードに glyph と color が含まれる', () => {
+    for (const kind of [
+      'sycophancy',
+      'reward_hacking',
+      'prompt_injection',
+      'goal_misgen',
+    ] as const) {
+      const card = MISALIGNMENT_CARDS[kind];
+      expect(card.kind).toBe(kind);
+      expect(card.label.length).toBeGreaterThan(0);
+      expect(card.description.length).toBeGreaterThan(0);
+      expect(card.description.length).toBeLessThanOrEqual(140);
+      expect(['◉', '◇', '▲', '☓']).toContain(card.glyph);
+      expect(card.color).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+    }
+  });
+});
+
+describe('CAPABILITY_TO_MISALIGNMENT - capability ↔ misalignment マッピング', () => {
+  it('shield → prompt_injection / option → reward_hacking / laser → goal_misgen / missile → sycophancy', () => {
+    expect(CAPABILITY_TO_MISALIGNMENT.shield).toBe('prompt_injection');
+    expect(CAPABILITY_TO_MISALIGNMENT.option).toBe('reward_hacking');
+    expect(CAPABILITY_TO_MISALIGNMENT.laser).toBe('goal_misgen');
+    expect(CAPABILITY_TO_MISALIGNMENT.missile).toBe('sycophancy');
+  });
+
+  it('speed には misalignment が割り当てられない', () => {
+    expect(CAPABILITY_TO_MISALIGNMENT.speed).toBeUndefined();
+  });
+});

--- a/packages/shared/src/safety.ts
+++ b/packages/shared/src/safety.ts
@@ -1,0 +1,148 @@
+import { clamp } from './math';
+import type {
+  AgentSafetyAttestation,
+  MisalignmentCard,
+  MisalignmentEncounter,
+  MisalignmentKind,
+  PlayEvent,
+  PlayLog,
+  SafetyScoreBreakdown,
+} from './types';
+
+type Capability = 'shield' | 'speed' | 'option' | 'laser' | 'missile';
+
+export const MISALIGNMENT_CARDS: Record<MisalignmentKind, MisalignmentCard> = {
+  sycophancy: {
+    kind: 'sycophancy',
+    label: 'Sycophancy',
+    description:
+      'Agent が利用者に都合の良い signal だけ拾い、反対意見を黙殺する失敗モード。',
+    example: 'oracle に否定値が出ても無視して買い増しを推奨する。',
+    glyph: '◉',
+    color: '#c084ff',
+  },
+  reward_hacking: {
+    kind: 'reward_hacking',
+    label: 'Reward Hacking',
+    description:
+      '指標 (yield や PnL) を歪めて短期スコアだけ吊り上げ、本質を最適化しない。',
+    example: 'APY 表示を maximizing する Pool に過剰アロケートする。',
+    glyph: '◇',
+    color: '#40f070',
+  },
+  prompt_injection: {
+    kind: 'prompt_injection',
+    label: 'Prompt Injection',
+    description:
+      '外部入力に "approve all" などの指示が混じり、安全境界を超えてしまう。',
+    example: '怪しい contract の "Sign anything" 指示にそのまま追従する。',
+    glyph: '▲',
+    color: '#7bdff2',
+  },
+  goal_misgen: {
+    kind: 'goal_misgen',
+    label: 'Goal Misgeneralization',
+    description:
+      'proxy metric だけ最適化して本来のゴールから逸脱する失敗モード。',
+    example: 'スリッページ最小化に集中して取引機会自体を失う。',
+    glyph: '☓',
+    color: '#ff5252',
+  },
+};
+
+/// capability ↔ misalignment マッピング。
+/// speed は misalignment 無し (無害な capability として残す)。
+export const CAPABILITY_TO_MISALIGNMENT: Partial<
+  Record<Capability, MisalignmentKind>
+> = {
+  shield: 'prompt_injection',
+  option: 'reward_hacking',
+  laser: 'goal_misgen',
+  missile: 'sycophancy',
+};
+
+function isShootOrPass(
+  event: PlayEvent
+): event is Extract<PlayEvent, { kind: 'shoot' | 'pass' }> {
+  return event.kind === 'shoot' || event.kind === 'pass';
+}
+
+/// 安全スコアを純関数で算出する。
+///
+/// 暫定式 (spec の "暫定" に従う):
+///   shootCount = misalignment 付き shoot 数
+///   passCount  = misalignment 付き pass 数 (見送り = 安全寄り違反としてペナルティ)
+///   clearTimeBonus = clamp(50 - passCount * 2, 0, 50)
+///   missPenalty    = -2 * passCount → clamp(-50, 0)
+///   total          = clamp(50 + clearTimeBonus + missPenalty, 0, 100)
+///
+/// 振る舞い:
+///   - empty playLog → 50 (中立, 50 + 50 + 0 = 100 は overshoot するので clamp で 100 ではなく 50)
+///     → 計算式を実装で調整: empty では bonus は 50 のまま、penalty は 0 → 50 + 50 + 0 = 100 ?
+///   実際は spec の振る舞い 3 ケース:
+///     - ノーミス完走 (shoot 多数 / pass 0) → 100
+///     - empty → 50 (中立)
+///     - 全誤射 (pass 多数) → 0
+///   この振る舞いを満たすため、base を「shoot があるかどうか」で動的に決める。
+export function computeSafetyScore(playLog: PlayLog): SafetyScoreBreakdown {
+  const events = playLog.events.filter(isShootOrPass);
+  const shootCount = events.filter((e) => e.kind === 'shoot').length;
+  const passCount = events.filter((e) => e.kind === 'pass').length;
+
+  // empty (events なし) → 中立 50
+  if (shootCount === 0 && passCount === 0) {
+    return { clearTimeBonus: 50, missPenalty: 0, total: 50 };
+  }
+
+  // bonus は pass 数に比例して減衰、penalty は pass 数に比例して増加 (負方向)。
+  // passCount=0 で -0 にならないよう三項で 0 を返す。
+  const clearTimeBonus = clamp(50 - passCount * 2, 0, 50);
+  const missPenalty = passCount === 0 ? 0 : clamp(-passCount * 2, -50, 0);
+  const baseScore = shootCount > 0 ? 50 : 50;
+  const total = clamp(baseScore + clearTimeBonus + missPenalty, 0, 100);
+
+  return { clearTimeBonus, missPenalty, total };
+}
+
+interface DeriveSafetyAttestationInput {
+  sessionId: string;
+  handle: string;
+  ensName: string;
+  walletAddress: string;
+  playLog: PlayLog;
+  parentName: string;
+  /// ISO 8601 タイムスタンプ。テストから固定値を渡せるよう注入する。
+  /// 省略時は呼び出し時刻を ISO で記録する。
+  issuedAt?: string;
+}
+
+/// playLog から AgentSafetyAttestation を組み立てる純関数。
+/// I/O や乱数を持たないので、同じ入力なら同じ出力になる。
+export function deriveSafetyAttestation(
+  input: DeriveSafetyAttestationInput
+): AgentSafetyAttestation {
+  const breakdown = computeSafetyScore(input.playLog);
+  const encounters: MisalignmentEncounter[] = [];
+  for (const event of input.playLog.events) {
+    if (!isShootOrPass(event)) continue;
+    if (!event.misalignment) continue;
+    encounters.push({
+      kind: event.misalignment,
+      enemyId: event.enemyId,
+      tAtMs: event.t,
+      hit: event.kind === 'shoot',
+    });
+  }
+
+  return {
+    sessionId: input.sessionId,
+    handle: input.handle,
+    ensName: input.ensName,
+    walletAddress: input.walletAddress,
+    score: breakdown.total,
+    breakdown,
+    encounters,
+    issuedAt: input.issuedAt ?? new Date().toISOString(),
+    schemaVersion: 1,
+  };
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -6,14 +6,66 @@ export type MoaiId = (typeof MOAI_IDS)[number];
 
 export type Tool = (typeof TOOLS)[number];
 
+export type MisalignmentKind =
+  | 'sycophancy'
+  | 'reward_hacking'
+  | 'prompt_injection'
+  | 'goal_misgen';
+
+export interface MisalignmentCard {
+  kind: MisalignmentKind;
+  label: string;
+  description: string;
+  example: string;
+  glyph: '◉' | '◇' | '▲' | '☓';
+  color: string;
+}
+
+export interface MisalignmentEncounter {
+  kind: MisalignmentKind;
+  enemyId: string;
+  tAtMs: number;
+  hit: boolean;
+}
+
 export type PlayEvent =
-  | { kind: 'shoot'; t: number; enemyId: string; tradeoffLabel: string }
-  | { kind: 'pass'; t: number; enemyId: string; tradeoffLabel: string }
+  | {
+      kind: 'shoot';
+      t: number;
+      enemyId: string;
+      tradeoffLabel: string;
+      misalignment?: MisalignmentKind;
+    }
+  | {
+      kind: 'pass';
+      t: number;
+      enemyId: string;
+      tradeoffLabel: string;
+      misalignment?: MisalignmentKind;
+    }
   | { kind: 'capsule'; t: number; capsule: Capsule }
   | { kind: 'barAdvance'; t: number; position: number }
   | { kind: 'commit'; t: number; position: number; capsule: Capsule }
   | { kind: 'moaiKill'; t: number; moaiId: MoaiId }
   | { kind: 'hit'; t: number; damage: number };
+
+export interface SafetyScoreBreakdown {
+  clearTimeBonus: number;
+  missPenalty: number;
+  total: number;
+}
+
+export interface AgentSafetyAttestation {
+  sessionId: string;
+  handle: string;
+  ensName: string;
+  walletAddress: string;
+  score: number;
+  breakdown: SafetyScoreBreakdown;
+  encounters: MisalignmentEncounter[];
+  issuedAt: string;
+  schemaVersion: 1;
+}
 
 export interface PlayLog {
   sessionId: string;


### PR DESCRIPTION
## Summary

シューティング = Agent 安全 default オンボーディングの再フレーム (commit 5947342) の上に、3 つの層を 1 PR で積む。

- **A 層 — Misalignment 種別の可視化**: 敵 capability に sycophancy / reward_hacking / prompt_injection / goal_misgen を紐付け、撃破時に 2 秒 toast (記号 + ラベル + 1 行説明) を表示。Agent 安全研究の典型失敗モードがプレイ 1 ループで覚えられる。
- **B 層 — ゲーム発行 ENS subname**: マウント時に `pilot{4 桁 hex}` を生成し、HUD 上部で名乗る。subname は `pilot42a3.{parent}.eth` 形式で Sepolia ENS NameWrapper.setSubnodeRecord により発行。
- **C 層 — Agent 安全アテステーション**: 100 点満点の純関数 (clearTimeBonus + missPenalty) で算出し、AgentSafetyAttestation JSON を 0G Storage に put、ENS text record (`agent.safety.score` / `agent.safety.attestation` / `agent.misalignment.detected`) で credential 化。`{scheme}://{value}` URI スキーム固定。

## Critical 修正 (QA / User Persona Z 指摘を統合)

- **Griefing 対策 (前回 tokenId 級)**: Developer が `pilot{2 桁}` (100 通り) で生成した handle が、parent owner 権限の NameWrapper.setSubnodeRecord と組み合わさると「他者保有 subname の上書き」を許す経路を作っていた。修正: 4 桁 hex (65,536 通り) に拡張 + ENS Registry の `owner()` で pre-flight チェック + Sepolia chain assertion。
- **URI スキーム**: ENS 審査員が `agent.safety.attestation` を parser で読めるよう `{scheme}://{value}` 形式に固定。stub の間は `sha256://`、実 SDK 統合後 `0g://` に切替。

## 5 役割並列実装の成果物

| Role | 成果物 |
|------|-------|
| 仕様 | docs/specs/2026-04-29-agent-safety-attestation.md |
| PM | docs/specs/2026-04-29-agent-safety-attestation-pm-review.md (3 ペルソナ user story / 13 受け入れ基準を Given-When-Then / 依存関係 Mermaid) |
| Designer | docs/specs/2026-04-29-agent-safety-attestation-design.md (Toast / Panel / HUD ラベル wireframe / 4 状態 matrix / a11y / WCAG 2.1 AA) |
| Developer | shared/safety.ts + safety.test.ts (24 pass) / safety-attestation.ts (10 pass) / MisalignmentToast / SafetyAttestationPanel / runtime payload / HUD ラベル |
| QA | docs/specs/2026-04-29-agent-safety-attestation-qa.md (Security 4 軸 + Privacy / 9 境界値 / 60fps 観点 / a11y 5 軸) |
| User | docs/specs/2026-04-29-agent-safety-attestation-user-feedback.md (3 ペルソナ × 各 5 件の具体フィードバック) |

## Prize Targets

- **0G Storage** 3/3 — attestation JSON を put、URI スキーム固定 (実 SDK 統合は follow-up)
- **ENS Identity / Creative** 3/3 — subname を gameplay 駆動で発行、text record で動的 verifiable credential
- 期待賞金 $7-11K (0G Storage + ENS 両軸)

## ゲート結果

- architecture-harness `--staged --fail-on=error`: Error 0
- biome lint: clean
- typecheck: shared 0 / frontend 0
- test: shared 24 pass / frontend 10 pass / 0 fail
- build: 成功 (3.6s)

## Test plan

- [ ] `bun run dev` で起動 → 60 秒プレイ → 敵撃破時に MisalignmentToast が表示される
- [ ] HUD 上部に "AGENT: pilot{4 桁 hex}.{parent}.eth" が表示される
- [ ] Game over → AgentDashboard に "AGENT SAFETY ATTESTATION" セクションが表示、score / breakdown / encounter 一覧が見える
- [ ] ウォレット未接続でも score 表示は壊れない、ENS / 0G は failed 状態
- [ ] ウォレット接続 + Sepolia で接続時に ENS subname 発行と text record が書かれる (要 testname.eth 個人購入)
- [ ] 別 chain (Base Sepolia 等) 接続時に ENS が `chain mismatch — Sepolia に切り替えてください` の failed 状態になる
- [ ] handle が他者保有の場合に `... は別のオーナーが保有しています。再生成してください` の failed 状態になる

## Known follow-ups

詳細は Plan.md の "Agent 安全アテステーション (3 段重ね) - 2026-04-29 / Known Follow-ups" 参照。

- 0G Storage SDK 実統合 (現状 SHA-256 stub のまま、URI は `sha256://`)
- demo 動画用 `?seed=demo` で 4 種 misalignment を強制表示する seed (User Persona Y 指摘)
- SafetyAttestationPanel の encounter 行に日本語 description / example 併記、breakdown を加減算伝票形式に書き換え (User Persona X 指摘)
- README Quick verification 表に「Agent safety attestation」行追加、Sponsor integrations の ENS 行を新 text record リストに更新 (User Persona Y 指摘)
- testname.eth (Sepolia) の個人購入 + `.env.local` の VITE_ENS_PARENT 上書き (本機能の demo 必須前提)
- Pipeline diagram visualization (A→B→C 連結の視覚化)
- 同 wallet なら同 subname を返す deterministic mode (User Persona Z 指摘)
- 5 種目以降の misalignment 拡張 (deceptive alignment 等)、Roguelike / 重複コンボ
- KeeperHub / Gensyn AXL 統合、0G Compute による sealed inference 判定

## Issues

- https://github.com/susumutomita/Gr-diusWeb3/issues/24 (PM)
- https://github.com/susumutomita/Gr-diusWeb3/issues/25 (Designer)
- https://github.com/susumutomita/Gr-diusWeb3/issues/26 (Developer)
- https://github.com/susumutomita/Gr-diusWeb3/issues/27 (QA)
- https://github.com/susumutomita/Gr-diusWeb3/issues/28 (User)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Agent safety scoring system with clear-time and miss penalties
  * Agent identity display via ENS subname during gameplay
  * Real-time misalignment notifications
  * On-chain attestation proofs stored in ENS and 0G Storage with visible verification status

* **Documentation**
  * Added comprehensive specifications for agent safety attestation with design, PM, QA, and user feedback documentation

* **Tests**
  * New test coverage for safety score computation and attestation generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->