### PR TITLE
fix(game): 敵弾ヒットを壁衝突と同じ即死扱いに変更

### DIFF
--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -847,8 +847,9 @@ export function step(rt: Runtime, input: InputState) {
     );
   });
 
-  // Player damage
-  if (rt.player.iframes <= 0) {
+  // Enemy bullets — instant kill regardless of iframes (Gradius rule: bullet = death,
+  // same as walls). Death explosion is staged by the rt.player.hp <= 0 branch below.
+  if (rt.dyingT <= 0 && rt.player.hp > 0) {
     const hit = (hx: number, hy: number, hr: number) => {
       const dx = rt.player.x + 8 - hx;
       const dy = rt.player.y + 5 - hy;
@@ -856,10 +857,32 @@ export function step(rt: Runtime, input: InputState) {
     };
     for (const b of rt.enemyBullets) {
       if (hit(b.x, b.y, 4)) {
-        rt.player.hp -= 1;
-        rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 1 });
+        rt.player.hp = 0;
+        rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 99 });
+        break;
+      }
+    }
+  }
+
+  // Enemy ship collision — iframe-gated chip damage (still survivable).
+  if (rt.player.iframes <= 0 && rt.dyingT <= 0 && rt.player.hp > 0) {
+    for (const e of rt.enemies) {
+      const ew = e.type === 'moai' ? 24 : 12;
+      const eh = e.type === 'moai' ? 28 : 10;
+      if (
+        rt.player.x + 16 > e.x &&
+        rt.player.x < e.x + ew &&
+        rt.player.y + 10 > e.y &&
+        rt.player.y < e.y + eh
+      ) {
+        rt.player.hp -= e.type === 'moai' ? 2 : 1;
         rt.player.iframes = 60;
         rt.flashT = 25;
+        rt.events.push({
+          kind: 'hit',
+          t: elapsedMs(rt),
+          damage: e.type === 'moai' ? 2 : 1,
+        });
         const cx = rt.player.x + 8;
         const cy = rt.player.y + 5;
         spawnBurst(rt, cx, cy, '#ff5252', 50);
@@ -868,35 +891,6 @@ export function step(rt: Runtime, input: InputState) {
         pushToast(rt, `HULL ${rt.player.hp}`, PAL.warn);
         playSfx('hit');
         break;
-      }
-    }
-    if (rt.player.iframes <= 0) {
-      for (const e of rt.enemies) {
-        const ew = e.type === 'moai' ? 24 : 12;
-        const eh = e.type === 'moai' ? 28 : 10;
-        if (
-          rt.player.x + 16 > e.x &&
-          rt.player.x < e.x + ew &&
-          rt.player.y + 10 > e.y &&
-          rt.player.y < e.y + eh
-        ) {
-          rt.player.hp -= e.type === 'moai' ? 2 : 1;
-          rt.player.iframes = 60;
-          rt.flashT = 25;
-          rt.events.push({
-            kind: 'hit',
-            t: elapsedMs(rt),
-            damage: e.type === 'moai' ? 2 : 1,
-          });
-          const cx = rt.player.x + 8;
-          const cy = rt.player.y + 5;
-          spawnBurst(rt, cx, cy, '#ff5252', 50);
-          spawnBurst(rt, cx, cy, '#ffe66d', 25);
-          spawnBurst(rt, cx, cy, '#ffffff', 12);
-          pushToast(rt, `HULL ${rt.player.hp}`, PAL.warn);
-          playSfx('hit');
-          break;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- 敵弾被弾時に `rt.player.hp -= 1` + iframe で複数発耐えていた挙動を、壁衝突と同じ即死 (`rt.player.hp = 0`) に変更。
- 既存の死亡演出フロー (3 段重ねバースト → `dyingT = 45` → `finished` → debrief) にそのまま合流するので、機体爆発 → ゲーム終了の見え方が壁衝突と完全に一致する。
- 敵機への接触ダメージは仕様通り iframe ガード付き chip damage のまま残し、敵弾だけ Gradius ルール (弾 = 死) に揃えた。

`packages/frontend/src/game/runtime.ts:850` 周辺のみの変更。

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件。
- [x] `bun run lint` (biome check) — クリーン。
- [x] `bun run typecheck` — shared / frontend 共に exit 0。
- [x] `bun run test` — shared 31 pass / frontend 15 pass・1 skip・0 fail。
- [x] `bun run build` — shared / frontend 共に成功。
- [ ] ローカルで dev server を立ち上げ、敵弾を 1 発被弾 → 即爆発 → debrief に遷移する golden path を目視確認。
- [ ] 壁衝突との見た目の差分が出ていないか比較確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Game Mechanics

* Enemy bullets now defeat the player instantly upon contact
* Enemy ship collisions now apply type-specific damage with temporary invulnerability windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->