### PR TITLE
fix(game): 敵機体への接触も壁・弾と同じ即死扱いに変更

### DIFF
--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -864,8 +864,8 @@ export function step(rt: Runtime, input: InputState) {
     }
   }
 
-  // Enemy ship collision — iframe-gated chip damage (still survivable).
-  if (rt.player.iframes <= 0 && rt.dyingT <= 0 && rt.player.hp > 0) {
+  // Enemy ship contact — instant kill (Gradius rule: 触れたら死、壁・弾と同じ挙動).
+  if (rt.dyingT <= 0 && rt.player.hp > 0) {
     for (const e of rt.enemies) {
       const ew = e.type === 'moai' ? 24 : 12;
       const eh = e.type === 'moai' ? 28 : 10;
@@ -875,21 +875,8 @@ export function step(rt: Runtime, input: InputState) {
         rt.player.y + 10 > e.y &&
         rt.player.y < e.y + eh
       ) {
-        rt.player.hp -= e.type === 'moai' ? 2 : 1;
-        rt.player.iframes = 60;
-        rt.flashT = 25;
-        rt.events.push({
-          kind: 'hit',
-          t: elapsedMs(rt),
-          damage: e.type === 'moai' ? 2 : 1,
-        });
-        const cx = rt.player.x + 8;
-        const cy = rt.player.y + 5;
-        spawnBurst(rt, cx, cy, '#ff5252', 50);
-        spawnBurst(rt, cx, cy, '#ffe66d', 25);
-        spawnBurst(rt, cx, cy, '#ffffff', 12);
-        pushToast(rt, `HULL ${rt.player.hp}`, PAL.warn);
-        playSfx('hit');
+        rt.player.hp = 0;
+        rt.events.push({ kind: 'hit', t: elapsedMs(rt), damage: 99 });
         break;
       }
     }


### PR DESCRIPTION
## Summary

- 直前の #37 で敵弾を即死に揃えたあとも、敵機への接触だけ iframe ガード付きの chip damage (`-1` / moai は `-2`) で残っていて非対称だった。
- 接触も `rt.player.hp = 0` にして既存の死亡演出フロー (3 段重ねバースト → `dyingT = 45` → `finished` → debrief) に合流させ、壁・敵弾・敵接触の 3 種すべて Gradius ルール (触れたら死) で揃えた。
- これで `rt.player.iframes` は spawn 時の 24F 猶予と spawn 中の 0.55 透過描画にだけ意味を持つ状態に縮退する。

`packages/frontend/src/game/runtime.ts:867` のブロックのみの変更。

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件。
- [x] `bun run lint` (biome check) — クリーン。
- [x] `bun run typecheck` — shared / frontend 共に exit 0。
- [x] `bun run test` — shared 31 pass / frontend 15 pass・1 skip・0 fail。
- [x] `bun run build` — shared / frontend 共に成功。
- [ ] ローカル dev で敵に体当たり → 即爆発 → debrief に遷移する golden path を目視確認。
- [ ] moai (boss) 接触も同じく即死になることを確認。