### PR TITLE
fix(web3): 接続済 wallet が config 外 chain でも walletClient を resolve

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -204,7 +204,12 @@ export function App() {
   const parentName = DEFAULT_PARENT_NAME;
   const arcadeRef = useRef<HTMLDivElement | null>(null);
   const { address: ownerAddress } = useAccount();
-  const { data: walletClient } = useWalletClient();
+  // assertChainId: false — ウォレットが wagmi config 外の chain (mainnet 等) に
+  // いても walletClient を返す。ENS / Uniswap / 0G mint は writeContract 側で
+  // chain を明示しているので、viem が必要に応じて wallet_switchEthereumChain を
+  // 走らせる。default のままだと ConnectorChainMismatchError で data: undefined に
+  // なり、接続済なのに「wallet not connected」と表示される。
+  const { data: walletClient } = useWalletClient({ assertChainId: false });
   // wallet 未接続なら random、接続済なら deterministic。後から接続された場合に
   // 一度 deterministic に切り替わるが、disconnect で random に戻すと混乱するので
   // 一度 deterministic になったら固定する。

--- a/packages/frontend/src/lib/wagmi.ts
+++ b/packages/frontend/src/lib/wagmi.ts
@@ -6,9 +6,10 @@ import {
   sepolia,
 } from 'wagmi/chains';
 import { coinbaseWallet, injected } from 'wagmi/connectors';
+import { galileo } from '../web3/chains';
 
 export const config = createConfig({
-  chains: [sepolia, baseSepolia, optimismSepolia, arbitrumSepolia],
+  chains: [sepolia, baseSepolia, optimismSepolia, arbitrumSepolia, galileo],
   multiInjectedProviderDiscovery: true,
   connectors: [
     injected({ shimDisconnect: true }),
@@ -21,6 +22,7 @@ export const config = createConfig({
     [baseSepolia.id]: http(),
     [optimismSepolia.id]: http(),
     [arbitrumSepolia.id]: http(),
+    [galileo.id]: http(),
   },
   ssr: false,
 });


### PR DESCRIPTION
## Summary

接続済なのに dashboard で「⚡ Connect a wallet」と表示され、`0G iNFT / 0G STORAGE / ENS` がすべて `FAIL: wallet not connected` になる現象の根本原因を修正。

### 根本原因

ユーザーの wallet が wagmi config の `chains` 配列に無い chain (Ethereum mainnet / 0G Galileo / Polygon 等) にいると、wagmi v2 の `useWalletClient` は `ConnectorChainMismatchError` を投げて `data: undefined` を返す。

- `@wagmi/core/src/actions/getConnectorClient.ts:114` — `assertChainId` が default true のため `connectorChainId !== chainId` で throw する。
- `@wagmi/core/src/createConfig.ts:290-293` — wallet が unsupported chain に切り替わっても `state.chainId` を更新しない (`isChainConfigured` が false の場合 return)。
- 結果: `parameters.chainId = useChainId()` は config 既定 (sepolia) のまま、`connectorChainId` は wallet 実 chain (mainnet 等) で必ず mismatch。

App.tsx は `walletClient` が undefined のとき `mint / storage / ens` をすべて `wallet not connected` で fail させていたので、AgentDashboard の wallet missing callout が triggered されていた。

### 対応

1. `useWalletClient({ assertChainId: false })` で chain 不一致でも walletClient を返させる。
2. 0G Galileo を wagmi config の `chains` と `transports` に追加し、0G を primary に使うユーザーでも `state.chainId` が正しく追従するようにする。

ENS / Uniswap / 0G mint の `writeContract` 呼び出しはすべて `chain` を明示しているので (`packages/frontend/src/web3/ens-register.ts`, `uniswap-swap.ts`, `zerog-mint.ts`)、viem が必要に応じて `wallet_switchEthereumChain` を走らせる。これで isConnected が true なら walletClient も必ず resolve するようになり、callout は本当に未接続なときだけ出る。

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件。
- [x] `bun run lint` (biome check) — クリーン。
- [x] `bun run typecheck` — `assertChainId` は wagmi v2 の `useWalletClient` parameters に存在する optional として受理される。shared / frontend 共に exit 0。
- [x] `bun run test` — shared 31 pass / frontend 15 pass・1 skip・0 fail。
- [x] `bun run build` — shared / frontend 共に成功。
- [ ] ローカル dev で MetaMask を Ethereum mainnet に置いて接続 → ゲーム完走 → `⚡ Connect a wallet` が出ないこと、forge 実行時に Sepolia への switch ダイアログが出ることを目視確認。
- [ ] MetaMask を 0G Galileo に置いて接続 → 同様に挙動が破綻しないこと、ENS の write 時に Sepolia への switch ダイアログが出ること。
- [ ] 完全に未接続のまま完走 → 従来通り「wallet not connected」表示が出ること (regression 確認)。