### PR TITLE
fix(web3): writeContract 直前に switchChain + storage/mint の outcome を独立レポート

### DIFF
--- a/packages/frontend/src/web3/ens-register.ts
+++ b/packages/frontend/src/web3/ens-register.ts
@@ -6,6 +6,7 @@ import {
   namehash,
 } from 'viem';
 import { sepolia } from './chains';
+import { ensureChain } from './utils';
 
 /// Sepolia ENS NameWrapper. Source:
 /// https://docs.ens.domains/learn/deployments
@@ -83,6 +84,8 @@ export async function registerSubname(
   const parentNode = namehash(parent);
   const fullName = `${input.handle}.${parent}`;
   const node = namehash(fullName);
+
+  await ensureChain(walletClient, sepolia);
 
   // Step 1: NameWrapper.setSubnodeRecord — only the parent owner can call
   // this. For a hackathon-controlled parent this is the deployer wallet.

--- a/packages/frontend/src/web3/forge-onchain.test.ts
+++ b/packages/frontend/src/web3/forge-onchain.test.ts
@@ -16,10 +16,8 @@ const SAMPLE_ENS: EnsProof = {
 describe('aggregateProof - オンチェーン pipeline 結果集約', () => {
   it('全ステップ成功時に 4 つのスロットを success にする', () => {
     const proof = aggregateProof(
-      {
-        status: 'fulfilled',
-        value: { storage: SAMPLE_STORAGE, mint: SAMPLE_MINT },
-      },
+      { status: 'fulfilled', value: SAMPLE_STORAGE },
+      { status: 'fulfilled', value: SAMPLE_MINT },
       { status: 'fulfilled', value: SAMPLE_ENS }
     );
     expect(proof.storage).toEqual({ status: 'success', data: SAMPLE_STORAGE });
@@ -28,24 +26,38 @@ describe('aggregateProof - オンチェーン pipeline 結果集約', () => {
     expect(proof.swap).toEqual({ status: 'idle' });
   });
 
-  it('storage→mint チェーン失敗時は両方を failed にして ENS は独立評価する', () => {
+  it('storage 成功 / mint 失敗 を独立してレポートする (混線させない)', () => {
+    const proof = aggregateProof(
+      { status: 'fulfilled', value: SAMPLE_STORAGE },
+      { status: 'rejected', reason: new Error('VITE_INFT_ADDRESS unset') },
+      { status: 'fulfilled', value: SAMPLE_ENS }
+    );
+    expect(proof.storage).toEqual({ status: 'success', data: SAMPLE_STORAGE });
+    expect(proof.mint.status).toBe('failed');
+    expect(proof.mint.error).toBe('VITE_INFT_ADDRESS unset');
+    expect(proof.ens).toEqual({ status: 'success', data: SAMPLE_ENS });
+  });
+
+  it('storage 失敗時に mint も失敗扱い (orchestrator 側で skip 理由を入れる)', () => {
     const proof = aggregateProof(
       { status: 'rejected', reason: new Error('rpc timeout') },
+      {
+        status: 'rejected',
+        reason: new Error('skipped: storage upload failed'),
+      },
       { status: 'fulfilled', value: SAMPLE_ENS }
     );
     expect(proof.storage.status).toBe('failed');
     expect(proof.storage.error).toBe('rpc timeout');
     expect(proof.mint.status).toBe('failed');
-    expect(proof.mint.error).toBe('rpc timeout');
+    expect(proof.mint.error).toBe('skipped: storage upload failed');
     expect(proof.ens).toEqual({ status: 'success', data: SAMPLE_ENS });
   });
 
   it('ENS 失敗時も他のステップを成功扱いに保つ', () => {
     const proof = aggregateProof(
-      {
-        status: 'fulfilled',
-        value: { storage: SAMPLE_STORAGE, mint: SAMPLE_MINT },
-      },
+      { status: 'fulfilled', value: SAMPLE_STORAGE },
+      { status: 'fulfilled', value: SAMPLE_MINT },
       { status: 'rejected', reason: new Error('user rejected signature') }
     );
     expect(proof.mint.status).toBe('success');
@@ -57,19 +69,18 @@ describe('aggregateProof - オンチェーン pipeline 結果集約', () => {
   it('Error 以外の reason も文字列化してエラー欄に格納する', () => {
     const proof = aggregateProof(
       { status: 'rejected', reason: 'plain string failure' },
+      { status: 'rejected', reason: 'mint plain string' },
       { status: 'rejected', reason: 42 }
     );
-    expect(proof.mint.error).toBe('plain string failure');
     expect(proof.storage.error).toBe('plain string failure');
+    expect(proof.mint.error).toBe('mint plain string');
     expect(proof.ens.error).toBe('unknown error');
   });
 
   it('swap スロットは初期状態が idle のまま (orchestrator では更新しない)', () => {
     const proof = aggregateProof(
-      {
-        status: 'fulfilled',
-        value: { storage: SAMPLE_STORAGE, mint: SAMPLE_MINT },
-      },
+      { status: 'fulfilled', value: SAMPLE_STORAGE },
+      { status: 'fulfilled', value: SAMPLE_MINT },
       { status: 'fulfilled', value: SAMPLE_ENS }
     );
     expect(proof.swap.status).toBe('idle');

--- a/packages/frontend/src/web3/forge-onchain.ts
+++ b/packages/frontend/src/web3/forge-onchain.ts
@@ -23,23 +23,27 @@ function toHexBytes(maybeHex: string): Hex {
 /// Pure aggregator: takes the resolved/rejected branches of the on-chain
 /// pipeline and produces an OnChainProof. Exported for unit testing the
 /// success/fail aggregation independently of the SDK calls.
+///
+/// storage と mint は chain として依存しているが、画面上は独立した行として
+/// 表示するので失敗 reason も別々に渡す。例えば storage put が成功して mint
+/// が VITE_INFT_ADDRESS 未設定で落ちた場合、storage 行は success、mint 行
+/// は failed として正確にレポートする (それまでは両方 mint の error message
+/// で塗りつぶされていた)。
 export function aggregateProof(
-  storageMintSettled: PromiseSettledResult<{
-    storage: StorageProof;
-    mint: MintProof;
-  }>,
+  storageSettled: PromiseSettledResult<StorageProof>,
+  mintSettled: PromiseSettledResult<MintProof>,
   ensSettled: PromiseSettledResult<EnsProof>
 ): OnChainProof {
   return {
     ...idleProof,
     storage:
-      storageMintSettled.status === 'fulfilled'
-        ? { status: 'success', data: storageMintSettled.value.storage }
-        : { status: 'failed', error: errorMessage(storageMintSettled.reason) },
+      storageSettled.status === 'fulfilled'
+        ? { status: 'success', data: storageSettled.value }
+        : { status: 'failed', error: errorMessage(storageSettled.reason) },
     mint:
-      storageMintSettled.status === 'fulfilled'
-        ? { status: 'success', data: storageMintSettled.value.mint }
-        : { status: 'failed', error: errorMessage(storageMintSettled.reason) },
+      mintSettled.status === 'fulfilled'
+        ? { status: 'success', data: mintSettled.value }
+        : { status: 'failed', error: errorMessage(mintSettled.reason) },
     ens:
       ensSettled.status === 'fulfilled'
         ? { status: 'success', data: ensSettled.value }
@@ -47,10 +51,11 @@ export function aggregateProof(
   };
 }
 
-/// Run the on-chain forge pipeline: storage put → mint (chained, since the
-/// CID has to be embedded in the iNFT metadata) plus ENS subname registration
-/// in parallel. Each independent branch is wrapped in Promise.allSettled so a
-/// single failure never blocks the rest of the dashboard.
+/// Run the on-chain forge pipeline: storage put → mint (mint depends on
+/// the CID, so it's chained sequentially) and ENS subname registration in
+/// parallel. Each row is reported independently so a single failure (e.g.
+/// mint reverting because the contract isn't deployed yet) doesn't mask
+/// upstream successes.
 ///
 /// Pure orchestration: this function does not throw. It always resolves with
 /// an OnChainProof where each step is either success or failed.
@@ -73,7 +78,10 @@ export async function runOnChainForge(
 
   const playLogHash = toHexBytes(draft.agent.birthHash);
 
-  const storageThenMint = (async () => {
+  const storageThenMint = (async (): Promise<{
+    storageSettled: PromiseSettledResult<StorageProof>;
+    mintSettled: PromiseSettledResult<MintProof>;
+  }> => {
     // 0G Storage に playLog を real put。signer 構築に失敗したら sha256 fallback。
     let signer: ZeroGSigner | undefined;
     try {
@@ -81,16 +89,37 @@ export async function runOnChainForge(
     } catch {
       signer = undefined;
     }
-    const storage = await putPlayLog(draft.playLog, signer);
-    const mint = await mintINft(walletClient, {
-      ensName: draft.agent.ensName,
-      playLogHash,
-      policyBlob: '0x' as Hex,
-      archetype: draft.agent.archetype,
-      combatPower: BigInt(draft.agent.profile.combatPower),
-      storageCID: storage.cid,
-    });
-    return { storage, mint };
+    let storage: StorageProof;
+    try {
+      storage = await putPlayLog(draft.playLog, signer);
+    } catch (storageError) {
+      return {
+        storageSettled: { status: 'rejected', reason: storageError },
+        mintSettled: {
+          status: 'rejected',
+          reason: new Error('skipped: storage upload failed'),
+        },
+      };
+    }
+    try {
+      const mint = await mintINft(walletClient, {
+        ensName: draft.agent.ensName,
+        playLogHash,
+        policyBlob: '0x' as Hex,
+        archetype: draft.agent.archetype,
+        combatPower: BigInt(draft.agent.profile.combatPower),
+        storageCID: storage.cid,
+      });
+      return {
+        storageSettled: { status: 'fulfilled', value: storage },
+        mintSettled: { status: 'fulfilled', value: mint },
+      };
+    } catch (mintError) {
+      return {
+        storageSettled: { status: 'fulfilled', value: storage },
+        mintSettled: { status: 'rejected', reason: mintError },
+      };
+    }
   })();
 
   const ensPromise = registerSubname(walletClient, {
@@ -103,10 +132,19 @@ export async function runOnChainForge(
     },
   });
 
-  const [storageMintSettled, ensSettled] = await Promise.allSettled([
+  const [{ storageSettled, mintSettled }, ensSettled] = await Promise.all([
     storageThenMint,
-    ensPromise,
+    ensPromise.then(
+      (value): PromiseSettledResult<EnsProof> => ({
+        status: 'fulfilled',
+        value,
+      }),
+      (reason): PromiseSettledResult<EnsProof> => ({
+        status: 'rejected',
+        reason,
+      })
+    ),
   ]);
 
-  return aggregateProof(storageMintSettled, ensSettled);
+  return aggregateProof(storageSettled, mintSettled, ensSettled);
 }

--- a/packages/frontend/src/web3/uniswap-swap.ts
+++ b/packages/frontend/src/web3/uniswap-swap.ts
@@ -6,6 +6,7 @@ import {
   parseEther,
 } from 'viem';
 import { sepolia } from './chains';
+import { ensureChain } from './utils';
 
 /// Uniswap v3 SwapRouter02 on Sepolia.
 /// https://docs.uniswap.org/contracts/v3/reference/deployments
@@ -65,6 +66,8 @@ export async function executeFirstSwap(
   }
 
   const amountIn = parseEther('0.0001');
+
+  await ensureChain(walletClient, sepolia);
 
   const txHash = await walletClient.writeContract({
     address: SWAP_ROUTER_02,

--- a/packages/frontend/src/web3/utils.ts
+++ b/packages/frontend/src/web3/utils.ts
@@ -1,7 +1,23 @@
+import type { Chain, WalletClient } from 'viem';
+
 /// 失敗 reason を画面・ログ表示用の文字列に正規化する。
 /// Error / string / その他を 1 行で返す。private key やシークレットを含む
 /// 値が来た場合に過剰に詳細を露出しないよう reason の origin は捨てる。
 export function errorMessage(reason: unknown): string {
   if (reason instanceof Error) return reason.message;
   return typeof reason === 'string' ? reason : 'unknown error';
+}
+
+/// writeContract 直前に wallet を target chain に揃える。
+/// viem の writeContract({ chain }) は chain mismatch を assert で投げるだけで
+/// auto switch しない (`viem/utils/chain/assertCurrentChain`)。なので各 tx の
+/// 直前に明示的に switchChain を呼んで、必要なら wallet_switchEthereumChain
+/// プロンプトをユーザーに見せる。chain がもう一致していれば no-op。
+export async function ensureChain(
+  walletClient: WalletClient,
+  target: Chain
+): Promise<void> {
+  const currentId = await walletClient.getChainId();
+  if (currentId === target.id) return;
+  await walletClient.switchChain({ id: target.id });
 }

--- a/packages/frontend/src/web3/zerog-mint.ts
+++ b/packages/frontend/src/web3/zerog-mint.ts
@@ -8,6 +8,7 @@ import {
   keccak256,
 } from 'viem';
 import { galileo } from './chains';
+import { ensureChain } from './utils';
 
 const INFT_ABI = [
   {
@@ -71,6 +72,8 @@ export async function mintINft(
       'mintINft: VITE_INFT_ADDRESS is not configured. Deploy AgentForgeINFT to 0G Galileo and set the env var.'
     );
   }
+
+  await ensureChain(walletClient, galileo);
 
   const txHash = await walletClient.writeContract({
     address,


### PR DESCRIPTION
## Summary

スクリーンショットで報告された 3 つの症状の根本原因を修正:

| 症状 | 行 | 旧表示 | 原因 |
|---|---|---|---|
| ENS が ChainMismatchError | ENS | `The current chain of the wallet (id: 1) does not match the target chain (id: 11155111 - Sepolia)` | viem の `writeContract({ chain })` は chain mismatch を assert で投げるだけで auto switch しない |
| 0G STORAGE 行に iNFT のエラー | STORAGE | `mintINft: VITE_INFT_ADDRESS is not configured` | `forge-onchain` が storage と mint を 1 本の Promise にチェーンしていたため、mint の reject が storage 行も塗りつぶしていた |
| 0G iNFT 失敗 | MINT | (同上) | env 未設定で deploy 待ち。コード側ではない (PR スコープ外) |

PR #39 で walletClient は resolve するようになったが、その先の write call が落ちる構造が残っていたため画面上は `FAIL` 表示のままだった。

### 対応

1. **`ensureChain(walletClient, target)` ヘルパーを `web3/utils.ts` に追加。** `getChainId()` で現在 chain を確認し、不一致なら `switchChain({ id })` を呼んで `wallet_switchEthereumChain` プロンプトを出す。一致なら no-op。
2. **`mintINft` (galileo) / `registerSubname` (sepolia) / `executeFirstSwap` (sepolia) の `writeContract` 直前に `ensureChain` を挿入。** 各 tx は必要な chain にユーザーを誘導してから送る。
3. **`forge-onchain` の aggregator を refactor して storage / mint / ens を独立した `PromiseSettledResult` で受ける。** orchestrator 側でも storage 成功 → mint だけ失敗のケースを正確に表現できるように try/catch を分離。storage が失敗した場合は mint reason を `skipped: storage upload failed` で明示する。
4. **テストを新しい signature に追従。** 「storage 成功 / mint 失敗 を独立してレポートする (混線させない)」回帰テストを追加 (16 pass、+1)。

## 残課題 (この PR では触らない)

- `0G iNFT` 行の `VITE_INFT_ADDRESS is not configured` は contract デプロイ + env 設定の話。コード修正対象外で、この PR がマージされた後 env が入れば mint 行だけ独立に success に変わる (今は storage まで巻き込まれて両方 fail に見えるのを直すのが本 PR のゴール)。

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件。
- [x] `bun run lint` (biome check) — クリーン。
- [x] `bun run typecheck` — shared / frontend 共に exit 0。
- [x] `bun run test` — shared 31 pass / frontend 16 pass・1 skip・0 fail (+1 新規)。
- [x] `bun run build` — shared / frontend 共に成功。
- [ ] ローカル dev で MetaMask を Ethereum mainnet に置いて完走 → ENS 行で Sepolia への switch ダイアログが出ることを目視確認。
- [ ] 同じく mainnet 始発 → mint 行のエラーが storage 行に伝播していないことを目視確認 (storage 行は CID success、mint 行だけ env 未設定で fail)。
- [ ] 既に Sepolia にいる場合は switch プロンプトが出ない (no-op) ことを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic blockchain network validation before ENS registration, NFT minting, and token swaps to prevent transaction failures.

* **Refactor**
  * Restructured transaction proof handling to track success/failure states independently across multiple operations for improved error reporting.

* **Tests**
  * Updated test cases to verify correct error handling across independent transaction branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->