### PR TITLE
feat(web3): testnet-only ガード — wagmi config / ensureChain / TestnetGuard 三段構え

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,48 @@
+Gr@diusWeb3 Local Agent Runbook
+
+Scope
+- This repository is testnet-only.
+- Allowed chains for any mutating onchain action:
+  - Sepolia
+  - 0G Galileo (chain id 16602)
+- Never attempt mainnet, fork, or unknown chain execution for write actions.
+- Do not use real value beyond testnet ETH / testnet tokens.
+
+Operating rules
+- Read this file first, then read README.md, Plan.md, CLAUDE.md, and the relevant web3 files before acting.
+- Prefer the smallest possible change.
+- Do not introduce a backend unless absolutely necessary; this app is frontend-only.
+- Preserve existing working tree changes, including FEEDBACK.md.
+- If a chain is not Sepolia or 0G Galileo, stop and refuse the action.
+- If wallet connection, chain state, or env config is ambiguous, stop and ask for confirmation instead of guessing.
+- Never use a private key, seed phrase, API token, or mainnet credential in this repo.
+
+Allowed actions
+- Read-only browsing of app state, docs, and tests.
+- Testnet-only onchain writes routed through the repo’s guard utilities.
+- Local test execution, linting, and build verification.
+- Updating docs, tests, and copy to make the testnet-only constraint explicit.
+
+Disallowed actions
+- Mainnet execution of any kind.
+- Signing transactions on unsupported chains.
+- Funding or bridging real assets.
+- Circumventing the guard utilities or editing them out for convenience.
+
+Stop conditions
+- Connected chain is not Sepolia or 0G Galileo.
+- The requested action would touch mainnet, a live wallet with non-testnet funds, or an unsupported chain.
+- A write path cannot prove it is testnet-only.
+- A command produces a credential, secret, or unknown remote endpoint.
+
+Suggested Hermes / Claude Code loop
+1. Read AGENT.md, CLAUDE.md, README.md, and Plan.md.
+2. Inspect the relevant source file and tests.
+3. Make the minimal code/doc change.
+4. Add or update Japanese BDD-style tests for the changed behavior.
+5. Run the narrowest relevant tests first, then broader checks if needed.
+6. Verify the app still refuses non-testnet chain IDs for every write path.
+7. Stop immediately after validation; do not expand scope into mainnet support.
+
+Implementation note
+- The repository already contains testnet-aware chain config. New write paths must call the shared guard utility in packages/frontend/src/web3/utils.ts.

--- a/Plan.md
+++ b/Plan.md
@@ -284,4 +284,20 @@
 - **chain switch popup 6 連発の集約**: User Persona 共通の指摘。EIP-5792 multicall や 0G upload を Sepolia 上で代理実行する仕組み (今回未対応、follow-up)。
 - **`.env.example` の編集が permission で禁止**されているため `VITE_ZEROG_INDEXER` / `VITE_ZEROG_RPC` の追記は人間に依頼。コードのデフォルト値があるので動作には支障なし。
 - 0G Storage download / merkle 検証機能 (今回 upload のみ)。
-- 0G Storage SDK の TypeScript 型定義に一部 unknown が残る (orchestrator 側で as 変換、follow-up で SDK 側に PR 検討)。
+- 0G Storage SDK の TypeScript 型定義に一部 unknown が残る (orchestrator 側で as 変換、follow-up で SDK 側に PR 検討).
+
+### Autonomous agent loop foundation (testnet-only)
+
+- 目的: Hermes / Claude Code のようなローカル LLM runtime が `AGENT.md` を読んで、
+  この repo 内で安全に testnet だけを操作できるようにする。
+- ルール:
+  - write path は Sepolia / 0G Galileo (16602) 以外を拒否すること。
+  - mainnet / unknown chain / wallet mismatch は即停止。
+  - runbook は root の `AGENT.md`、実装 guard は `packages/frontend/src/web3/utils.ts`。
+- 実装メモ:
+  - `ensureChain` は target / current が testnet allowlist 外なら throw する。
+  - `executeFirstSwap` / `registerSubname` / `mintINft` / safety attestation の write path はすべて shared guard 経由に統一。
+  - UI には TESTNET_ONLY / testnet-only の文言を追加し、レビュー時に誤解しにくくする。
+- 検証:
+  - `packages/frontend/src/web3/utils.test.ts` で allowlist と mainnet 拒否を確認。
+  - 実地 write は Sepolia / 0G Galileo 以外では開始されないことをコードで保証。

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ A 60-second retro arcade shooter that doubles as the world's fastest onboarding 
 | Forge orchestrator (`Promise.allSettled` so one failure never blocks the dashboard) | [`packages/frontend/src/web3/forge-onchain.ts`](./packages/frontend/src/web3/forge-onchain.ts) |
 | Uniswap DX feedback (required for Uniswap prize submission) | [`FEEDBACK.md`](./FEEDBACK.md) |
 | Spec + scoring rubric + Plan log | [`docs/specs/2026-04-27-web3-wiring.md`](./docs/specs/2026-04-27-web3-wiring.md), [`Plan.md`](./Plan.md) |
+| Local autonomous agent runbook (testnet-only) | [`AGENT.md`](./AGENT.md) |
 
-The contract + module surface is intentionally tight (~7 frontend files, 1 contract) so judges can read the entire on-chain pipeline in under 5 minutes.
+The contract + module surface is intentionally tight (~7 frontend files, 1 contract) so judges can read the entire on-chain pipeline in under 5 minutes. For the local autonomous agent loop, read [`AGENT.md`](./AGENT.md) first; it explicitly limits execution to Sepolia and 0G Galileo.
 
 ---
 
@@ -179,7 +180,9 @@ button in the nav bar speaks the standard EIP-1193 protocol — MetaMask /
 Coinbase Wallet / any injected provider connects natively, and chain
 switching to Sepolia / Base Sepolia / OP Sepolia / Arbitrum Sepolia happens
 in-app. The connected address becomes the agent's owner address; no
-in-browser private key derivation is used for live signing.
+in-browser private key derivation is used for live signing. All write paths
+are guarded in code to refuse non-testnet / mainnet execution; the agent loop
+runbook lives in [`AGENT.md`](./AGENT.md).
 
 ---
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { Fighter } from './components/Fighter';
 import { Callout, HUDCorners, Reticle } from './components/HUD';
 import { GAME_END_EVENT, MusicPlayer } from './components/MusicPlayer';
 import { SafetyAttestationPanel } from './components/SafetyAttestationPanel';
+import { TestnetGuard } from './components/TestnetGuard';
 import type { Archetype } from './game/runtime';
 import { runOnChainForge } from './web3/forge-onchain';
 import {
@@ -331,6 +332,7 @@ export function App() {
 
   return (
     <div style={S.shell}>
+      <TestnetGuard />
       <StatusBar />
       <Nav onPlay={jumpToArcade} />
       <Hero
@@ -419,6 +421,7 @@ function StatusBar() {
         v={chainLabel}
         color={isConnected ? A.hud : A.mute}
       />
+      <StatusCell k="MODE" v="TESTNET_ONLY" color={A.amber} />
       <StatusCell k="UTC" v={clock} color={A.green} />
       <StatusCell k="OP" v="ETHGLOBAL_TOKYO" />
       <span style={{ color: A.amber, justifySelf: 'end' }}>

--- a/packages/frontend/src/components/AgentDashboard.tsx
+++ b/packages/frontend/src/components/AgentDashboard.tsx
@@ -435,9 +435,10 @@ function OnChainProofPanel({
         <span className="eyebrow" style={{ color: A.amber }}>
           ON-CHAIN PROOF
         </span>
-        <h2 style={{ color: A.ink }}>Realized on testnet</h2>
+        <h2 style={{ color: A.ink }}>Realized on testnet only</h2>
         <p style={{ color: A.mute, fontSize: 12 }}>
           0G Galileo iNFT · 0G Storage CID · Sepolia ENS · Sepolia Uniswap.
+          Mainnet / unsupported chain IDs are rejected before any write.
         </p>
       </div>
 

--- a/packages/frontend/src/components/TestnetGuard.tsx
+++ b/packages/frontend/src/components/TestnetGuard.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { useAccount, useSwitchChain } from 'wagmi';
+import { PRIMARY_TESTNET, SUPPORTED_TESTNETS } from '../web3/chains';
+
+const SUPPORTED_IDS: ReadonlySet<number> = new Set(
+  SUPPORTED_TESTNETS.map((c) => c.id)
+);
+
+const SUPPORTED_LABEL = SUPPORTED_TESTNETS.map((c) => c.name).join(' / ');
+
+/// Wallet が mainnet 等 testnet allowlist 外の chain にいるときに、
+/// `wallet_switchEthereumChain` で Sepolia に強制スイッチを試みる。
+/// auto switch を 1 回試みた chainId は記録しておき、ユーザーが拒否した
+/// 場合に無限プロンプトループにならないようにする。
+///
+/// 表示は controlled banner で、ユーザーが拒否したまま mainnet に居続けた
+/// 場合でも「testnet 専用」が常時見えるようにする。
+export function TestnetGuard() {
+  const { isConnected, chainId } = useAccount();
+  const { switchChain } = useSwitchChain();
+  const [lastAttempted, setLastAttempted] = useState<number | null>(null);
+
+  const onUnsupported =
+    isConnected && chainId !== undefined && !SUPPORTED_IDS.has(chainId);
+
+  useEffect(() => {
+    if (!onUnsupported || chainId === undefined) return;
+    if (lastAttempted === chainId) return;
+    setLastAttempted(chainId);
+    switchChain({ chainId: PRIMARY_TESTNET.id });
+  }, [onUnsupported, chainId, lastAttempted, switchChain]);
+
+  if (!onUnsupported) return null;
+
+  return (
+    <div role="alert" style={STYLES.banner}>
+      <span style={STYLES.tag}>TESTNET ONLY</span>
+      <span style={STYLES.body}>
+        Gr@diusWeb3 は {SUPPORTED_LABEL} 専用です。現在 wallet は chain{' '}
+        {chainId} にいます。{PRIMARY_TESTNET.name} への切り替えを wallet で
+        承認してください。
+      </span>
+      <button
+        type="button"
+        style={STYLES.button}
+        onClick={() => switchChain({ chainId: PRIMARY_TESTNET.id })}
+      >
+        Switch to {PRIMARY_TESTNET.name}
+      </button>
+    </div>
+  );
+}
+
+const STYLES = {
+  banner: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    padding: '10px 16px',
+    background: '#2b1605',
+    borderBottom: '1px solid #ffb84d',
+    color: '#ffb84d',
+    fontSize: 12,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase' as const,
+    fontFamily: 'inherit',
+    position: 'sticky' as const,
+    top: 0,
+    zIndex: 50,
+  },
+  tag: {
+    fontWeight: 700,
+    border: '1px solid #ffb84d',
+    padding: '2px 8px',
+    letterSpacing: '0.18em',
+  },
+  body: {
+    flex: 1,
+    lineHeight: 1.5,
+  },
+  button: {
+    background: 'transparent',
+    color: '#ffb84d',
+    border: '1px solid #ffb84d',
+    padding: '6px 12px',
+    fontSize: 11,
+    letterSpacing: '0.16em',
+    textTransform: 'uppercase' as const,
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+  },
+} as const;

--- a/packages/frontend/src/lib/wagmi.ts
+++ b/packages/frontend/src/lib/wagmi.ts
@@ -1,15 +1,13 @@
 import { http, createConfig } from 'wagmi';
-import {
-  arbitrumSepolia,
-  baseSepolia,
-  optimismSepolia,
-  sepolia,
-} from 'wagmi/chains';
 import { coinbaseWallet, injected } from 'wagmi/connectors';
-import { galileo } from '../web3/chains';
+import { galileo, sepolia } from '../web3/chains';
 
+/// Gr@diusWeb3 は testnet 専用。chains には ENS/Uniswap 用の Sepolia と
+/// iNFT mint 用の 0G Galileo のみを置き、mainnet を含めない。これに
+/// 載っていない chain (mainnet 等) に wallet がいるときは TestnetGuard が
+/// Sepolia への switch を要求する。
 export const config = createConfig({
-  chains: [sepolia, baseSepolia, optimismSepolia, arbitrumSepolia, galileo],
+  chains: [sepolia, galileo],
   multiInjectedProviderDiscovery: true,
   connectors: [
     injected({ shimDisconnect: true }),
@@ -19,9 +17,6 @@ export const config = createConfig({
   ],
   transports: {
     [sepolia.id]: http(),
-    [baseSepolia.id]: http(),
-    [optimismSepolia.id]: http(),
-    [arbitrumSepolia.id]: http(),
     [galileo.id]: http(),
   },
   ssr: false,

--- a/packages/frontend/src/web3/chains.ts
+++ b/packages/frontend/src/web3/chains.ts
@@ -20,4 +20,13 @@ export const galileo = defineChain({
   testnet: true,
 });
 
+/// アプリが許容するすべての testnet。mainnet を絶対に触らせないための allowlist。
+/// ENS / Uniswap は Sepolia、iNFT mint は 0G Galileo。それ以外は wallet 接続
+/// 時点で Sepolia へ強制スイッチするので、ここに含めない。
+export const SUPPORTED_TESTNETS = [sepolia, galileo] as const;
+
+/// 接続直後 / 不明 chain にいたときの誘導先。ENS と Uniswap が Sepolia なので
+/// primary を Sepolia に置く。0G mint は ensureChain が galileo に切り替える。
+export const PRIMARY_TESTNET = sepolia;
+
 export { sepolia };

--- a/packages/frontend/src/web3/safety-attestation.ts
+++ b/packages/frontend/src/web3/safety-attestation.ts
@@ -15,7 +15,7 @@ import {
 import { galileo, sepolia } from './chains';
 import { registerSubname } from './ens-register';
 import type { EnsProof, OnChainStep, StorageProof } from './types';
-import { errorMessage } from './utils';
+import { ensureChain, errorMessage } from './utils';
 import { buildZeroGSigner, putAttestation } from './zerog-storage';
 
 /// Sepolia の ENS Registry。NameWrapper とは別、namehash → owner address を引く。
@@ -35,35 +35,15 @@ const REGISTRY_OWNER_ABI = [
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-/// 任意の chain id への switch を試行する共通ヘルパ。
-/// 既に同 chain ならば no-op。switchChain が throw した場合は friendly な
-/// 日本語メッセージで上位に伝播する (private key 等は露出させない)。
-async function ensureChain(
-  walletClient: WalletClient,
-  targetId: number,
-  label: string
-): Promise<void> {
-  const chainId = walletClient.chain?.id;
-  if (chainId === targetId) return;
-  try {
-    await walletClient.switchChain({ id: targetId });
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : 'unknown';
-    throw new Error(
-      `chain mismatch — ${label} (${targetId}) への切替に失敗しました (現在 ${chainId ?? 'unknown'}): ${detail}`
-    );
-  }
-}
-
 /// Sepolia 接続を assert する。ENS write は Sepolia 以外で走るとアテステーション
 /// が別 chain に書かれる事故になるため、書込み直前で必ず通す。
 async function ensureSepoliaChain(walletClient: WalletClient): Promise<void> {
-  await ensureChain(walletClient, sepolia.id, 'Sepolia');
+  await ensureChain(walletClient, sepolia);
 }
 
 /// 0G Galileo 接続を assert する。0G Storage への put 直前のみ呼ぶ。
 async function ensureGalileoChain(walletClient: WalletClient): Promise<void> {
-  await ensureChain(walletClient, galileo.id, '0G Galileo');
+  await ensureChain(walletClient, galileo);
 }
 
 /// pilot{4 桁 hex} の handle が「自分以外のオーナーに先取りされていない」ことを

--- a/packages/frontend/src/web3/utils.test.ts
+++ b/packages/frontend/src/web3/utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import type { WalletClient } from 'viem';
+import { galileo, sepolia } from './chains';
+import { executeFirstSwap } from './uniswap-swap';
+import {
+  assertSupportedTestnetChainId,
+  describeSupportedTestnets,
+  isSupportedTestnetChainId,
+} from './utils';
+
+describe('testnet guard - オンチェーン書き込みは testnet のみ許可する', () => {
+  it('Sepolia と 0G Galileo だけを許可し、それ以外は拒否する', () => {
+    expect(isSupportedTestnetChainId(sepolia.id)).toBe(true);
+    expect(isSupportedTestnetChainId(galileo.id)).toBe(true);
+    expect(isSupportedTestnetChainId(1)).toBe(false);
+  });
+
+  it('許可チェーン一覧を runbook と同じ順序で返す', () => {
+    expect(describeSupportedTestnets()).toBe('Sepolia / 0G Galileo');
+  });
+
+  it('mainnet の chainId を受けると friendly なエラーで止める', () => {
+    expect(() => assertSupportedTestnetChainId(1, 'connected wallet')).toThrow(
+      'testnet only'
+    );
+  });
+});
+
+describe('executeFirstSwap - testnet 以外では write を開始しない', () => {
+  it('mainnet 相当の chainId では swap 前に拒否する', async () => {
+    const walletClient = {
+      account: {
+        address: '0x000000000000000000000000000000000000dEaD',
+      },
+      getChainId: async () => 1,
+      switchChain: async () => {
+        throw new Error('switchChain must not be called for mainnet');
+      },
+      writeContract: async () => {
+        throw new Error('writeContract must not be called for mainnet');
+      },
+    } as unknown as WalletClient;
+
+    await expect(executeFirstSwap(walletClient)).rejects.toThrow(
+      'testnet only'
+    );
+  });
+});

--- a/packages/frontend/src/web3/utils.ts
+++ b/packages/frontend/src/web3/utils.ts
@@ -1,4 +1,5 @@
 import type { Chain, WalletClient } from 'viem';
+import { galileo, sepolia } from './chains';
 
 /// 失敗 reason を画面・ログ表示用の文字列に正規化する。
 /// Error / string / その他を 1 行で返す。private key やシークレットを含む
@@ -8,16 +9,65 @@ export function errorMessage(reason: unknown): string {
   return typeof reason === 'string' ? reason : 'unknown error';
 }
 
+const SUPPORTED_TESTNET_CHAIN_IDS = new Map<number, string>([
+  [sepolia.id, 'Sepolia'],
+  [galileo.id, '0G Galileo'],
+]);
+
+export function isSupportedTestnetChainId(chainId: number): boolean {
+  return SUPPORTED_TESTNET_CHAIN_IDS.has(chainId);
+}
+
+export function describeSupportedTestnets(): string {
+  return Array.from(SUPPORTED_TESTNET_CHAIN_IDS.values()).join(' / ');
+}
+
+export function formatTestnetOnlyError(
+  chainId: number,
+  context: string
+): string {
+  const label = SUPPORTED_TESTNET_CHAIN_IDS.get(chainId) ?? `chain ${chainId}`;
+  return `testnet only: ${context} は ${describeSupportedTestnets()} でのみ実行できます (current ${label})`;
+}
+
+export function assertSupportedTestnetChainId(
+  chainId: number,
+  context: string
+): void {
+  if (!isSupportedTestnetChainId(chainId)) {
+    throw new Error(formatTestnetOnlyError(chainId, context));
+  }
+}
+
 /// writeContract 直前に wallet を target chain に揃える。
 /// viem の writeContract({ chain }) は chain mismatch を assert で投げるだけで
 /// auto switch しない (`viem/utils/chain/assertCurrentChain`)。なので各 tx の
 /// 直前に明示的に switchChain を呼んで、必要なら wallet_switchEthereumChain
 /// プロンプトをユーザーに見せる。chain がもう一致していれば no-op。
+///
+/// Defense-in-depth: target も current も testnet allowlist 外なら throw する。
+/// これでロジックバグや将来の改変で mainnet writeContract に到達しても、
+/// ここで必ず止まる (Gr@diusWeb3 は testnet 専用)。
 export async function ensureChain(
   walletClient: WalletClient,
   target: Chain
 ): Promise<void> {
+  assertSupportedTestnetChainId(target.id, `target chain ${target.name}`);
   const currentId = await walletClient.getChainId();
+  assertSupportedTestnetChainId(currentId, 'connected wallet');
   if (currentId === target.id) return;
-  await walletClient.switchChain({ id: target.id });
+  try {
+    await walletClient.switchChain({ id: target.id });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'unknown';
+    throw new Error(
+      `chain mismatch — ${target.name} (${target.id}) への切替に失敗しました (現在 ${currentId}): ${detail}`
+    );
+  }
+  const switchedId = await walletClient.getChainId();
+  if (switchedId !== target.id) {
+    throw new Error(
+      `chain mismatch — ${target.name} (${target.id}) への切替後に現在 chainId が一致しませんでした (現在 ${switchedId})`
+    );
+  }
 }


### PR DESCRIPTION
## Summary

「mainnet は事故るので testnet にしか繋がらないようにしたい。シューティングゲームが終わったあとは Agent が取引をして、署名依頼だけがユーザーに来るイメージ」というリクエストへの三段構え対応。

### Layer 1 — wagmi config を testnet 2 chain に絞る

`packages/frontend/src/lib/wagmi.ts` の `chains` を Sepolia (ENS + Uniswap) と 0G Galileo (iNFT mint) の 2 つだけに絞り、mainnet も使われていない他の Sepolia 派生も含めない。これで wagmi 経由で mainnet を活性 chain として認識できなくなる。

### Layer 2 — `ensureChain` を defense-in-depth で強化

`packages/frontend/src/web3/utils.ts`:

- `SUPPORTED_TESTNET_CHAIN_IDS = Map<id, label>` を allowlist として保持。`isSupportedTestnetChainId` / `assertSupportedTestnetChainId` / `describeSupportedTestnets` をエクスポート。
- `ensureChain(walletClient, target)`:
  - target が allowlist 外なら throw (将来 mainnet を引数に取るバグが入っても止まる)。
  - `getChainId()` で取った current が allowlist 外でも throw。
  - `switchChain` が throw / 切替後 chainId 不一致でも friendly Japanese エラーで上位へ。
- `safety-attestation.ts` の独自 `ensureChain` 実装を削除し、shared 経由に統一。

`utils.test.ts` を新設して allowlist と「`executeFirstSwap` は mainnet 相当の `chainId === 1` を返す walletClient では writeContract 前に reject する」を回帰テスト化 (20 pass、+4)。

### Layer 3 — `TestnetGuard` コンポーネントで UX を testnet 専用に固定

`packages/frontend/src/components/TestnetGuard.tsx`:

- `useAccount().chainId` を監視し、wallet が allowlist 外 (mainnet 等) にいると `wallet_switchEthereumChain` を 1 回自動発火して Sepolia に誘導。
- 同じ `chainId` に対しては再試行しないので、ユーザーが拒否してもプロンプトループにはならない。
- 切替が完了するまでページ最上部に sticky banner で「TESTNET ONLY — Switch to Sepolia」ボタンを表示。

`AgentDashboard.tsx` の OnChainProofPanel 見出しも「Realized on testnet only」+「Mainnet / unsupported chain IDs are rejected before any write.」に更新し、UI 側でも testnet 専用が明示される。

### 補足: Agent loop runbook

ローカルで自律的に動かす AI agent (Claude Code 含む) 向けに `AGENT.md` を新設し、testnet-only / Sepolia + Galileo 限定 / mainnet 絶対禁止 / guard utilities を迂回しないこと、を runbook 化。`README.md` と `Plan.md` にも参照を追加。

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件。
- [x] `bun run lint` (biome check) — クリーン。
- [x] `bun run typecheck` — shared / frontend 共に exit 0。
- [x] `bun run test` — shared 31 pass / frontend 20 pass・1 skip・0 fail (+4 新規)。
- [x] `bun run build` — shared / frontend 共に成功。
- [ ] ローカル dev で MetaMask を Ethereum mainnet に置いて接続 → 自動で Sepolia への switch ダイアログが出ることを目視確認。
- [ ] そのままユーザーが拒否 → 「TESTNET ONLY」banner が出続けて再プロンプトはされないことを確認。
- [ ] Sepolia に切替後 → banner 消失、ゲーム完走で forge が動くことを確認。
- [ ] 0G Galileo に手動切替 → banner 出ないこと、ENS step で Sepolia 切替ダイアログが出ること。