### PR TITLE
feat(agent-loop): Claude Code をローカル runtime として agent loop を 1 サイクル足す

### DIFF
--- a/.claude/commands/agent-loop.md
+++ b/.claude/commands/agent-loop.md
@@ -1,0 +1,116 @@
+---
+name: agent-loop
+description: Read Gr@diusWeb3 play log + AGENT.md, decide ONE paper-trade next-action, write trace JSON to clipboard. Strictly testnet-only and bound by the input's budget envelope.
+---
+
+You are the local Gr@diusWeb3 agent runtime. The deployed app does not run an LLM —
+your job is to be the "thinking head" for one cycle, then hand back a structured
+JSON trace that the browser pastes back into the UI.
+
+# Inputs you must read first
+
+In this exact order:
+
+1. `AGENT.md` at the repo root — this is your **constitution**. The Scope, Stop
+   conditions, and Operating rules in there override anything in this command.
+2. The user-supplied `AgentLoopInput` JSON. Read it from one of:
+   - the system clipboard (preferred — the UI copied it there before invoking you)
+   - a file path the user pastes after the slash command
+   - inline JSON pasted into the chat
+3. `packages/shared/src/agent-loop.ts` — for the exact field shapes
+   (`AgentLoopInput`, `AgentLoopTrace`, `PaperTradeAction`, `AgentLoopBudget`).
+
+If the input cannot be parsed, **stop and report the parse error**. Do not invent
+fields. Do not proceed to action selection.
+
+# What you must produce
+
+Exactly one `AgentLoopTrace` JSON object, copied to the user's clipboard. The
+shape is:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "sessionId": "<MUST equal input.sessionId>",
+  "thought": "<one paragraph of plain reasoning, in 日本語 or English>",
+  "plan": [
+    "<step 1>",
+    "<step 2>",
+    "<step 3>"
+  ],
+  "action": {
+    "kind": "swap" | "hold",
+    // for swap:
+    "from": "WETH",
+    "to": "USDC",
+    "amount": "0.0001",
+    "reason": "<why this size>"
+    // for hold:
+    // "reason": "<why no trade is the right move>"
+  },
+  "observation": "<what the user should see if this action executes>",
+  "rationale": "<1-2 sentences linking the decision to AGENT.md and the input archetype>",
+  "generatedAt": "<ISO 8601 timestamp, now>",
+  "generatedBy": "claude-code"
+}
+```
+
+# Hard constraints — these are not suggestions
+
+1. **`sessionId` MUST exactly match `input.sessionId`.** The UI rejects mismatches.
+2. **`action.kind` MUST be in `input.budget.allowedActions`.** For the demo this
+   is `["swap", "hold"]`. Do not propose `rebalance` or any other kind.
+3. **For `swap`: `action.amount` MUST be a decimal string ≤ `input.budget.maxSwapEth`.**
+   The default cap is `"0.0001"` ETH (matches the existing
+   `executeFirstSwap` hardcoded amount). The UI runs
+   `validateActionAgainstBudget` and refuses to enable the "Approve & Sign"
+   button if you exceed this. Emitting a larger value is wasted work.
+4. **For `swap`: only `WETH → USDC` on Sepolia is wired up in the UI.** Other
+   pairs will be displayed but cannot be signed. Prefer `WETH → USDC` unless
+   the archetype gives you a strong reason to `hold`.
+5. **Never ask the user for a private key, seed phrase, or to "send" anything
+   directly from the CLI.** Signing happens in the browser MetaMask. You produce
+   intent; the user approves it.
+6. **You do not call any RPC, do not import the testnet swap module, do not run
+   network requests.** This is a pure thinking step. The browser handles the
+   chain.
+7. **`generatedBy` MUST be `"claude-code"`** (not `"simulator"` — that string is
+   reserved for the deterministic fallback).
+
+# Decision heuristics (lightweight, archetype-aware)
+
+`input.archetype` is one of `defensive | balanced | aggressive | swarm` (or
+similar — treat unknown values as `balanced`). The play log can give richer
+context but the archetype is the cheap headline:
+
+- **defensive** → bias toward `hold` unless `combatPower` is high. When
+  swapping, stay at the budget cap (small position).
+- **balanced** → swap at the budget cap; `hold` is acceptable if the play log
+  shows the pilot ate hits late in the run.
+- **aggressive** → swap at the budget cap; `hold` only if the trace would be
+  contradicted by the play log (e.g. zero hits taken).
+- **swarm** → swap at the budget cap; emphasize "first move of many" in the
+  observation since the narrative is multi-agent.
+
+These are *defaults*. If the play log tells a clearer story (e.g. high
+`finalScore` + many `dodge` events → "agent is precise, ship it"), let that
+override the archetype default and say so in `rationale`.
+
+# How to deliver
+
+1. Print the trace JSON to the chat (pretty-printed, fenced as ```json).
+2. Copy the same JSON to the system clipboard (`pbcopy` on macOS,
+   `wl-copy`/`xclip` on Linux). On the OS where neither is available,
+   tell the user explicitly so they copy manually.
+3. End with a one-line summary like:
+   `done — paste the trace into the "Agent loop" panel in the browser.`
+
+# Stop conditions
+
+- The input fails to parse, or `schemaVersion !== 1`.
+- The input's `budget.allowedChainIds` does not include any testnet you'd
+  normally target — abort and explain.
+- The user's request would touch mainnet, real funds, or any chain that is
+  not on the testnet allowlist (`AGENT.md` Scope section). This is a hard stop.
+- You cannot honor the budget envelope. **Never weaken the budget** to make
+  the action fit; emit `hold` instead with a reason.

--- a/AGENT.md
+++ b/AGENT.md
@@ -46,3 +46,28 @@ Suggested Hermes / Claude Code loop
 
 Implementation note
 - The repository already contains testnet-aware chain config. New write paths must call the shared guard utility in packages/frontend/src/web3/utils.ts.
+
+Agent loop handoff (one cycle)
+- The deployed UI does not run an LLM. It hands off to whatever agent runtime
+  is reading this file (Claude Code locally is the default).
+- Slash command spec: .claude/commands/agent-loop.md.
+- JSON contract: packages/shared/src/agent-loop.ts (AgentLoopInput → AgentLoopTrace,
+  schemaVersion 1).
+- Flow: browser copies AgentLoopInput JSON to clipboard → user runs
+  /agent-loop → trace JSON returned to clipboard → user pastes into the
+  "Agent loop" panel in the browser → UI validates and gates the
+  "Approve & Sign" button on the budget envelope below.
+
+Budget envelope (HARD limits, non-negotiable)
+- Per-action ETH ceiling: 0.0001 (matches executeFirstSwap's hardcoded amount
+  in packages/frontend/src/web3/uniswap-swap.ts).
+- Allowed PaperTradeAction kinds for the demo: "swap" and "hold". Anything
+  else (e.g. "rebalance") is refused at validateActionAgainstBudget before
+  the UI ever offers a sign button.
+- Allowed chain ids: Sepolia (11155111) and 0G Galileo (16602). Mirrors
+  SUPPORTED_TESTNET_CHAIN_IDS in packages/frontend/src/web3/utils.ts.
+- The agent never weakens the envelope to make an action fit. If the desired
+  trade would exceed the cap, emit a "hold" action with a reason instead.
+- The agent never asks the user for a private key, seed phrase, or signs
+  anything itself. Real signing happens in the browser MetaMask via the
+  existing forge swap path. The agent produces intent only.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react';
 import { useAccount, useChainId, useWalletClient } from 'wagmi';
 import { AgentDashboard } from './components/AgentDashboard';
+import { AgentLoopPanel } from './components/AgentLoopPanel';
 import { BirthArcade } from './components/BirthArcade';
 import { ConnectButton } from './components/ConnectButton';
 import { Fighter } from './components/Fighter';
@@ -363,6 +364,24 @@ export function App() {
           onFirstSwap={handleFirstSwap}
           swapping={swapping}
         />
+      ) : null}
+      {birth ? (
+        <section style={S.section}>
+          <SectionHead
+            num="§ 08 / AGENT_LOOP"
+            title="Local Claude Code as the thinking head."
+            right="HANDOFF"
+          />
+          <div style={{ padding: '24px 28px 40px' }}>
+            <AgentLoopPanel
+              birth={birth}
+              proof={proof}
+              walletAddress={ownerAddress}
+              onApproveSwap={handleFirstSwap}
+              swapping={swapping}
+            />
+          </div>
+        </section>
       ) : null}
       <CTASection onPlay={jumpToArcade} />
       <FooterBar />

--- a/packages/frontend/src/components/AgentLoopPanel.tsx
+++ b/packages/frontend/src/components/AgentLoopPanel.tsx
@@ -1,0 +1,472 @@
+import {
+  type AgentLoopForgeSnapshot,
+  type AgentLoopInput,
+  type AgentLoopTrace,
+  type BudgetVerdict,
+  buildAgentLoopInput,
+  safeParseAgentLoopTrace,
+  validateActionAgainstBudget,
+} from '@gradiusweb3/shared/browser';
+import type { StoredAgentBirth } from '@gradiusweb3/shared/browser';
+import { type CSSProperties, useMemo, useState } from 'react';
+import type { OnChainProof } from '../web3/types';
+
+const A = {
+  ink: '#e6f1ff',
+  mute: '#5a6c80',
+  panel: '#0a1118',
+  rule: '#1a2735',
+  amber: '#ffb84d',
+  acid: '#c8ff00',
+  hot: '#ff4438',
+  green: '#3dffa3',
+} as const;
+
+interface Props {
+  birth: StoredAgentBirth;
+  proof: OnChainProof;
+  walletAddress?: string;
+  onApproveSwap: () => void;
+  swapping: boolean;
+}
+
+export function AgentLoopPanel({
+  birth,
+  proof,
+  walletAddress,
+  onApproveSwap,
+  swapping,
+}: Props) {
+  const input = useMemo<AgentLoopInput>(
+    () =>
+      buildAgentLoopInput({
+        draft: birth,
+        walletAddress,
+        forgeProof: snapshotFromProof(proof),
+      }),
+    [birth, walletAddress, proof]
+  );
+
+  const inputJson = useMemo(() => JSON.stringify(input, null, 2), [input]);
+
+  const [pasteText, setPasteText] = useState('');
+  const [pasteError, setPasteError] = useState<string | null>(null);
+  const [trace, setTrace] = useState<AgentLoopTrace | null>(null);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>(
+    'idle'
+  );
+
+  const verdict: BudgetVerdict | null = useMemo(() => {
+    if (!trace) return null;
+    return validateActionAgainstBudget(trace.action, input.budget);
+  }, [trace, input.budget]);
+
+  const sessionMatches = trace ? trace.sessionId === input.sessionId : false;
+  const canSign = trace !== null && verdict?.ok === true && sessionMatches;
+
+  function copyInput() {
+    void (async () => {
+      try {
+        await navigator.clipboard.writeText(inputJson);
+        setCopyState('copied');
+        setTimeout(() => setCopyState('idle'), 1800);
+      } catch {
+        setCopyState('error');
+      }
+    })();
+  }
+
+  function downloadInput() {
+    const blob = new Blob([inputJson], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `agent-loop-input-${input.sessionId}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function validatePaste() {
+    setPasteError(null);
+    setTrace(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(pasteText);
+    } catch (caught) {
+      setPasteError(
+        `JSON として読めません: ${
+          caught instanceof Error ? caught.message : String(caught)
+        }`
+      );
+      return;
+    }
+    const result = safeParseAgentLoopTrace(parsed);
+    if (!result.ok) {
+      setPasteError(result.error);
+      return;
+    }
+    if (result.trace.sessionId !== input.sessionId) {
+      setPasteError(
+        `sessionId 不一致: 期待 "${input.sessionId}" / 受信 "${result.trace.sessionId}"`
+      );
+      return;
+    }
+    setTrace(result.trace);
+  }
+
+  return (
+    <section style={STYLES.section}>
+      <div style={STYLES.header}>
+        <span style={STYLES.eyebrow}>AGENT LOOP</span>
+        <h2 style={{ color: A.ink, margin: 0 }}>
+          Hand off to local Claude Code
+        </h2>
+        <p style={{ color: A.mute, fontSize: 12, margin: 0, lineHeight: 1.6 }}>
+          The deployed app does not run an LLM. Copy the play log + forge
+          snapshot below, run{' '}
+          <code style={STYLES.code}>claude /agent-loop</code> locally so Claude
+          Code reads <code style={STYLES.code}>AGENT.md</code> as its
+          constitution, then paste the resulting trace JSON back here. Real
+          signing stays in your browser MetaMask, capped at{' '}
+          <strong>{input.budget.maxSwapEth} ETH</strong> per action.
+        </p>
+      </div>
+
+      <div style={STYLES.row}>
+        <h3 style={STYLES.h3}>1. Export input</h3>
+        <div style={STYLES.buttonRow}>
+          <button type="button" style={STYLES.button} onClick={copyInput}>
+            {copyState === 'copied'
+              ? '✓ Copied'
+              : copyState === 'error'
+                ? '✗ Clipboard blocked'
+                : '📋 Copy input JSON'}
+          </button>
+          <button type="button" style={STYLES.button} onClick={downloadInput}>
+            ⬇️ Download
+          </button>
+        </div>
+        <pre style={STYLES.preview}>
+          <code>{previewJson(inputJson)}</code>
+        </pre>
+      </div>
+
+      <div style={STYLES.row}>
+        <h3 style={STYLES.h3}>2. Run locally</h3>
+        <ol style={STYLES.ol}>
+          <li>
+            Open Claude Code in the repo, run{' '}
+            <code style={STYLES.code}>/agent-loop</code>.
+          </li>
+          <li>
+            It will read <code style={STYLES.code}>AGENT.md</code> + the input
+            JSON from your clipboard.
+          </li>
+          <li>It outputs a trace JSON respecting your budget envelope.</li>
+        </ol>
+      </div>
+
+      <div style={STYLES.row}>
+        <h3 style={STYLES.h3}>3. Paste trace</h3>
+        <textarea
+          style={STYLES.textarea}
+          placeholder='{"schemaVersion":1,"sessionId":"...","thought":"...",...}'
+          value={pasteText}
+          onChange={(e) => setPasteText(e.target.value)}
+          rows={6}
+          spellCheck={false}
+        />
+        <div style={STYLES.buttonRow}>
+          <button
+            type="button"
+            style={STYLES.button}
+            onClick={validatePaste}
+            disabled={pasteText.trim().length === 0}
+          >
+            Validate
+          </button>
+        </div>
+        {pasteError ? (
+          <div style={STYLES.error}>
+            <strong>✗ Rejected:</strong> {pasteError}
+          </div>
+        ) : null}
+      </div>
+
+      {trace ? (
+        <div style={STYLES.row}>
+          <h3 style={STYLES.h3}>4. Decision</h3>
+          <TraceTimeline trace={trace} verdict={verdict} />
+
+          <div style={STYLES.buttonRow}>
+            <button
+              type="button"
+              style={canSign ? STYLES.signOk : STYLES.signBlocked}
+              onClick={onApproveSwap}
+              disabled={!canSign || swapping || trace.action.kind !== 'swap'}
+            >
+              {swapping
+                ? 'Awaiting MetaMask…'
+                : trace.action.kind === 'hold'
+                  ? '⏸ Hold (no signature needed)'
+                  : canSign
+                    ? `Approve & Sign on Testnet (≤ ${input.budget.maxSwapEth} ETH)`
+                    : '✗ Blocked by budget'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function snapshotFromProof(proof: OnChainProof): AgentLoopForgeSnapshot {
+  const snapshot: AgentLoopForgeSnapshot = {};
+  if (proof.storage.status === 'success' && proof.storage.data) {
+    snapshot.storage = { cid: proof.storage.data.cid };
+  }
+  if (proof.mint.status === 'success' && proof.mint.data) {
+    snapshot.mint = {
+      txHash: proof.mint.data.txHash,
+      tokenId: proof.mint.data.tokenId,
+    };
+  }
+  if (proof.ens.status === 'success' && proof.ens.data) {
+    snapshot.ens = { name: proof.ens.data.name };
+  }
+  if (proof.swap.status === 'success' && proof.swap.data) {
+    snapshot.swap = { txHash: proof.swap.data.txHash };
+  }
+  return snapshot;
+}
+
+function previewJson(json: string): string {
+  // Keep the on-page preview small but representative — first ~1.6KB.
+  if (json.length <= 1600) return json;
+  return `${json.slice(0, 1600)}\n… (${json.length - 1600} more chars in clipboard / download)`;
+}
+
+function TraceTimeline({
+  trace,
+  verdict,
+}: {
+  trace: AgentLoopTrace;
+  verdict: BudgetVerdict | null;
+}) {
+  return (
+    <div style={STYLES.timeline}>
+      <Field label="THOUGHT" body={trace.thought} />
+      <div>
+        <div style={STYLES.fieldLabel}>PLAN</div>
+        <ol style={STYLES.planOl}>
+          {trace.plan.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+      </div>
+      <Field label="ACTION" body={renderAction(trace.action)} />
+      <Field label="OBSERVATION" body={trace.observation} />
+      <Field label="RATIONALE" body={trace.rationale} />
+      <div style={STYLES.metaRow}>
+        <span>
+          generated by{' '}
+          <strong style={{ color: A.ink }}>{trace.generatedBy}</strong>
+        </span>
+        <span>{trace.generatedAt}</span>
+      </div>
+      <div
+        style={{
+          ...STYLES.budgetRow,
+          color: verdict?.ok ? A.green : A.hot,
+          borderColor: verdict?.ok ? A.green : A.hot,
+        }}
+      >
+        {verdict?.ok
+          ? '✓ Within budget — sign button is live'
+          : `✗ Budget verdict: ${verdict?.reason ?? 'pending validation'}`}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, body }: { label: string; body: string }) {
+  return (
+    <div>
+      <div style={STYLES.fieldLabel}>{label}</div>
+      <div style={STYLES.fieldBody}>{body}</div>
+    </div>
+  );
+}
+
+function renderAction(action: AgentLoopTrace['action']): string {
+  if (action.kind === 'swap') {
+    return `swap ${action.amount} ${action.from} → ${action.to} · reason: ${action.reason}`;
+  }
+  if (action.kind === 'hold') {
+    return `hold · reason: ${action.reason}`;
+  }
+  return `rebalance: ${action.targets
+    .map((t) => `${t.asset}=${t.weight}`)
+    .join(', ')} · reason: ${action.reason}`;
+}
+
+const STYLES = {
+  section: {
+    border: `1px solid ${A.rule}`,
+    background: A.panel,
+    padding: 20,
+    margin: '20px 0',
+    display: 'grid',
+    gap: 16,
+  },
+  header: {
+    display: 'grid',
+    gap: 6,
+  },
+  eyebrow: {
+    color: A.amber,
+    fontSize: 11,
+    letterSpacing: '0.18em',
+    textTransform: 'uppercase',
+    fontWeight: 700,
+  },
+  row: {
+    display: 'grid',
+    gap: 10,
+    paddingTop: 14,
+    borderTop: `1px dashed ${A.rule}`,
+  },
+  h3: {
+    color: A.ink,
+    margin: 0,
+    fontSize: 13,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+  },
+  buttonRow: {
+    display: 'flex',
+    gap: 10,
+    flexWrap: 'wrap',
+  },
+  button: {
+    background: 'transparent',
+    color: A.ink,
+    border: `1px solid ${A.ink}`,
+    padding: '8px 14px',
+    fontSize: 12,
+    letterSpacing: '0.14em',
+    textTransform: 'uppercase',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+  },
+  signOk: {
+    background: A.acid,
+    color: '#000',
+    border: `1px solid ${A.acid}`,
+    padding: '10px 16px',
+    fontSize: 13,
+    letterSpacing: '0.16em',
+    textTransform: 'uppercase',
+    cursor: 'pointer',
+    fontWeight: 700,
+    fontFamily: 'inherit',
+  },
+  signBlocked: {
+    background: 'transparent',
+    color: A.mute,
+    border: `1px dashed ${A.mute}`,
+    padding: '10px 16px',
+    fontSize: 13,
+    letterSpacing: '0.16em',
+    textTransform: 'uppercase',
+    cursor: 'not-allowed',
+    fontFamily: 'inherit',
+  },
+  preview: {
+    background: '#040810',
+    color: A.ink,
+    padding: 12,
+    margin: 0,
+    fontSize: 11,
+    lineHeight: 1.5,
+    overflowX: 'auto',
+    maxHeight: 220,
+    overflowY: 'auto',
+    border: `1px solid ${A.rule}`,
+  },
+  ol: {
+    margin: 0,
+    paddingLeft: 20,
+    color: A.mute,
+    fontSize: 12,
+    lineHeight: 1.7,
+  },
+  textarea: {
+    width: '100%',
+    minHeight: 120,
+    background: '#040810',
+    color: A.ink,
+    border: `1px solid ${A.rule}`,
+    padding: 12,
+    fontSize: 12,
+    fontFamily: 'monospace',
+    resize: 'vertical',
+  },
+  error: {
+    color: A.hot,
+    border: `1px solid ${A.hot}`,
+    padding: '10px 12px',
+    fontSize: 12,
+    lineHeight: 1.6,
+  },
+  code: {
+    background: '#040810',
+    color: A.acid,
+    padding: '2px 6px',
+    fontSize: 11,
+    border: `1px solid ${A.rule}`,
+  },
+  timeline: {
+    display: 'grid',
+    gap: 12,
+    border: `1px solid ${A.rule}`,
+    padding: 14,
+    background: '#040810',
+  },
+  fieldLabel: {
+    color: A.amber,
+    fontSize: 10,
+    letterSpacing: '0.2em',
+    textTransform: 'uppercase',
+    fontWeight: 700,
+    marginBottom: 4,
+  },
+  fieldBody: {
+    color: A.ink,
+    fontSize: 13,
+    lineHeight: 1.6,
+  },
+  planOl: {
+    margin: 0,
+    paddingLeft: 22,
+    color: A.ink,
+    fontSize: 13,
+    lineHeight: 1.7,
+  },
+  metaRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    color: A.mute,
+    fontSize: 11,
+    letterSpacing: '0.1em',
+    paddingTop: 6,
+    borderTop: `1px dashed ${A.rule}`,
+  },
+  budgetRow: {
+    fontSize: 12,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    border: '1px solid',
+    padding: '8px 12px',
+  },
+} satisfies Record<string, CSSProperties>;

--- a/packages/shared/src/agent-loop.test.ts
+++ b/packages/shared/src/agent-loop.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  AGENT_LOOP_SCHEMA_VERSION,
+  type AgentLoopBudget,
+  type AgentLoopTrace,
+  DEFAULT_AGENT_LOOP_BUDGET,
+  buildAgentLoopInput,
+  compareEthDecimalStrings,
+  parseAgentLoopTrace,
+  safeParseAgentLoopTrace,
+  validateActionAgainstBudget,
+} from './agent-loop';
+import type { AgentBirthDraft } from './types';
+
+const SAMPLE_DRAFT: AgentBirthDraft = {
+  sessionId: 'sess-loop-1',
+  playerName: 'Kotetsu',
+  playLog: {
+    sessionId: 'sess-loop-1',
+    events: [],
+    durationMs: 60_000,
+    finalScore: 1234,
+  },
+  agent: {
+    tokenId: '0',
+    ensName: 'kotetsu-abc.gradiusweb3.eth',
+    walletAddress: '0x000000000000000000000000000000000000dEaD',
+    seed: 'sha256:deadbeef',
+    birthHash: '0xabc',
+    archetype: 'balanced',
+    highlights: [],
+    profile: {
+      attack: 50,
+      defense: 50,
+      intelligence: 50,
+      agility: 50,
+      cooperation: 50,
+      combatPower: 4321,
+    },
+    policy: {
+      toolsAllowed: [],
+      swarmEnabled: false,
+      maxConcurrentAgents: 1,
+      executionMode: 'balanced',
+      maxPositionSizeUsd: 100,
+      maxDrawdownPct: 5,
+      slippageTolerancePct: 0.5,
+      rebalanceIntervalSec: 60,
+      stopLossPct: 5,
+    },
+    nodes: [],
+  },
+  feed: [],
+};
+
+const SAMPLE_TRACE: AgentLoopTrace = {
+  schemaVersion: AGENT_LOOP_SCHEMA_VERSION,
+  sessionId: 'sess-loop-1',
+  thought: 'pilot は balanced archetype。slippage 上限を尊重する',
+  plan: ['observe combat power', 'pick smallest swap', 'log result'],
+  action: {
+    kind: 'swap',
+    from: 'WETH',
+    to: 'USDC',
+    amount: '0.0001',
+    reason: 'budget 上限ピッタリで demo に最も映える',
+  },
+  observation: '0.0001 ETH 相当の USDC が wallet に着くはず',
+  rationale: 'AGENT.md の testnet-only と budget envelope を遵守',
+  generatedAt: '2026-05-03T06:00:00.000Z',
+  generatedBy: 'claude-code',
+};
+
+describe('compareEthDecimalStrings - 浮動小数点誤差を避けて ETH 文字列を比較する', () => {
+  it('"0.0001" は "0.0001" と等しい (= 0)', () => {
+    expect(compareEthDecimalStrings('0.0001', '0.0001')).toBe(0);
+  });
+  it('"0.00009" は "0.0001" より小さい (< 0)', () => {
+    expect(compareEthDecimalStrings('0.00009', '0.0001')).toBe(-1);
+  });
+  it('"0.001" は "0.0001" より大きい (> 0)', () => {
+    expect(compareEthDecimalStrings('0.001', '0.0001')).toBe(1);
+  });
+  it('整数同士もちゃんと比較できる', () => {
+    expect(compareEthDecimalStrings('1', '2')).toBe(-1);
+    expect(compareEthDecimalStrings('5', '5')).toBe(0);
+  });
+  it('decimal でない入力は throw する (UI 側で reject させたいケース)', () => {
+    expect(() => compareEthDecimalStrings('not-a-number', '0.1')).toThrow(
+      'invalid decimal'
+    );
+  });
+});
+
+describe('validateActionAgainstBudget - 署名ボタンの最後の砦', () => {
+  const budget: AgentLoopBudget = DEFAULT_AGENT_LOOP_BUDGET;
+
+  it('budget 上限ピッタリの swap は ok', () => {
+    const verdict = validateActionAgainstBudget(
+      {
+        kind: 'swap',
+        from: 'WETH',
+        to: 'USDC',
+        amount: '0.0001',
+        reason: 'limit',
+      },
+      budget
+    );
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('budget を超える swap は ok=false で reason を返す (人間が読める)', () => {
+    const verdict = validateActionAgainstBudget(
+      {
+        kind: 'swap',
+        from: 'WETH',
+        to: 'USDC',
+        amount: '1.0',
+        reason: 'too big',
+      },
+      budget
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toContain('0.0001');
+      expect(verdict.reason).toContain('1.0');
+    }
+  });
+
+  it('hold は amount を持たないので常に ok (allowedActions に含まれていれば)', () => {
+    const verdict = validateActionAgainstBudget(
+      { kind: 'hold', reason: 'wait for better entry' },
+      budget
+    );
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('allowedActions に含まれない kind は reject', () => {
+    const verdict = validateActionAgainstBudget(
+      {
+        kind: 'rebalance',
+        targets: [{ asset: 'USDC', weight: 1 }],
+        reason: 'demo only allows swap/hold',
+      },
+      budget
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toContain('rebalance');
+    }
+  });
+
+  it('amount が decimal でない (e.g. 注入を狙った文字列) は reject', () => {
+    const verdict = validateActionAgainstBudget(
+      {
+        kind: 'swap',
+        from: 'WETH',
+        to: 'USDC',
+        amount: '0.0001; rm -rf /',
+        reason: 'injection',
+      },
+      budget
+    );
+    expect(verdict.ok).toBe(false);
+  });
+});
+
+describe('parseAgentLoopTrace - Claude Code が貼った JSON を validate する', () => {
+  it('正しい trace はそのまま型付きで返る', () => {
+    const trace = parseAgentLoopTrace(SAMPLE_TRACE);
+    expect(trace.sessionId).toBe('sess-loop-1');
+    expect(trace.action.kind).toBe('swap');
+  });
+
+  it('schemaVersion が違うと拒否する (将来の breaking change を検出)', () => {
+    expect(() =>
+      parseAgentLoopTrace({ ...SAMPLE_TRACE, schemaVersion: 999 })
+    ).toThrow('schemaVersion');
+  });
+
+  it('plan が空 array だと拒否する (考えていない agent を弾く)', () => {
+    expect(() => parseAgentLoopTrace({ ...SAMPLE_TRACE, plan: [] })).toThrow(
+      'plan'
+    );
+  });
+
+  it('未知の action.kind は拒否する', () => {
+    expect(() =>
+      parseAgentLoopTrace({
+        ...SAMPLE_TRACE,
+        action: { kind: 'liquidate-all', reason: 'sus' },
+      })
+    ).toThrow('未知の kind');
+  });
+
+  it('generatedBy が claude-code / simulator 以外は拒否する', () => {
+    expect(() =>
+      parseAgentLoopTrace({ ...SAMPLE_TRACE, generatedBy: 'rogue-script' })
+    ).toThrow('generatedBy');
+  });
+});
+
+describe('safeParseAgentLoopTrace - UI が壊れた paste を赤バナーで返す', () => {
+  it('壊れた JSON 相当の値でも throw せず ok:false で返す', () => {
+    const result = safeParseAgentLoopTrace({ schemaVersion: 1, garbage: true });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('正しい trace では ok:true でラップされる', () => {
+    const result = safeParseAgentLoopTrace(SAMPLE_TRACE);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.trace.sessionId).toBe('sess-loop-1');
+    }
+  });
+});
+
+describe('buildAgentLoopInput - draft から Claude Code に渡す input を組み立てる', () => {
+  it('draft の playLog / archetype / birthHash を素通しで含める', () => {
+    const input = buildAgentLoopInput({
+      draft: SAMPLE_DRAFT,
+      emittedAt: '2026-05-03T06:00:00.000Z',
+    });
+    expect(input.sessionId).toBe('sess-loop-1');
+    expect(input.archetype).toBe('balanced');
+    expect(input.birthHash).toBe('0xabc');
+    expect(input.combatPower).toBe(4321);
+    expect(input.playLog.finalScore).toBe(1234);
+  });
+
+  it('budget を渡さない場合は DEFAULT_AGENT_LOOP_BUDGET が必ず付与される', () => {
+    const input = buildAgentLoopInput({ draft: SAMPLE_DRAFT });
+    expect(input.budget).toEqual(DEFAULT_AGENT_LOOP_BUDGET);
+    expect(input.budget.maxSwapEth).toBe('0.0001');
+    expect(input.budget.allowedChainIds).toContain(11155111);
+    expect(input.budget.allowedChainIds).toContain(16602);
+  });
+
+  it('walletAddress が引数で上書きされる (ConnectButton の address を優先)', () => {
+    const input = buildAgentLoopInput({
+      draft: SAMPLE_DRAFT,
+      walletAddress: '0x1111111111111111111111111111111111111111',
+    });
+    expect(input.walletAddress).toBe(
+      '0x1111111111111111111111111111111111111111'
+    );
+  });
+});

--- a/packages/shared/src/agent-loop.ts
+++ b/packages/shared/src/agent-loop.ts
@@ -1,0 +1,348 @@
+import type { AgentBirthDraft, PlayLog } from './types';
+
+/// Schema version for the input/trace JSON contract that crosses the browser
+/// → Claude Code (local) → browser boundary. Bump when fields change in a
+/// breaking way; loaders ignore traces with mismatched versions.
+export const AGENT_LOOP_SCHEMA_VERSION = 1 as const;
+
+/// Snapshot of forge results passed alongside the play log so the agent can
+/// reason about what already happened on-chain. All fields optional because
+/// individual forge steps can fail independently (testnet flakiness).
+export interface AgentLoopForgeSnapshot {
+  storage?: { cid: string };
+  mint?: { txHash: string; tokenId: string };
+  ens?: { name: string };
+  swap?: { txHash: string };
+}
+
+/// Hard budget envelope the local agent MUST honor. Mirrors the existing
+/// `executeFirstSwap` cap (0.0001 ETH on Sepolia). Decisions outside the
+/// envelope are blocked at the UI before any signature is ever requested,
+/// so Claude Code returning a 100-ETH-swap suggestion is structurally
+/// impossible to execute — the worst it can do is produce a rejected JSON.
+export interface AgentLoopBudget {
+  /// Per-action ETH ceiling. Stringified to avoid float drift across the
+  /// JSON boundary; matches viem's `parseEther` input format.
+  maxSwapEth: string;
+  /// Action `kind`s the user has pre-approved for this session. Anything
+  /// outside this list is rejected even if technically within ETH cap.
+  allowedActions: ReadonlyArray<PaperTradeAction['kind']>;
+  /// Chains that actually allow signing. Mirrors the testnet allowlist in
+  /// `web3/utils.ts` so the agent can see what the runtime will accept.
+  allowedChainIds: ReadonlyArray<number>;
+  /// Free-form note shown to Claude Code (and to the human) so the
+  /// constraint is impossible to miss in the prompt.
+  note?: string;
+}
+
+/// Default budget for the demo. Matches the existing `executeFirstSwap`
+/// hardcoded amount and the `SUPPORTED_TESTNET_CHAIN_IDS` allowlist.
+export const DEFAULT_AGENT_LOOP_BUDGET: AgentLoopBudget = {
+  maxSwapEth: '0.0001',
+  allowedActions: ['swap', 'hold'],
+  // Sepolia (11155111) と 0G Galileo (16602) のみ。新 chain を増やすときは
+  // ここと web3/utils.ts の SUPPORTED_TESTNET_CHAIN_IDS を一緒に動かす。
+  allowedChainIds: [11155111, 16602],
+  note: 'Paper-only. Real signing happens in the browser MetaMask via the existing forge swap path; this envelope mirrors that hard cap.',
+};
+
+/// What the deployed app hands to the local Claude Code runtime. Treat this
+/// as a stable contract — the slash command in `.claude/commands/agent-loop.md`
+/// reads exactly these fields.
+export interface AgentLoopInput {
+  schemaVersion: typeof AGENT_LOOP_SCHEMA_VERSION;
+  sessionId: string;
+  pilot: string;
+  archetype: string;
+  combatPower: number;
+  birthHash: string;
+  ensName?: string;
+  walletAddress?: string;
+  playLog: PlayLog;
+  forgeProof?: AgentLoopForgeSnapshot;
+  budget: AgentLoopBudget;
+  emittedAt: string;
+}
+
+/// Paper-trade decision. The loop deliberately stays paper-only — real
+/// testnet writes are the existing forge pipeline's job. Adding new kinds is
+/// safe; consumers should fall back to a `hold` rendering for unknowns.
+export type PaperTradeAction =
+  | {
+      kind: 'swap';
+      from: string;
+      to: string;
+      amount: string;
+      reason: string;
+    }
+  | {
+      kind: 'hold';
+      reason: string;
+    }
+  | {
+      kind: 'rebalance';
+      targets: Array<{ asset: string; weight: number }>;
+      reason: string;
+    };
+
+/// What the local Claude Code runtime writes back. `generatedBy` lets the UI
+/// distinguish "real LLM run" from "deterministic fallback simulator".
+export interface AgentLoopTrace {
+  schemaVersion: typeof AGENT_LOOP_SCHEMA_VERSION;
+  sessionId: string;
+  thought: string;
+  plan: string[];
+  action: PaperTradeAction;
+  observation: string;
+  rationale: string;
+  generatedAt: string;
+  generatedBy: 'claude-code' | 'simulator';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(
+  source: Record<string, unknown>,
+  key: string,
+  context: string
+): string {
+  const v = source[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(`${context}: "${key}" は非空 string が必要です`);
+  }
+  return v;
+}
+
+function optionalString(
+  source: Record<string, unknown>,
+  key: string,
+  context: string
+): string | undefined {
+  const v = source[key];
+  if (v === undefined) return undefined;
+  if (typeof v !== 'string') {
+    throw new Error(`${context}: "${key}" は string が必要です`);
+  }
+  return v;
+}
+
+function requireNumber(
+  source: Record<string, unknown>,
+  key: string,
+  context: string
+): number {
+  const v = source[key];
+  if (typeof v !== 'number' || Number.isNaN(v)) {
+    throw new Error(`${context}: "${key}" は数値が必要です`);
+  }
+  return v;
+}
+
+function parsePaperTradeAction(
+  value: unknown,
+  context: string
+): PaperTradeAction {
+  if (!isRecord(value)) {
+    throw new Error(`${context}: action は object が必要です`);
+  }
+  const kind = requireString(value, 'kind', `${context}.action`);
+  if (kind === 'swap') {
+    return {
+      kind: 'swap',
+      from: requireString(value, 'from', `${context}.action.swap`),
+      to: requireString(value, 'to', `${context}.action.swap`),
+      amount: requireString(value, 'amount', `${context}.action.swap`),
+      reason: requireString(value, 'reason', `${context}.action.swap`),
+    };
+  }
+  if (kind === 'hold') {
+    return {
+      kind: 'hold',
+      reason: requireString(value, 'reason', `${context}.action.hold`),
+    };
+  }
+  if (kind === 'rebalance') {
+    const rawTargets = value.targets;
+    if (!Array.isArray(rawTargets) || rawTargets.length === 0) {
+      throw new Error(
+        `${context}.action.rebalance: targets は非空 array が必要です`
+      );
+    }
+    const targets = rawTargets.map((entry, index) => {
+      if (!isRecord(entry)) {
+        throw new Error(
+          `${context}.action.rebalance.targets[${index}]: object が必要です`
+        );
+      }
+      return {
+        asset: requireString(
+          entry,
+          'asset',
+          `${context}.action.rebalance.targets[${index}]`
+        ),
+        weight: requireNumber(
+          entry,
+          'weight',
+          `${context}.action.rebalance.targets[${index}]`
+        ),
+      };
+    });
+    return {
+      kind: 'rebalance',
+      targets,
+      reason: requireString(value, 'reason', `${context}.action.rebalance`),
+    };
+  }
+  throw new Error(`${context}.action: 未知の kind "${kind}"`);
+}
+
+/// Throwing parser. Use when the caller already wraps the boundary in
+/// try/catch (e.g. before rendering the UI).
+export function parseAgentLoopTrace(value: unknown): AgentLoopTrace {
+  const context = 'AgentLoopTrace';
+  if (!isRecord(value)) {
+    throw new Error(`${context}: object が必要です`);
+  }
+  const schemaVersion = value.schemaVersion;
+  if (schemaVersion !== AGENT_LOOP_SCHEMA_VERSION) {
+    throw new Error(
+      `${context}: schemaVersion が ${AGENT_LOOP_SCHEMA_VERSION} ではありません (受信 ${String(
+        schemaVersion
+      )})`
+    );
+  }
+  const generatedBy = value.generatedBy;
+  if (generatedBy !== 'claude-code' && generatedBy !== 'simulator') {
+    throw new Error(
+      `${context}: generatedBy は "claude-code" / "simulator" のいずれか`
+    );
+  }
+  const rawPlan = value.plan;
+  if (!Array.isArray(rawPlan) || rawPlan.length === 0) {
+    throw new Error(`${context}: plan は非空 string array が必要です`);
+  }
+  const plan = rawPlan.map((entry, index) => {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      throw new Error(`${context}.plan[${index}]: 非空 string が必要です`);
+    }
+    return entry;
+  });
+  return {
+    schemaVersion: AGENT_LOOP_SCHEMA_VERSION,
+    sessionId: requireString(value, 'sessionId', context),
+    thought: requireString(value, 'thought', context),
+    plan,
+    action: parsePaperTradeAction(value.action, context),
+    observation: requireString(value, 'observation', context),
+    rationale: requireString(value, 'rationale', context),
+    generatedAt: requireString(value, 'generatedAt', context),
+    generatedBy,
+  };
+}
+
+/// Non-throwing variant — returns either the parsed trace or the error
+/// message. UI components prefer this so a malformed paste turns into a
+/// red banner instead of a runtime crash.
+export function safeParseAgentLoopTrace(
+  value: unknown
+): { ok: true; trace: AgentLoopTrace } | { ok: false; error: string } {
+  try {
+    return { ok: true, trace: parseAgentLoopTrace(value) };
+  } catch (caught) {
+    return {
+      ok: false,
+      error: caught instanceof Error ? caught.message : String(caught),
+    };
+  }
+}
+
+/// Build the input handed to Claude Code from a finished forge run. Pure
+/// (no I/O) so the same builder is reusable from CLI export scripts.
+export function buildAgentLoopInput(args: {
+  draft: AgentBirthDraft;
+  walletAddress?: string;
+  forgeProof?: AgentLoopForgeSnapshot;
+  budget?: AgentLoopBudget;
+  emittedAt?: string;
+}): AgentLoopInput {
+  const now = args.emittedAt ?? new Date().toISOString();
+  return {
+    schemaVersion: AGENT_LOOP_SCHEMA_VERSION,
+    sessionId: args.draft.sessionId,
+    pilot: args.draft.playerName,
+    archetype: args.draft.agent.archetype,
+    combatPower: args.draft.agent.profile.combatPower,
+    birthHash: args.draft.agent.birthHash,
+    ensName: args.draft.agent.ensName,
+    walletAddress: args.walletAddress ?? args.draft.agent.walletAddress,
+    playLog: args.draft.playLog,
+    forgeProof: args.forgeProof,
+    budget: args.budget ?? DEFAULT_AGENT_LOOP_BUDGET,
+    emittedAt: now,
+  };
+}
+
+/// Decimal-safe compare without pulling a bigdecimal dep. Both inputs are
+/// fixed-point decimal strings (e.g. "0.0001"); we normalize to a common
+/// fractional length and compare as bigint integers. Returns -1 / 0 / 1.
+/// Throws on negative / non-numeric input — callers feed validated UI fields.
+export function compareEthDecimalStrings(a: string, b: string): -1 | 0 | 1 {
+  const re = /^\d+(?:\.\d+)?$/;
+  if (!re.test(a) || !re.test(b)) {
+    throw new Error(
+      `compareEthDecimalStrings: invalid decimal "${a}" / "${b}"`
+    );
+  }
+  const [aWhole, aFrac = ''] = a.split('.');
+  const [bWhole, bFrac = ''] = b.split('.');
+  const fracLen = Math.max(aFrac.length, bFrac.length);
+  const aInt = BigInt(aWhole + aFrac.padEnd(fracLen, '0'));
+  const bInt = BigInt(bWhole + bFrac.padEnd(fracLen, '0'));
+  if (aInt < bInt) return -1;
+  if (aInt > bInt) return 1;
+  return 0;
+}
+
+/// Verdict shape consumed by the trace renderer. UI uses `ok` to gate the
+/// "Approve & Sign" button; `reason` is shown next to the action.
+export type BudgetVerdict = { ok: true } | { ok: false; reason: string };
+
+/// Hard runtime check the UI runs *before* turning a trace into a real
+/// transaction. Even if Claude Code returned a sane-looking JSON, the user
+/// might have edited it in the paste textarea — so this is the last line
+/// of defense before MetaMask sees anything.
+export function validateActionAgainstBudget(
+  action: PaperTradeAction,
+  budget: AgentLoopBudget
+): BudgetVerdict {
+  if (!budget.allowedActions.includes(action.kind)) {
+    return {
+      ok: false,
+      reason: `action.kind="${action.kind}" は budget.allowedActions=${JSON.stringify(
+        budget.allowedActions
+      )} に含まれません`,
+    };
+  }
+  if (action.kind === 'swap') {
+    let cmp: number;
+    try {
+      cmp = compareEthDecimalStrings(action.amount, budget.maxSwapEth);
+    } catch (caught) {
+      return {
+        ok: false,
+        reason: `swap.amount="${action.amount}" を decimal として読めませんでした (${
+          caught instanceof Error ? caught.message : String(caught)
+        })`,
+      };
+    }
+    if (cmp > 0) {
+      return {
+        ok: false,
+        reason: `swap.amount=${action.amount} ETH が budget.maxSwapEth=${budget.maxSwapEth} ETH を超えています`,
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -1,3 +1,4 @@
+export * from './agent-loop';
 export * from './forge';
 export * from './math';
 export * from './policy';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from './agent-loop';
 export * from './forge';
 export * from './math';
 export * from './policy';


### PR DESCRIPTION
## Summary

「LLM ループが無いと作品として弱い」「mainnet 暴走は絶対防ぎたい」「ブラウザ単体でローカル Claude Code とやり取りしたい」の 3 点を満たす最小構成。デプロイ側に LLM コストはゼロ、Vercel 静的ホスティングのまま動く。

## Architecture (案 A: file/clipboard handoff, no backend)

```
[Browser]                          [Local Claude Code]
buildAgentLoopInput()              /agent-loop slash command
 → clipboard / download                 ↓
                                   read AGENT.md (constitution)
                                   read input JSON
                                   decide ONE PaperTradeAction
                                   write AgentLoopTrace JSON
 ← clipboard paste                      ↓
parseAgentLoopTrace()
validateActionAgainstBudget()
 → "Approve & Sign on Testnet" (MetaMask 経由 / executeFirstSwap)
```

「LLM が考える / ユーザーが署名する / 最大 0.0001 ETH しか動かない」の 3 安全条件を **構造で担保**。

## Layers

### 1. JSON contract (`packages/shared/src/agent-loop.ts`)

- `AgentLoopInput` (sessionId / archetype / playLog / forgeProof / **budget**)
- `AgentLoopTrace` (thought / plan / action / observation / rationale / generatedAt / generatedBy)
- `PaperTradeAction` (`swap` | `hold` | `rebalance` discriminated union)
- `AgentLoopBudget` (maxSwapEth / allowedActions / allowedChainIds)
- `parseAgentLoopTrace` / `safeParseAgentLoopTrace` / `buildAgentLoopInput`
- `compareEthDecimalStrings` — 浮動小数点誤差を避けた decimal 比較
- `validateActionAgainstBudget` — UI が「Approve & Sign」を enable する前の最後の砦

### 2. Slash command (`.claude/commands/agent-loop.md`)

- `AGENT.md` を憲法として読む
- clipboard から input JSON 取得
- 1 手の paper trade を archetype heuristic (defensive/balanced/aggressive/swarm) で決定
- trace JSON を chat 出力 + clipboard にコピー
- **HARD constraint**: budget を超える action は出さない、超えそうなら `hold` を返す
- **HARD constraint**: signing は要求しない、CLI で送らない（browser MetaMask に戻す）

### 3. UI (`packages/frontend/src/components/AgentLoopPanel.tsx`)

- 「📋 Copy input JSON」/「⬇️ Download」で input を export
- 「Paste trace JSON here」textarea + 「Validate」ボタン
- thought / plan / action timeline を描画
- **budget verdict を緑 / 赤で明示**
- `canSign = trace 有効 && budget ok && sessionId 一致` のときだけ「Approve & Sign on Testnet (≤ 0.0001 ETH)」を enable
- swap kind は既存 `handleFirstSwap` (executeFirstSwap = `0.0001 ETH` Sepolia 固定) に流す。hold kind なら署名不要

### 4. Budget envelope (`AGENT.md` 末尾セクション)

- `0.0001 ETH` per action — `executeFirstSwap` の hardcode に揃える
- `allowedActions = [swap, hold]` — rebalance は demo 範囲外
- `allowedChainIds = [Sepolia 11155111, 0G Galileo 16602]` — `SUPPORTED_TESTNET_CHAIN_IDS` のミラー
- agent は envelope を弱めない、超えそうなら `hold` を返す
- agent は秘密鍵を要求しない、CLI で署名しない

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [x] `bun run lint` (biome) — クリーン (59 files)
- [x] `bun run typecheck` — shared / frontend 共に exit 0
- [x] `bun run test` — shared **51 pass (+20 新規)** / frontend 20 pass・1 skip・0 fail
- [x] `bun run build` — shared / frontend 共に成功
- [ ] ローカル dev で 1 サイクル目視: ゲーム完走 → AGENT_LOOP セクションで input copy → ターミナルで `claude /agent-loop` → trace を貼り戻し → thought/plan/action 表示 → 「Approve & Sign」で MetaMask 起動
- [ ] わざと壊した JSON を貼って赤バナーが出ることを確認 (sessionId mismatch / 未知 action.kind / amount=1.0 で budget 超過)
- [ ] hold を返した trace では「Hold (no signature needed)」表記になり MetaMask が起動しないことを確認

## What this PR does NOT do (意図的に out of scope)

- Claude Code 以外の runtime (Hermes など) サポート — 同じ JSON contract で後から足せる
- 連続サイクル — 今は 1 ハンドオフ = 1 trace の片道。ループしたければユーザーが繰り返すだけ
- 自動 clipboard reading — ブラウザ制約上、paste は人間の操作が必要
- 実 swap path の差し替え — agent action は既存 `executeFirstSwap` に流すだけ。amount は依然 hardcode 0.0001 ETH（agent が言ってきた値はあくまで意図表示で、実 tx の量は変わらない）