### PR TITLE
fix(web3): mainnet 始発の auto switch を直す + UI エラーを英語に統一

### DIFF
--- a/packages/frontend/src/web3/utils.test.ts
+++ b/packages/frontend/src/web3/utils.test.ts
@@ -26,23 +26,58 @@ describe('testnet guard - オンチェーン書き込みは testnet のみ許可
   });
 });
 
-describe('executeFirstSwap - testnet 以外では write を開始しない', () => {
-  it('mainnet 相当の chainId では swap 前に拒否する', async () => {
+describe('executeFirstSwap - mainnet 始発でも switch を試み、reject されたら止める', () => {
+  it('mainnet 上で wallet が switch を拒否すると writeContract に到達せず chain mismatch で止まる', async () => {
+    const switchAttempts: Array<{ id: number }> = [];
     const walletClient = {
       account: {
         address: '0x000000000000000000000000000000000000dEaD',
       },
       getChainId: async () => 1,
-      switchChain: async () => {
-        throw new Error('switchChain must not be called for mainnet');
+      switchChain: async (args: { id: number }) => {
+        switchAttempts.push(args);
+        // ユーザーが MetaMask の switch ダイアログで Reject を押した相当
+        throw new Error('user rejected the request');
       },
       writeContract: async () => {
-        throw new Error('writeContract must not be called for mainnet');
+        throw new Error(
+          'writeContract must not be called when chain switch was rejected'
+        );
       },
     } as unknown as WalletClient;
 
     await expect(executeFirstSwap(walletClient)).rejects.toThrow(
-      'testnet only'
+      /chain mismatch.*Sepolia/i
     );
+    // user reject 経路でも switch は必ず 1 回試される (mainnet 始発の人を救う唯一の経路)
+    expect(switchAttempts).toEqual([{ id: sepolia.id }]);
+  });
+
+  it('mainnet 始発でも switch が成功すれば writeContract まで届く', async () => {
+    const switchAttempts: Array<{ id: number }> = [];
+    let currentChainId = 1;
+    let writeContractCalls = 0;
+    const walletClient = {
+      account: {
+        address: '0x000000000000000000000000000000000000dEaD',
+      },
+      getChainId: async () => currentChainId,
+      switchChain: async (args: { id: number }) => {
+        switchAttempts.push(args);
+        currentChainId = args.id;
+      },
+      writeContract: async () => {
+        writeContractCalls += 1;
+        // 実際に tx を送るところまでは行かないので、ここで意図的に止める
+        throw new Error('mock: tx send not implemented in test');
+      },
+    } as unknown as WalletClient;
+
+    await expect(executeFirstSwap(walletClient)).rejects.toThrow(
+      'mock: tx send not implemented in test'
+    );
+    expect(switchAttempts).toEqual([{ id: sepolia.id }]);
+    expect(writeContractCalls).toBe(1);
+    expect(currentChainId).toBe(sepolia.id);
   });
 });

--- a/packages/frontend/src/web3/utils.ts
+++ b/packages/frontend/src/web3/utils.ts
@@ -27,7 +27,7 @@ export function formatTestnetOnlyError(
   context: string
 ): string {
   const label = SUPPORTED_TESTNET_CHAIN_IDS.get(chainId) ?? `chain ${chainId}`;
-  return `testnet only: ${context} は ${describeSupportedTestnets()} でのみ実行できます (current ${label})`;
+  return `testnet only: ${context} must be on ${describeSupportedTestnets()} (current ${label})`;
 }
 
 export function assertSupportedTestnetChainId(
@@ -45,29 +45,39 @@ export function assertSupportedTestnetChainId(
 /// 直前に明示的に switchChain を呼んで、必要なら wallet_switchEthereumChain
 /// プロンプトをユーザーに見せる。chain がもう一致していれば no-op。
 ///
-/// Defense-in-depth: target も current も testnet allowlist 外なら throw する。
-/// これでロジックバグや将来の改変で mainnet writeContract に到達しても、
-/// ここで必ず止まる (Gr@diusWeb3 は testnet 専用)。
+/// 流れ:
+/// 1. target が testnet allowlist 外なら即 throw (mainnet writeContract を構造で防ぐ)。
+/// 2. current === target なら no-op (already on target)。
+/// 3. それ以外は switchChain を試みる。これが mainnet 始発の人を救う唯一の経路
+///    なので、current が unsupported でも事前 reject せず switch を呼ぶ。
+/// 4. switch が throw すれば user reject 等として friendly に伝播。
+/// 5. switch 後の chain が target でなければ throw (defense-in-depth: ここで初めて
+///    current が allowlist 外であることを検出する)。
+///
+/// User-facing strings は English (UI 全体が English ベースなので統一)。
 export async function ensureChain(
   walletClient: WalletClient,
   target: Chain
 ): Promise<void> {
   assertSupportedTestnetChainId(target.id, `target chain ${target.name}`);
   const currentId = await walletClient.getChainId();
-  assertSupportedTestnetChainId(currentId, 'connected wallet');
   if (currentId === target.id) return;
   try {
     await walletClient.switchChain({ id: target.id });
   } catch (err) {
     const detail = err instanceof Error ? err.message : 'unknown';
     throw new Error(
-      `chain mismatch — ${target.name} (${target.id}) への切替に失敗しました (現在 ${currentId}): ${detail}`
+      `chain mismatch: switch to ${target.name} (${target.id}) was rejected (current chain ${currentId}): ${detail}`
     );
   }
   const switchedId = await walletClient.getChainId();
   if (switchedId !== target.id) {
     throw new Error(
-      `chain mismatch — ${target.name} (${target.id}) への切替後に現在 chainId が一致しませんでした (現在 ${switchedId})`
+      `chain mismatch: after switch, current chainId (${switchedId}) does not equal target ${target.name} (${target.id})`
     );
   }
+  assertSupportedTestnetChainId(
+    switchedId,
+    `connected wallet after switch to ${target.name}`
+  );
 }

--- a/packages/shared/src/agent-loop.test.ts
+++ b/packages/shared/src/agent-loop.test.ts
@@ -190,7 +190,7 @@ describe('parseAgentLoopTrace - Claude Code が貼った JSON を validate す�
         ...SAMPLE_TRACE,
         action: { kind: 'liquidate-all', reason: 'sus' },
       })
-    ).toThrow('未知の kind');
+    ).toThrow('unknown kind');
   });
 
   it('generatedBy が claude-code / simulator 以外は拒否する', () => {

--- a/packages/shared/src/agent-loop.ts
+++ b/packages/shared/src/agent-loop.ts
@@ -110,20 +110,7 @@ function requireString(
 ): string {
   const v = source[key];
   if (typeof v !== 'string' || v.length === 0) {
-    throw new Error(`${context}: "${key}" は非空 string が必要です`);
-  }
-  return v;
-}
-
-function optionalString(
-  source: Record<string, unknown>,
-  key: string,
-  context: string
-): string | undefined {
-  const v = source[key];
-  if (v === undefined) return undefined;
-  if (typeof v !== 'string') {
-    throw new Error(`${context}: "${key}" は string が必要です`);
+    throw new Error(`${context}: "${key}" must be a non-empty string`);
   }
   return v;
 }
@@ -135,7 +122,7 @@ function requireNumber(
 ): number {
   const v = source[key];
   if (typeof v !== 'number' || Number.isNaN(v)) {
-    throw new Error(`${context}: "${key}" は数値が必要です`);
+    throw new Error(`${context}: "${key}" must be a number`);
   }
   return v;
 }
@@ -145,7 +132,7 @@ function parsePaperTradeAction(
   context: string
 ): PaperTradeAction {
   if (!isRecord(value)) {
-    throw new Error(`${context}: action は object が必要です`);
+    throw new Error(`${context}: action must be an object`);
   }
   const kind = requireString(value, 'kind', `${context}.action`);
   if (kind === 'swap') {
@@ -167,13 +154,13 @@ function parsePaperTradeAction(
     const rawTargets = value.targets;
     if (!Array.isArray(rawTargets) || rawTargets.length === 0) {
       throw new Error(
-        `${context}.action.rebalance: targets は非空 array が必要です`
+        `${context}.action.rebalance: "targets" must be a non-empty array`
       );
     }
     const targets = rawTargets.map((entry, index) => {
       if (!isRecord(entry)) {
         throw new Error(
-          `${context}.action.rebalance.targets[${index}]: object が必要です`
+          `${context}.action.rebalance.targets[${index}]: must be an object`
         );
       }
       return {
@@ -195,7 +182,7 @@ function parsePaperTradeAction(
       reason: requireString(value, 'reason', `${context}.action.rebalance`),
     };
   }
-  throw new Error(`${context}.action: 未知の kind "${kind}"`);
+  throw new Error(`${context}.action: unknown kind "${kind}"`);
 }
 
 /// Throwing parser. Use when the caller already wraps the boundary in
@@ -203,12 +190,12 @@ function parsePaperTradeAction(
 export function parseAgentLoopTrace(value: unknown): AgentLoopTrace {
   const context = 'AgentLoopTrace';
   if (!isRecord(value)) {
-    throw new Error(`${context}: object が必要です`);
+    throw new Error(`${context}: must be an object`);
   }
   const schemaVersion = value.schemaVersion;
   if (schemaVersion !== AGENT_LOOP_SCHEMA_VERSION) {
     throw new Error(
-      `${context}: schemaVersion が ${AGENT_LOOP_SCHEMA_VERSION} ではありません (受信 ${String(
+      `${context}: schemaVersion is not ${AGENT_LOOP_SCHEMA_VERSION} (received ${String(
         schemaVersion
       )})`
     );
@@ -216,16 +203,16 @@ export function parseAgentLoopTrace(value: unknown): AgentLoopTrace {
   const generatedBy = value.generatedBy;
   if (generatedBy !== 'claude-code' && generatedBy !== 'simulator') {
     throw new Error(
-      `${context}: generatedBy は "claude-code" / "simulator" のいずれか`
+      `${context}: generatedBy must be "claude-code" or "simulator"`
     );
   }
   const rawPlan = value.plan;
   if (!Array.isArray(rawPlan) || rawPlan.length === 0) {
-    throw new Error(`${context}: plan は非空 string array が必要です`);
+    throw new Error(`${context}: plan must be a non-empty array of strings`);
   }
   const plan = rawPlan.map((entry, index) => {
     if (typeof entry !== 'string' || entry.length === 0) {
-      throw new Error(`${context}.plan[${index}]: 非空 string が必要です`);
+      throw new Error(`${context}.plan[${index}]: must be a non-empty string`);
     }
     return entry;
   });
@@ -320,9 +307,9 @@ export function validateActionAgainstBudget(
   if (!budget.allowedActions.includes(action.kind)) {
     return {
       ok: false,
-      reason: `action.kind="${action.kind}" は budget.allowedActions=${JSON.stringify(
+      reason: `action.kind="${action.kind}" is not in budget.allowedActions=${JSON.stringify(
         budget.allowedActions
-      )} に含まれません`,
+      )}`,
     };
   }
   if (action.kind === 'swap') {
@@ -332,7 +319,7 @@ export function validateActionAgainstBudget(
     } catch (caught) {
       return {
         ok: false,
-        reason: `swap.amount="${action.amount}" を decimal として読めませんでした (${
+        reason: `swap.amount="${action.amount}" could not be parsed as a decimal (${
           caught instanceof Error ? caught.message : String(caught)
         })`,
       };
@@ -340,7 +327,7 @@ export function validateActionAgainstBudget(
     if (cmp > 0) {
       return {
         ok: false,
-        reason: `swap.amount=${action.amount} ETH が budget.maxSwapEth=${budget.maxSwapEth} ETH を超えています`,
+        reason: `swap.amount=${action.amount} ETH exceeds budget.maxSwapEth=${budget.maxSwapEth} ETH`,
       };
     }
   }


### PR DESCRIPTION
## Summary

スクリーンショット報告の 2 件を直す:

| 症状 | 対応 |
|---|---|
| `ENS / UNISWAP TX` 行が JP メッセージで FAIL: `testnet only: connected wallet は Sepolia / 0G Galileo でのみ実行できます (current chain 1)` | `ensureChain` の事前 current-chain assertion を外し、switch を試みる経路を復活 + メッセージ英語化 |
| `0G STORAGE` だけ OK で他が常に詰む | mainnet 始発の人にも `wallet_switchEthereumChain` プロンプトが出るようになる |

## 根本原因

PR #41 で defense-in-depth として `ensureChain` が `switchChain` の **前に** current chain を `assertSupportedTestnetChainId` で検証していた。これが「mainnet 始発のユーザーを救う唯一の経路」=`switchChain` を呼ぶ前に throw してしまい、`TestnetGuard` の auto switch が走っても writeContract 直前で死ぬ構造になっていた。`TestnetGuard` の意図 (mainnet → Sepolia auto switch) と完全に矛盾していた。

## 直した流れ (`packages/frontend/src/web3/utils.ts`)

```
1. target が testnet allowlist 外 → 即 throw (mainnet writeContract は構造で防ぐ)
2. current === target → no-op (already on target)
3. それ以外 → switchChain を試みる (mainnet 始発の人を救う唯一の経路)
4. switch が throw → user reject 等として friendly に上位へ伝播
5. switch 後 chain が target でない → throw
6. 最終 chain を allowlist で再検証 (defense-in-depth はここで残す)
```

## 英語化した文字列

| ファイル | Before | After |
|---|---|---|
| `utils.ts` `formatTestnetOnlyError` | `... は Sepolia / 0G Galileo でのみ実行できます (current ${label})` | `... must be on Sepolia / 0G Galileo (current ${label})` |
| `utils.ts` ensureChain 切替失敗 | `chain mismatch — Sepolia (11155111) への切替に失敗しました ...` | `chain mismatch: switch to Sepolia (11155111) was rejected ...` |
| `utils.ts` ensureChain 切替後不一致 | `... への切替後に現在 chainId が一致しませんでした ...` | `chain mismatch: after switch, current chainId (...) does not equal target ...` |
| `agent-loop.ts` parser errors | `"${key}" は非空 string が必要です` 等 | `"${key}" must be a non-empty string` 等 |
| `agent-loop.ts` budget validator | `swap.amount=... ETH が ... を超えています` | `swap.amount=... ETH exceeds budget.maxSwapEth=... ETH` |

挙動変更なし、文字列のみ。コード内コメントと commit message は引き続き日本語 (CLAUDE.md の docs convention に従う)。

## Tests

- `packages/frontend/src/web3/utils.test.ts`:
  - 旧テスト「mainnet で swap 前に拒否」を「switch を試み、拒否されたら chain mismatch で止まる (writeContract まで届かない)」に書き換え (現実の挙動を反映)
  - **新テスト** 「mainnet 始発でも switch が成功すれば writeContract に届く」を追加 (happy path 回帰、`switchAttempts === [{ id: sepolia.id }]` と `currentChainId === sepolia.id` を assert)
- `packages/shared/src/agent-loop.test.ts`: `'未知の kind'` → `'unknown kind'` (1 行のみ)

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [x] `bun run lint` (biome) — クリーン (59 files)
- [x] `bun run typecheck` — shared / frontend 共に exit 0
- [x] `bun run test` — shared 51 pass / frontend 21 pass・1 skip・0 fail (+1 happy path)
- [x] `bun run build` — shared / frontend 共に成功
- [ ] ローカル dev で MetaMask を Ethereum mainnet に置いて完走 → ENS step 直前に Sepolia 切替ダイアログが出る (今までは出ていなかった) のを目視確認
- [ ] 同じ状態で switch を Reject → "chain mismatch: switch to Sepolia (11155111) was rejected" が ENS 行に出ることを確認 (英語表示)
- [ ] 既に Sepolia にいる場合は switch ダイアログが出ない (no-op) を確認