### PR TITLE
docs(readme): testnet ガード + agent loop + 画像ショーケースを反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ A 60-second retro arcade shooter that doubles as the world's fastest onboarding 
 [![Vercel-ready](https://img.shields.io/badge/deploy-vercel-000000?logo=vercel)](https://vercel.com)
 
 [**▶ Play live demo**](https://gr-dius-web3-frontend.vercel.app/) ·
-[**Pitch deck**](./docs/specs/image%20copy.png) ·
+[**Pitch deck**](./pitch_deck.md) ·
 [**Spec**](./docs/specs/2026-04-26-agent-forge.md) ·
-[**Sponsor prizes**](./docs/prizes/)
+[**Sponsor prizes**](./docs/prizes/) ·
+[**Local agent runbook**](./AGENT.md)
+
+![Landing — Gr@diusWeb3 hero](./images/01-landing-hero.png)
 
 </div>
 
@@ -28,18 +31,20 @@ A 60-second retro arcade shooter that doubles as the world's fastest onboarding 
 | What to check | Where |
 |---------------|-------|
 | Live demo (free play, ~60 s) | https://gr-dius-web3-frontend.vercel.app/ |
+| Pitch deck (Marp, 7 slides) | [`pitch_deck.md`](./pitch_deck.md) — build with `make pitch_pdf` |
 | 0G iNFT contract source (ERC-721 + tokenURI, deterministic `keccak(msg.sender, playLogHash)`) | [`contracts/src/AgentForgeINFT.sol`](./contracts/src/AgentForgeINFT.sol) |
 | 0G Galileo deploy script + chain config (id 16602) | [`contracts/script/Deploy.s.sol`](./contracts/script/Deploy.s.sol), [`contracts/foundry.toml`](./contracts/foundry.toml) |
 | 0G Storage real put (`@0gfoundation/0g-ts-sdk` Indexer.upload, sha256 fallback) | [`packages/frontend/src/web3/zerog-storage.ts`](./packages/frontend/src/web3/zerog-storage.ts) |
 | 0G Storage explorer (paste rootHash from `agent.safety.attestation` 0g:// URI) | https://storagescan-galileo.0g.ai/ |
 | ENS Sepolia subname registration via real NameWrapper + Resolver | [`packages/frontend/src/web3/ens-register.ts`](./packages/frontend/src/web3/ens-register.ts) |
+| Uniswap v3 Sepolia first-trade execution (WETH→USDC, native-ETH wrap, 0.0001 ETH cap) | [`packages/frontend/src/web3/uniswap-swap.ts`](./packages/frontend/src/web3/uniswap-swap.ts) |
+| Forge orchestrator (independent storage / mint / ENS settled results) | [`packages/frontend/src/web3/forge-onchain.ts`](./packages/frontend/src/web3/forge-onchain.ts) |
+| Testnet-only guard (4 layers — see below) | [`packages/frontend/src/web3/utils.ts`](./packages/frontend/src/web3/utils.ts), [`packages/frontend/src/lib/wagmi.ts`](./packages/frontend/src/lib/wagmi.ts), [`packages/frontend/src/components/TestnetGuard.tsx`](./packages/frontend/src/components/TestnetGuard.tsx) |
+| Local Claude Code agent loop (1 cycle, paper-trade decision JSON) | [`AGENT.md`](./AGENT.md), [`.claude/commands/agent-loop.md`](./.claude/commands/agent-loop.md), [`packages/shared/src/agent-loop.ts`](./packages/shared/src/agent-loop.ts), [`packages/frontend/src/components/AgentLoopPanel.tsx`](./packages/frontend/src/components/AgentLoopPanel.tsx) |
 | Agent safety attestation (3-tier: misalignment cards / ENS subname / 0G + ENS credential) | [`packages/shared/src/safety.ts`](./packages/shared/src/safety.ts), [`packages/frontend/src/web3/safety-attestation.ts`](./packages/frontend/src/web3/safety-attestation.ts), [`packages/frontend/src/components/SafetyAttestationPanel.tsx`](./packages/frontend/src/components/SafetyAttestationPanel.tsx) |
-| Demo seed (`?seed=demo`) forces all 4 misalignment kinds in the first 4 waves | [`packages/frontend/src/components/BirthArcade.tsx`](./packages/frontend/src/components/BirthArcade.tsx), [`packages/frontend/src/game/runtime.ts`](./packages/frontend/src/game/runtime.ts) (`DEMO_CAPABILITY_ORDER`) |
-| Uniswap v3 Sepolia first-trade execution (WETH→USDC, native-ETH wrap) | [`packages/frontend/src/web3/uniswap-swap.ts`](./packages/frontend/src/web3/uniswap-swap.ts) |
-| Forge orchestrator (`Promise.allSettled` so one failure never blocks the dashboard) | [`packages/frontend/src/web3/forge-onchain.ts`](./packages/frontend/src/web3/forge-onchain.ts) |
+| Demo seed (`?seed=demo`) forces all 4 misalignment kinds in the first 4 waves | [`packages/frontend/src/components/BirthArcade.tsx`](./packages/frontend/src/components/BirthArcade.tsx), [`packages/frontend/src/game/runtime.ts`](./packages/frontend/src/game/runtime.ts) |
 | Uniswap DX feedback (required for Uniswap prize submission) | [`FEEDBACK.md`](./FEEDBACK.md) |
 | Spec + scoring rubric + Plan log | [`docs/specs/2026-04-27-web3-wiring.md`](./docs/specs/2026-04-27-web3-wiring.md), [`Plan.md`](./Plan.md) |
-| Local autonomous agent runbook (testnet-only) | [`AGENT.md`](./AGENT.md) |
 
 The contract + module surface is intentionally tight (~7 frontend files, 1 contract) so judges can read the entire on-chain pipeline in under 5 minutes. For the local autonomous agent loop, read [`AGENT.md`](./AGENT.md) first; it explicitly limits execution to Sepolia and 0G Galileo.
 
@@ -51,6 +56,8 @@ The contract + module surface is intentionally tight (~7 frontend files, 1 contr
 
 Gr@diusWeb3 turns that workflow into a **Konami-grade pixel shooter**. Constraints become enemies. Decisions become shots. The agent that emerges is born from your reflexes — and every choice has a visible cost. **Design = decisions under tradeoffs.**
 
+![6 modules, 6 footguns — each archetype is one default no agent ships armed with](./images/03-six-modules.png)
+
 ---
 
 ## What you get in 60 seconds of play
@@ -59,6 +66,7 @@ Gr@diusWeb3 turns that workflow into a **Konami-grade pixel shooter**. Constrain
 - **A real DeFi portfolio** in the agent's wallet (Conservative / Balanced / Aggressive presets, with allocations and execution policy).
 - **A persistent memory log** of how you played — reproducible, exportable, queryable.
 - **An Agent safety attestation**: each kill (or pass) maps to one of four canonical misalignment failure modes (sycophancy / reward hacking / prompt injection / goal misgeneralization); a 100-point score is computed at game-end and pinned to ENS as a verifiable credential.
+- **A handoff to local Claude Code** that reads your play log + `AGENT.md` and proposes the agent's next paper trade.
 - **A web of integrations** (Gensyn AXL peer mesh, 0G storage/compute, Uniswap routing, KeeperHub guarantees) — surfaced through gameplay rather than config.
 
 ---
@@ -79,6 +87,59 @@ Gr@diusWeb3 turns that workflow into a **Konami-grade pixel shooter**. Constrain
 
 There is no power-up bar. No commit button. No tutorial popup. The first slow tutorial enemy teaches the entire mechanic in 2 seconds — exactly like Mario stomps his first Goomba.
 
+| Game start | Mid-run vote | The result |
+|:---:|:---:|:---:|
+| ![Arcade title](./images/05-arcade-title.png) | ![Every kill commits a module](./images/07-gameplay-leverage.png) | ![Agent dashboard with BALANCED archetype](./images/08-agent-dashboard.png) |
+
+---
+
+## Seven steps from joystick to iNFT
+
+![Forge protocol — 7 steps from joystick to iNFT](./images/04-forge-protocol.png)
+
+The forge pipeline is deterministic from the play log alone: same shots in the same order produce the same agent, the same iNFT `tokenId`, and the same ENS subname. No randomness, no off-chain memory.
+
+---
+
+## Why it can't go wrong (testnet-only by construction)
+
+Four independent layers prevent any path to mainnet — even if a future contributor doesn't read the docs.
+
+| Layer | What it does | Where |
+|---|---|---|
+| **wagmi config** | Only `[sepolia, galileo]` are registered as chains. Mainnet RPC is not configured at all. | [`packages/frontend/src/lib/wagmi.ts`](./packages/frontend/src/lib/wagmi.ts) |
+| **`ensureChain` allowlist** | Every `writeContract` calls `ensureChain(target)` first. Throws if the target chain is not on the testnet allowlist. Defense-in-depth — even a future bug can't hit mainnet. | [`packages/frontend/src/web3/utils.ts`](./packages/frontend/src/web3/utils.ts) |
+| **`TestnetGuard`** | Watches `useAccount().chainId`; auto-fires `wallet_switchEthereumChain` to Sepolia when the user is on mainnet, with a sticky banner if they reject. | [`packages/frontend/src/components/TestnetGuard.tsx`](./packages/frontend/src/components/TestnetGuard.tsx) |
+| **Hardcoded swap cap** | `executeFirstSwap` is wired with `parseEther('0.0001')` — not configurable, not env-driven, not exposed to the agent. Worst-case loss is 0.0001 testnet ETH. | [`packages/frontend/src/web3/uniswap-swap.ts`](./packages/frontend/src/web3/uniswap-swap.ts) |
+
+User-facing error messages are English; code comments and ADRs stay in Japanese (project convention). See [`AGENT.md`](./AGENT.md) for the full runtime constitution.
+
+---
+
+## The agent loop — Claude Code as the thinking head
+
+After the forge runs, the dashboard hands off to a local Claude Code instance. The deployed app holds zero LLM cost and zero private keys.
+
+```
+[Browser]                          [Local Claude Code]
+buildAgentLoopInput()              /agent-loop slash command
+ → clipboard / download                 ↓
+                                   read AGENT.md (constitution)
+                                   read input JSON
+                                   decide ONE PaperTradeAction
+                                   write AgentLoopTrace JSON
+ ← clipboard paste                      ↓
+parseAgentLoopTrace()
+validateActionAgainstBudget()
+ → "Approve & Sign on Testnet" (MetaMask via existing forge swap path)
+```
+
+- **Contract**: [`packages/shared/src/agent-loop.ts`](./packages/shared/src/agent-loop.ts) (`AgentLoopInput` / `AgentLoopTrace` / `PaperTradeAction` / `AgentLoopBudget`).
+- **Slash command**: [`.claude/commands/agent-loop.md`](./.claude/commands/agent-loop.md) — Claude Code reads `AGENT.md` and emits one decision JSON.
+- **UI**: [`packages/frontend/src/components/AgentLoopPanel.tsx`](./packages/frontend/src/components/AgentLoopPanel.tsx) validates the paste, gates the sign button on the budget envelope, then routes Approve into the existing `executeFirstSwap`.
+
+The agent never holds a private key. Claude Code never signs. Every real signature flows through the user's browser MetaMask, and every signed transaction is capped at 0.0001 ETH on a testnet.
+
 ---
 
 ## Architecture
@@ -91,6 +152,8 @@ There is no power-up bar. No commit button. No tutorial popup. The first slow tu
                 │  game/sprites.ts · font.ts · terrain    │
                 │  components/BirthArcade.tsx             │
                 │  components/AgentDashboard.tsx          │
+                │  components/AgentLoopPanel.tsx          │
+                │  components/TestnetGuard.tsx            │
                 └──────────────┬──────────────────────────┘
                                │ in-process await
                                ▼
@@ -99,17 +162,20 @@ There is no power-up bar. No commit button. No tutorial popup. The first slow tu
                 │  - mapPlayLogToProfile  (pure fn)       │
                 │  - mapProfileToPolicy   (pure fn)       │
                 │  - deriveWalletFromPlayLog (SubtleCrypto)│
+                │  - buildAgentLoopInput (pure fn)        │
                 │  → agent profile + policy + iNFT spec   │
                 └──────────────┬──────────────────────────┘
                                │ optional, not in critical path
                                ▼
    ┌────────────┬──────────────┴─────────┬─────────────────┐
    ▼            ▼                        ▼                 ▼
- ENS         Gensyn AXL                0G              Uniswap +
- subname     peer mesh                 Storage         KeeperHub
- + records   (multi-agent)             + Compute       (execution)
+ ENS         Gensyn AXL                0G              Uniswap
+ subname     peer mesh                 Storage         v3 swap
+ + records   (multi-agent)             + iNFT          (Sepolia,
+ (Sepolia)                             (Galileo)        0.0001 ETH cap)
  ─────────────────────────────────────────────────────────────────
  Multi-chain Foundry deploys: Sepolia / Base / OP / Arbitrum Sepolia
+                              + 0G Galileo (16602)
 ```
 
 The frontend is **fully self-contained**: no backend, no API server, no database. Wallet derivation runs in the browser via Web Crypto. The agent forging pipeline is a pure function. This makes the project **provably reproducible** and **trivially deployable** to any static host (Vercel pre-configured).
@@ -132,6 +198,13 @@ Quality gate (run before opening a PR):
 ```bash
 bun scripts/architecture-harness.ts --staged --fail-on=error
 make before-commit       # lint_text + lint + typecheck + tests + build
+```
+
+Pitch deck (Marp):
+
+```bash
+make pitch               # HTML preview (Chromium not required)
+make pitch_pdf           # PDF for submission (downloads Chromium on first run)
 ```
 
 ---
@@ -168,21 +241,11 @@ make deploy NETWORK=sepolia INTERACTIVE=1
 make deploy_all
 ```
 
-`Deploy.s.sol` deploys `AgentForgeINFT.sol` (ERC-721 + tokenURI iNFT) per
-chain in a single broadcast. RPCs are wired via `contracts/foundry.toml`. The
-prior in-house `AgentForgeSubnameRegistry.sol` was removed in favour of real
-Sepolia ENS (NameWrapper + Resolver via viem).
+`Deploy.s.sol` deploys `AgentForgeINFT.sol` (ERC-721 + tokenURI iNFT) per chain in a single broadcast. RPCs are wired via `contracts/foundry.toml`. The prior in-house `AgentForgeSubnameRegistry.sol` was removed in favour of real Sepolia ENS (NameWrapper + Resolver via viem).
 
 ### Frontend wallet (in-app)
 
-The frontend uses **wagmi + viem** for wallet connection. The Connect Wallet
-button in the nav bar speaks the standard EIP-1193 protocol — MetaMask /
-Coinbase Wallet / any injected provider connects natively, and chain
-switching to Sepolia / Base Sepolia / OP Sepolia / Arbitrum Sepolia happens
-in-app. The connected address becomes the agent's owner address; no
-in-browser private key derivation is used for live signing. All write paths
-are guarded in code to refuse non-testnet / mainnet execution; the agent loop
-runbook lives in [`AGENT.md`](./AGENT.md).
+The frontend uses **wagmi + viem** for wallet connection. The Connect Wallet button in the nav bar speaks the standard EIP-1193 protocol — MetaMask / Coinbase Wallet / any injected provider connects natively. The connected address becomes the agent's owner address; no in-browser private key derivation is used for live signing. The four-layer testnet guard (above) is what makes mainnet execution structurally impossible.
 
 ---
 
@@ -193,10 +256,13 @@ runbook lives in [`AGENT.md`](./AGENT.md).
 | Runtime / package manager | **Bun** | One-shot install, native TypeScript, fast tests. |
 | Frontend | **Vite + React 19 + Canvas 2D** | Sub-300ms cold reload, NES-resolution rendering. |
 | Game engine | hand-rolled in `packages/frontend/src/game/` | NES 256×240 internal canvas, 60 fps loop, deterministic step. |
+| Wallet / chain | **wagmi + viem** | EIP-1193 across MetaMask / Coinbase / injected. |
 | Smart contracts | **Solidity 0.8.28 + Foundry** | Multi-chain script orchestration, no Hardhat lock-in. |
 | Wallet derivation | **Web Crypto SubtleCrypto** | Works in browser & Bun, no Node-only deps. |
 | Lint / format | **Biome** | Single tool, fast, opinionated. |
 | Tests | **bun test** with Japanese BDD descriptions | Built-in, zero config. |
+| Pitch deck | **@marp-team/marp-cli** (lockfile-pinned) | No `bunx` (supply-chain hardened). |
+| Local agent runtime | **Claude Code** | Reads `AGENT.md` constitution; deployed app holds zero LLM cost. |
 | Static deploy | **Vercel** (`vercel.json` included) | SPA rewrites, `bun install --frozen-lockfile` build. |
 
 ---
@@ -208,10 +274,10 @@ This project is purpose-built around the ETHGlobal sponsor stack — every primi
 | Sponsor | Role | Where in the code |
 |---------|------|-------------------|
 | **0G** | iNFT (ERC-721 with deterministic `tokenId = keccak(msg.sender, playLogHash)` and data-URI tokenURI) deployed to 0G Galileo testnet (chain id 16602). Play log + AgentSafetyAttestation are uploaded to 0G Storage via `@0gfoundation/0g-ts-sdk` (`Indexer.upload`); the resulting `0g://{rootHash}` URI is pinned in both the iNFT `storageCID` metadata field and the ENS text record `agent.safety.attestation`. SHA-256 fallback (`sha256://{hex}`) preserves the dashboard if the live indexer is unreachable. | `contracts/src/AgentForgeINFT.sol`, `packages/frontend/src/web3/zerog-mint.ts`, `packages/frontend/src/web3/zerog-storage.ts`, `packages/frontend/src/web3/safety-attestation.ts` |
-| **ENS** | Auto-issued subname `{pilot 4-hex}.gradiusweb3.eth` on **real Sepolia ENS** (NameWrapper + Resolver). Handle is wallet-deterministic (same wallet → same subname) with random fallback when no wallet is connected, and a pre-flight `Registry.owner()` check rejects collisions before the parent owner write. Verifiable text records: legacy `combat-power` / `archetype` / `design-hash`, plus the new safety credential trio `agent.safety.score` / `agent.safety.attestation` (URI-formatted, `sha256://` today, `0g://` once SDK lands) / `agent.misalignment.detected` (per-kind hit counts as JSON). | `packages/frontend/src/web3/ens-register.ts`, `packages/frontend/src/web3/safety-attestation.ts` |
-| **Gensyn AXL** | Multi-agent / swarm execution. OPTION-style commits in the design pipeline spawn additional encrypted peer nodes | `packages/frontend/src/game/runtime.ts` (votes), runtime topology in `AgentDashboard` |
-| **Uniswap** | The agent's actual on-chain action: real swaps via Uniswap API, `FEEDBACK.md` documents DX learnings | [`FEEDBACK.md`](./FEEDBACK.md) |
-| **KeeperHub** | Reliable execution layer for agent transactions: x402 coin-insert, private-mempool routing, MEV protection, retries | Wired into the agent runtime narrative |
+| **ENS** | Auto-issued subname `{pilot 4-hex}.gradiusweb3.eth` on **real Sepolia ENS** (NameWrapper + Resolver). Handle is wallet-deterministic (same wallet → same subname) with random fallback when no wallet is connected, and a pre-flight `Registry.owner()` check rejects collisions before the parent owner write. Verifiable text records: legacy `combat-power` / `archetype` / `design-hash`, plus the safety credential trio `agent.safety.score` / `agent.safety.attestation` (`0g://` URI when SDK lands, `sha256://` fallback otherwise) / `agent.misalignment.detected` (per-kind hit counts as JSON). | `packages/frontend/src/web3/ens-register.ts`, `packages/frontend/src/web3/safety-attestation.ts` |
+| **Gensyn AXL** | Multi-agent / swarm execution. Agent archetype mapping spawns peer-mesh topology in the dashboard. | `packages/frontend/src/game/runtime.ts` (votes), runtime topology in `AgentDashboard` |
+| **Uniswap** | The agent's actual on-chain action: real swap on Uniswap v3 Sepolia (WETH → USDC, 0.0001 ETH cap), `FEEDBACK.md` documents DX learnings. | [`packages/frontend/src/web3/uniswap-swap.ts`](./packages/frontend/src/web3/uniswap-swap.ts), [`FEEDBACK.md`](./FEEDBACK.md) |
+| **KeeperHub** | Reliable execution layer for agent transactions: x402 coin-insert, private-mempool routing, MEV protection, retries. | Wired into the agent runtime narrative |
 
 Each sponsor's prize requirements live in [`docs/prizes/`](./docs/prizes/) (English original + Japanese translation).
 
@@ -226,6 +292,8 @@ Each sponsor's prize requirements live in [`docs/prizes/`](./docs/prizes/) (Engl
 | **Reproducibility** | Low (settings drift, undocumented) | High (deterministic from play log) |
 | **Learning curve** | Steep — read docs to even start | Fun & intuitive — Mario 1-1 |
 | **Outcome** | Unpredictable | Explainable & tunable |
+| **Mainnet risk** | "Don't typo the chain ID" | Structurally impossible (4-layer guard) |
+| **LLM runtime cost** | Servers, secrets, cloud bills | Zero — Claude Code runs locally |
 | **Web3 integration** | Bolted on later | Native (iNFT + ENS + AXL + 0G + Uniswap from day 1) |
 
 ---
@@ -238,22 +306,28 @@ Each sponsor's prize requirements live in [`docs/prizes/`](./docs/prizes/) (Engl
 │   ├── frontend/              # Vite + React + Canvas (the only deployable)
 │   │   └── src/
 │   │       ├── game/          # NES-grade engine (palette, sprites, font, terrain, runtime)
-│   │       ├── components/    # BirthArcade, AgentDashboard, RadarDisplay
+│   │       ├── components/    # BirthArcade, AgentDashboard, AgentLoopPanel, TestnetGuard
+│   │       ├── web3/          # forge-onchain, ens-register, uniswap-swap, zerog-*, utils
+│   │       ├── lib/wagmi.ts   # testnet-only chains: [sepolia, galileo]
 │   │       └── App.tsx        # 15-section landing page
-│   ├── shared/                # Pure functional core (profile, policy, wallet, forge)
-│   └── backend/               # Optional Hono server (frozen — not in the deploy path)
+│   └── shared/                # Pure functional core (profile, policy, wallet, forge, agent-loop)
 ├── contracts/
 │   ├── src/                   # AgentForgeINFT.sol (ERC-721 + tokenURI)
 │   ├── script/Deploy.s.sol    # Multi-chain deploy script
 │   └── foundry.toml           # rpc_endpoints + etherscan
+├── .claude/
+│   └── commands/agent-loop.md # Claude Code slash command (local agent runtime)
 ├── docs/
-│   ├── specs/                 # Product spec + Claude Design pitch deck export
+│   ├── specs/                 # Product specs + design notes
 │   ├── prizes/                # Sponsor prize requirements (EN + JP)
 │   └── architecture/harness.md# Hard invariants
+├── images/                    # Hero / dashboard / gameplay screenshots (numbered)
+├── pitch_deck.md              # Marp pitch deck (7 slides, ZeroKey-style)
+├── AGENT.md                   # Local autonomous agent runbook (testnet-only)
 ├── Plan.md                    # Working plan + progress log + retro
 ├── FEEDBACK.md                # Uniswap-required DX feedback
 ├── vercel.json                # Static SPA deploy config
-├── Makefile                   # `make dev` / `make before-commit` / `make deploy`
+├── Makefile                   # `make dev` / `make before-commit` / `make pitch_pdf`
 └── CLAUDE.md                  # AI agent contributor guide (Japanese)
 ```
 
@@ -264,25 +338,27 @@ Each sponsor's prize requirements live in [`docs/prizes/`](./docs/prizes/) (Engl
 - Game engine, landing page, and contracts written from scratch with original sprites and code.
 - Five sponsor integrations woven through one product (not five demos in a trench coat).
 - No backend, no database, no fragile fetch flows — the entire app forges agents in-browser.
-- Pre-wired multi-chain deploy script so judges can verify on Sepolia / Base / OP / Arbitrum without reading our docs.
-- Hard architectural invariants enforced by `bun scripts/architecture-harness.ts` (no `npx`, no mock data, no `it.only`, `Plan.md` required).
+- Pre-wired multi-chain deploy script so judges can verify on Sepolia / Base / OP / Arbitrum / 0G Galileo without reading our docs.
+- Hard architectural invariants enforced by `bun scripts/architecture-harness.ts` (no `npx`, no `bunx`, no mock data, no `it.only`, `Plan.md` required).
+- Four-layer testnet guard so a future contributor cannot accidentally ship a mainnet write path.
+- Local Claude Code agent loop with paper-trade decisions, structurally bounded by a 0.0001 ETH cap.
 - Japanese BDD tests because the maintainer is Japanese and writes specs the way a Japanese engineer reads them.
 
 ---
 
 ## Roadmap
 
-- [ ] Real wallet integration (wagmi + RainbowKit) so the iNFT mints to the player's actual wallet
-- [ ] On-chain leaderboard scoring agent battle outcomes
-- [ ] Agent breeding (iNFT × iNFT → child iNFT) with deterministic stat inheritance
-- [ ] Mainnet readiness audit + bug bounty
-- [ ] Mobile arcade (touch controls, vertical layout)
+- [ ] Multi-cycle agent loop (today's loop is one paper-trade decision per game; later runs would chain decisions and observations).
+- [ ] On-chain leaderboard scoring agent battle outcomes.
+- [ ] Agent breeding (iNFT × iNFT → child iNFT) with deterministic stat inheritance.
+- [ ] Mainnet readiness audit + bug bounty (would require a 5th guard layer + ADR superseding the testnet-only invariant).
+- [ ] Mobile arcade (touch controls, vertical layout).
 
 ---
 
 ## Contributing
 
-Read [`CLAUDE.md`](./CLAUDE.md) and [`AGENTS.md`](./AGENTS.md). Then:
+Read [`CLAUDE.md`](./CLAUDE.md) and [`AGENT.md`](./AGENT.md). Then:
 
 1. Fork → branch → write tests in **Japanese BDD** style.
 2. `make before-commit` must be green (architecture-harness 0 errors, lint 0, typecheck 0, all tests pass, builds succeed).
@@ -297,6 +373,7 @@ The architecture invariants in [`docs/architecture/harness.md`](./docs/architect
 
 - **Konami** for *Gradius* (1985) and the Moai stage. The `@` in `Gr@dius` is intentional — homage and a deliberate trademark side-step.
 - **Claude Design** for the visual reference (`docs/specs/Gradius Web3 Redesign.html`).
+- **Anthropic Claude Code** for being the local agent runtime that lets the deployed app stay LLM-free.
 - The **0G / ENS / Gensyn / Uniswap / KeeperHub** teams for primitives that make agentic finance buildable in 60 seconds.
 
 ---


### PR DESCRIPTION
## Summary

PR #41 〜 #45 で main に入った変更を README に集約。判断材料が増えたので judge が 2 分で重要箇所を辿れるようにする。

## 追加した画像 (images/)

| 画像 | 配置先 |
|---|---|
| `01-landing-hero.png` | Hero 直下 (Vercel ライブデモのバナー) |
| `03-six-modules.png` | Why this exists の挿絵 (6 footguns ナラティブ) |
| `04-forge-protocol.png` | "Seven steps from joystick to iNFT" の挿絵 |
| `05-arcade-title.png` | How it plays の 3 段グリッド (左) |
| `07-gameplay-leverage.png` | How it plays の 3 段グリッド (中) |
| `08-agent-dashboard.png` | How it plays の 3 段グリッド (右) |

`02-arm-the-defaults.png` と `06-gameplay-precision.png` は今回 README からは外したが `images/` に残してある (pitch deck の旧 5 枚版で使った原本)。

## 追加した新セクション

### `Why it can't go wrong (testnet-only by construction)`

PR #41 / #44 の 4 層ガードを表で見せる:

1. wagmi config — `chains: [sepolia, galileo]` のみ
2. `ensureChain` allowlist — defense-in-depth
3. `TestnetGuard` — auto-switch + sticky banner
4. Hardcoded 0.0001 ETH swap cap — env-driven にしない

### `The agent loop — Claude Code as the thinking head`

PR #43 の loop 全体像を ASCII 図で。input/trace の JSON contract、slash command、UI panel、それぞれのファイルパス付き。

「Claude Code は秘密鍵を持たない / 署名は browser MetaMask / 実 tx は 0.0001 ETH cap で構造的に縛る」をはっきり書く。

## 主な更新

- Pitch deck リンクを `./docs/specs/image%20copy.png` (壊れていた) → `./pitch_deck.md` に修正
- Quick start に `make pitch` / `make pitch_pdf` を追加
- Tech stack 表に `wagmi + viem` / `@marp-team/marp-cli (lockfile-pinned)` / `Claude Code as local agent runtime` の 3 行を追加
- Differentiation 表に `Mainnet risk` (構造的に不可能) と `LLM runtime cost` (zero) の 2 行を追加
- Repository layout を最新化:
  - `packages/backend/` 行を削除 (ゾンビだった)
  - `components/AgentLoopPanel`, `TestnetGuard`, `web3/utils.ts`, `lib/wagmi.ts` を追記
  - `.claude/commands/agent-loop.md`, `images/`, `pitch_deck.md`, `AGENT.md` を追記
- Roadmap の「Real wallet integration (wagmi + RainbowKit)」を削除 (完了済み)、代わりに「Multi-cycle agent loop」「Mainnet readiness audit (5th guard layer + ADR)」を追加
- Acknowledgments に Anthropic Claude Code を追加 (deployed app が LLM-free でいられる理由)

## Test plan

- [x] `bun run lint:text` (textlint) — クリーン
- [x] `bun run lint` (biome) — クリーン
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] GitHub の README プレビューで画像が崩れていないか目視確認 (人間タスク)