### PR TITLE
feat(deploy): per-chain shortcut + Galileo verify skip + post-deploy 手順

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,23 +89,58 @@ dev:
 #        make deploy NETWORK=sepolia INTERACTIVE=1
 #
 # RPC URL is sourced from <NETWORK>_RPC_URL env var (e.g. SEPOLIA_RPC_URL).
+# Galileo は GALILEO_RPC_URL が未指定の場合に foundry.toml が
+# https://evmrpc-testnet.0g.ai を fallback として渡す。
 
 NETWORK_UPPER = $(shell echo $(NETWORK) | tr a-z A-Z)
 SIGNER_FLAGS = $(if $(LEDGER),--ledger,$(if $(TREZOR),--trezor,$(if $(INTERACTIVE),--interactive,$(if $(ACCOUNT),--account $(ACCOUNT),$(error No signer specified — pass ACCOUNT=name OR LEDGER=1 OR TREZOR=1 OR INTERACTIVE=1)))))
 SENDER_FLAG = $(if $(SENDER),--sender $(SENDER),)
 
+# 0G Galileo (16602) は Etherscan 互換 API を持たないので --verify を付けると
+# forge が verify ステップで必ず失敗する。Galileo のときは verify を外し、
+# それ以外 (Sepolia 系) は付ける。
+VERIFY_FLAG = $(if $(filter galileo,$(NETWORK)),,--verify)
+
+# `--chain galileo` は Foundry の組み込み chain alias 表に無くて警告になる。
+# Galileo のときは --chain を省いて RPC からの自動検出に任せる
+# (forge script は eth_chainId をそのまま使うので tx 署名は正しく動く)。
+CHAIN_FLAG = $(if $(filter galileo,$(NETWORK)),,--chain $(NETWORK))
+
 .PHONY: deploy
 deploy:
 	cd contracts && forge script script/Deploy.s.sol:Deploy \
-		--rpc-url $${$(NETWORK_UPPER)_RPC_URL:?missing $(NETWORK_UPPER)_RPC_URL} \
+		--rpc-url $(NETWORK) \
 		--broadcast \
-		--verify \
-		--chain $(NETWORK) \
+		$(VERIFY_FLAG) \
+		$(CHAIN_FLAG) \
 		$(SIGNER_FLAGS) $(SENDER_FLAG)
+
+# Per-chain shortcuts so judges can copy-paste a single line per chain.
+# 例: `make deploy_galileo ACCOUNT=deployer SENDER=0x...`
+# `--chain galileo` を Foundry の rpc_endpoints キーと合わせる。
+.PHONY: deploy_sepolia
+deploy_sepolia:
+	$(MAKE) deploy NETWORK=sepolia
+
+.PHONY: deploy_base_sepolia
+deploy_base_sepolia:
+	$(MAKE) deploy NETWORK=base_sepolia
+
+.PHONY: deploy_op_sepolia
+deploy_op_sepolia:
+	$(MAKE) deploy NETWORK=op_sepolia
+
+.PHONY: deploy_arbitrum_sepolia
+deploy_arbitrum_sepolia:
+	$(MAKE) deploy NETWORK=arbitrum_sepolia
+
+.PHONY: deploy_galileo
+deploy_galileo:
+	$(MAKE) deploy NETWORK=galileo
 
 .PHONY: deploy_all
 deploy_all:
-	@for network in sepolia base_sepolia op_sepolia arbitrum_sepolia; do \
+	@for network in sepolia base_sepolia op_sepolia arbitrum_sepolia galileo; do \
 		echo "▶ deploying to $$network"; \
 		$(MAKE) deploy NETWORK=$$network || exit 1; \
 	done

--- a/README.md
+++ b/README.md
@@ -95,7 +95,30 @@ make before-commit     # lint + typecheck + test + build
 make pitch_pdf         # build the submission deck
 ```
 
-Multi-chain contract deploy via Foundry keystore / Ledger / interactive — see the [Makefile](./Makefile) header. No raw private keys in `.env`, ever.
+### Make the iNFT live
+
+The repo ships a deploy script for `AgentForgeINFT.sol`, but the iNFT row of the dashboard fails until you actually deploy and tell the frontend where the contract lives.
+
+```bash
+# one-time keystore setup (Foundry)
+cast wallet import deployer --interactive
+
+# 0G Galileo (chain id 16602)
+make deploy_galileo ACCOUNT=deployer SENDER=0xYourAddress
+
+# Sepolia / Base Sepolia / OP Sepolia / Arbitrum Sepolia
+make deploy_sepolia          ACCOUNT=deployer SENDER=0xYourAddress
+make deploy_base_sepolia     ACCOUNT=deployer SENDER=0xYourAddress
+make deploy_op_sepolia       ACCOUNT=deployer SENDER=0xYourAddress
+make deploy_arbitrum_sepolia ACCOUNT=deployer SENDER=0xYourAddress
+
+# all of the above in one shot
+make deploy_all ACCOUNT=deployer SENDER=0xYourAddress
+```
+
+Per chain, copy the printed contract address into the Vercel project as `VITE_INFT_ADDRESS=0x...` and redeploy the frontend so the dashboard's iNFT mint can target it. Sepolia-family deploys verify on Etherscan automatically; Galileo skips verify (no Etherscan API yet).
+
+Signing always goes through Foundry's CLI flags — keystore (`ACCOUNT=...`), Ledger (`LEDGER=1`), Trezor (`TREZOR=1`), or interactive (`INTERACTIVE=1`). No raw private keys in `.env`, ever.
 
 ---
 


### PR DESCRIPTION
## Summary

User がデプロイしていない状態で iNFT mint (`mintINft: VITE_INFT_ADDRESS is not configured`) が必ず落ちていた件への対応。`2025-AgenticEthereum/contract` の per-chain target スタイルを真似つつ、既存の secure signing (keystore / Ledger / Trezor / interactive) は維持。

## Makefile 変更

| 追加 / 変更 | 理由 |
|---|---|
| `deploy_sepolia` / `deploy_base_sepolia` / `deploy_op_sepolia` / `deploy_arbitrum_sepolia` / `deploy_galileo` の per-chain shortcut | judge が `make deploy_galileo ACCOUNT=... SENDER=...` 1 行で動かせる |
| `deploy_all` に galileo を追加 | 今までの 4 chain + 0G Galileo を 1 コマンドで |
| `VERIFY_FLAG = $(if $(filter galileo,$(NETWORK)),,--verify)` | 0G Galileo は Etherscan 互換 API を持たないので `--verify` を付けると forge が verify ステップで必ず失敗する |
| `CHAIN_FLAG = $(if $(filter galileo,$(NETWORK)),,--chain $(NETWORK))` | foundry の組み込み chain alias 表に `galileo` は無く、`--chain galileo` は警告になる。chainId は `eth_chainId` 経由で自動検出されるので tx 署名は問題なし |
| `--rpc-url $(NETWORK)` (alias 参照に切替) | foundry.toml の `[rpc_endpoints]` 経由で resolve され、Galileo の `${GALILEO_RPC_URL:-https://evmrpc-testnet.0g.ai}` fallback も効くようになる |

## README 変更

Quick start の下に **Make the iNFT live** 節を追加。

```bash
cast wallet import deployer --interactive
make deploy_galileo ACCOUNT=deployer SENDER=0xYourAddress
# → 出てきた contract address を Vercel の VITE_INFT_ADDRESS に貼って再デプロイ
```

「deploy 後に Vercel 環境変数 `VITE_INFT_ADDRESS` を設定して再デプロイする」までのフロントエンド側 post-deploy 手順を明示し、judge が 1 ステップで再現できるようにする。

## Test plan

- [x] `forge build` — compile OK (lint warning だけ、エラーなし)
- [x] `bun run lint:text` (textlint) — クリーン
- [x] `bun run lint` (biome) — クリーン
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [x] `make -n deploy_galileo` — `--rpc-url galileo` / `--verify` なし / `--chain` なし / signer flags 付き ✓
- [x] `make -n deploy_sepolia` — `--rpc-url sepolia` / `--verify` あり / `--chain sepolia` / signer flags 付き ✓
- [ ] 実 deploy 走らせて contract address を取得し Vercel に設定する (人間タスク)

## What this PR does NOT do (意図的に out of scope)

- 生 private key を `.env` から読む方式への切替 — 既存の「never raw key」invariant を維持。reference project は `.env` に生 key を書いていたが、ここは shape だけ真似て security 方針は維持
- Vercel 自動再デプロイ — judges or maintainer が手動で env var セット + redeploy する想定
- ENS parent domain の取得 — `gradiusweb3.eth` を Sepolia で別途取得する必要があるが、これは別タスク