### PR TITLE
fix(ui): UI に残っていた日本語メッセージを英語に統一

### DIFF
--- a/packages/frontend/src/components/AgentLoopPanel.tsx
+++ b/packages/frontend/src/components/AgentLoopPanel.tsx
@@ -94,7 +94,7 @@ export function AgentLoopPanel({
       parsed = JSON.parse(pasteText);
     } catch (caught) {
       setPasteError(
-        `JSON として読めません: ${
+        `Could not parse as JSON: ${
           caught instanceof Error ? caught.message : String(caught)
         }`
       );
@@ -107,7 +107,7 @@ export function AgentLoopPanel({
     }
     if (result.trace.sessionId !== input.sessionId) {
       setPasteError(
-        `sessionId 不一致: 期待 "${input.sessionId}" / 受信 "${result.trace.sessionId}"`
+        `sessionId mismatch: expected "${input.sessionId}", received "${result.trace.sessionId}"`
       );
       return;
     }

--- a/packages/frontend/src/components/TestnetGuard.tsx
+++ b/packages/frontend/src/components/TestnetGuard.tsx
@@ -36,9 +36,9 @@ export function TestnetGuard() {
     <div role="alert" style={STYLES.banner}>
       <span style={STYLES.tag}>TESTNET ONLY</span>
       <span style={STYLES.body}>
-        Gr@diusWeb3 は {SUPPORTED_LABEL} 専用です。現在 wallet は chain{' '}
-        {chainId} にいます。{PRIMARY_TESTNET.name} への切り替えを wallet で
-        承認してください。
+        Gr@diusWeb3 only runs on {SUPPORTED_LABEL}. Wallet is currently on chain{' '}
+        {chainId}. Approve the switch to {PRIMARY_TESTNET.name} in your wallet
+        to continue.
       </span>
       <button
         type="button"


### PR DESCRIPTION
## Summary

スクショで指摘された「日本語のチップス」を英語化。`PR #44` で utils.ts と agent-loop.ts のエラー文を英語化したが、コンポーネント側に残っていた **sticky banner** と **paste バリデーションエラー** が見落とされていた。

## 変更箇所

| ファイル | Before | After |
|---|---|---|
| `TestnetGuard.tsx` (sticky banner) | "Gr@diusWeb3 は ... 専用です。現在 wallet は chain ... にいます。... への切り替えを wallet で承認してください。" | "Gr@diusWeb3 only runs on .... Wallet is currently on chain .... Approve the switch to ... in your wallet to continue." |
| `AgentLoopPanel.tsx` (paste error) | "JSON として読めません: ..." | "Could not parse as JSON: ..." |
| `AgentLoopPanel.tsx` (sessionId 不一致) | "sessionId 不一致: 期待 \"...\" / 受信 \"...\"" | "sessionId mismatch: expected \"...\", received \"...\"" |

`grep` で全コンポーネントの JP 文字列をスキャンし、user-facing は上記 3 箇所のみだった。残った JP は全て `///` のコードコメント (CLAUDE.md の docs convention に従い JP のまま維持)。ゲーム内 toast (`pushToast`) は元から英語。

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [x] `bun run lint` (biome) — クリーン
- [x] `bun run typecheck` — shared / frontend 共に exit 0
- [x] `bun run test` — frontend 21 pass・1 skip・0 fail
- [x] `bun run build` — frontend 成功
- [ ] ローカル dev で MetaMask を mainnet に切替 → sticky banner が英語表示になっていることを目視確認 (人間タスク)
- [ ] AgentLoopPanel に壊れた JSON を貼って "Could not parse as JSON" が出ることを確認 (人間タスク)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Text Updates**
  * Validation error messages now display in English with specific descriptions of JSON parsing failures and session ID mismatches, helping users better understand encountered issues.
  * Testnet compatibility banner now displays in English, clearly communicating supported networks and providing guidance for wallet approval and switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->