### PR TITLE
feat(deploy): make deploy_setup で使い捨て deployer を 1 コマンド化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,13 @@ dev:
 #
 # Signing: this Makefile NEVER takes a raw private key. Pick one mode:
 #
-#   1) Encrypted keystore (recommended):
+#   0) Disposable deployer wallet (recommended for testnet hackathons):
+#        make deploy_setup
+#        # → generates a fresh wallet, imports it into the encrypted keystore
+#        # → fund the printed address with testnet ETH, then:
+#        make deploy_galileo ACCOUNT=deployer SENDER=0xThatAddress
+#
+#   1) Encrypted keystore (general):
 #        cast wallet import deployer --interactive          # one-time
 #        make deploy NETWORK=sepolia ACCOUNT=deployer SENDER=0xYourAddress
 #
@@ -88,9 +94,51 @@ dev:
 #   3) Interactive prompt (key kept in memory, never on disk):
 #        make deploy NETWORK=sepolia INTERACTIVE=1
 #
-# RPC URL is sourced from <NETWORK>_RPC_URL env var (e.g. SEPOLIA_RPC_URL).
-# Galileo は GALILEO_RPC_URL が未指定の場合に foundry.toml が
-# https://evmrpc-testnet.0g.ai を fallback として渡す。
+# RPC URL is sourced from foundry.toml [rpc_endpoints] aliases. Sepolia 系は
+# `${SEPOLIA_RPC_URL}` 等を要求し、Galileo は `${GALILEO_RPC_URL:-https://evmrpc-testnet.0g.ai}`
+# が public RPC を fallback として渡す。
+
+# Disposable deployer wallet workflow.
+#
+# 普段使いの wallet の private key を絶対に import しないこと。
+# このターゲットは新規 wallet を生成し、Foundry の暗号化 keystore に直接
+# import する。生成された秘密鍵は標準出力に 1 度だけ表示されるので、
+# 心配ならパスワードマネージャーに保存してもよい (testnet 専用なので
+# keystore + パスワードだけ覚えていれば backup は不要)。
+#
+# 流れ:
+#   1) `make deploy_setup`        — 鍵生成 + keystore に import
+#   2) printed アドレスに testnet ETH を送る (faucet または別 wallet から)
+#   3) `make deploy_galileo ACCOUNT=deployer SENDER=0x...` で deploy
+.PHONY: deploy_setup
+deploy_setup:
+	@echo "▶ Generating a disposable deployer wallet (testnet only)."
+	@echo "▶ NEVER import your daily-driver private key into this keystore."
+	@echo "▶ The private key below is shown ONCE. Copy it to a password manager"
+	@echo "  if you want a backup, otherwise the keystore + password is enough."
+	@echo ""
+	cast wallet new
+	@echo ""
+	@echo "▶ Importing the generated key into the Foundry encrypted keystore."
+	@echo "▶ At the next prompts, paste the private key above and choose a"
+	@echo "  password to encrypt the keystore."
+	@echo ""
+	cast wallet import deployer --interactive
+	@echo ""
+	@echo "▶ Encrypted keystore saved at: $$HOME/.foundry/keystores/deployer"
+	@echo "▶ Next steps:"
+	@echo "    1. Send testnet ETH to the wallet address printed above."
+	@echo "       - 0G Galileo faucet: https://faucet.0g.ai/  (X login required)"
+	@echo "       - Sepolia faucet:    https://sepoliafaucet.com/"
+	@echo "    2. make deploy_galileo ACCOUNT=deployer SENDER=0x<thatAddress>"
+	@echo "    3. Set VITE_INFT_ADDRESS=<deployed contract address> in Vercel"
+	@echo "       and redeploy the frontend."
+
+# 既存 keystore 'deployer' のアドレスを表示する。再起動して deployer の
+# アドレスを忘れたとき用。`make deploy_address` を打てば cast が表示する。
+.PHONY: deploy_address
+deploy_address:
+	@cast wallet address --account deployer
 
 NETWORK_UPPER = $(shell echo $(NETWORK) | tr a-z A-Z)
 SIGNER_FLAGS = $(if $(LEDGER),--ledger,$(if $(TREZOR),--trezor,$(if $(INTERACTIVE),--interactive,$(if $(ACCOUNT),--account $(ACCOUNT),$(error No signer specified — pass ACCOUNT=name OR LEDGER=1 OR TREZOR=1 OR INTERACTIVE=1)))))

--- a/README.md
+++ b/README.md
@@ -97,23 +97,25 @@ make pitch_pdf         # build the submission deck
 
 ### Make the iNFT live
 
-The repo ships a deploy script for `AgentForgeINFT.sol`, but the iNFT row of the dashboard fails until you actually deploy and tell the frontend where the contract lives.
+The repo ships a deploy script for `AgentForgeINFT.sol`, but the iNFT row of the dashboard fails until you actually deploy and tell the frontend where the contract lives. Never import your daily-driver private key — generate a disposable deployer instead:
 
 ```bash
-# one-time keystore setup (Foundry)
-cast wallet import deployer --interactive
+# one-time: generate a fresh wallet + import it into the encrypted keystore
+make deploy_setup
 
-# 0G Galileo (chain id 16602)
-make deploy_galileo ACCOUNT=deployer SENDER=0xYourAddress
-
-# Sepolia / Base Sepolia / OP Sepolia / Arbitrum Sepolia
+# fund the printed address with 0G Galileo + Sepolia testnet ETH (faucets),
+# then deploy. Each `make deploy_*` command prompts for the keystore password.
+make deploy_galileo          ACCOUNT=deployer SENDER=0xYourAddress
 make deploy_sepolia          ACCOUNT=deployer SENDER=0xYourAddress
 make deploy_base_sepolia     ACCOUNT=deployer SENDER=0xYourAddress
 make deploy_op_sepolia       ACCOUNT=deployer SENDER=0xYourAddress
 make deploy_arbitrum_sepolia ACCOUNT=deployer SENDER=0xYourAddress
 
-# all of the above in one shot
+# or every chain in one shot
 make deploy_all ACCOUNT=deployer SENDER=0xYourAddress
+
+# forgot your deployer address? print it
+make deploy_address
 ```
 
 Per chain, copy the printed contract address into the Vercel project as `VITE_INFT_ADDRESS=0x...` and redeploy the frontend so the dashboard's iNFT mint can target it. Sepolia-family deploys verify on Etherscan automatically; Galileo skips verify (no Etherscan API yet).


### PR DESCRIPTION
## Summary

User の「`cast wallet import` 怖い」「daily-driver の key 触りたくない」への対応。**使い捨て deployer wallet** のセットアップを 1 コマンドで完結させる。

## 追加ターゲット

| Target | 何をする |
|---|---|
| `make deploy_setup` | 1) `cast wallet new` で fresh wallet 生成 (private key は 1 度だけ表示)<br>2) 続けて `cast wallet import deployer --interactive` で Foundry 暗号化 keystore に import<br>3) 次の手順 (faucet → deploy_galileo → Vercel env) を表示 |
| `make deploy_address` | 既存 deployer keystore のアドレスを表示 (再起動して忘れたとき用) |

## ポイント

- **daily-driver の private key を絶対に import しないこと** を Makefile docstring に明示
- 鍵は **暗号化 keystore のみ** に保存、生 key はディスクに残らない
- testnet 専用なので、keystore + password を覚えていれば backup 不要 (mainnet 残高ゼロの使い捨て)
- Ledger / Trezor / interactive など他の signing モードは引き続きそのまま

## README 更新

"Make the iNFT live" 節を `make deploy_setup` 起点に書き換え、`make deploy_address` のドキュメントも追加。

## Test plan

- [x] `make -n deploy_setup` — `cast wallet new` → `cast wallet import deployer --interactive` の展開を確認
- [x] `make -n deploy_address` — `cast wallet address --account deployer` の展開を確認
- [x] `bun run lint:text` (textlint) — クリーン
- [x] `bun run lint` (biome) — クリーン
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] 実走で wallet 生成 + import + faucet 入金 + `make deploy_galileo` までの一連の流れを目視確認 (人間タスク、ただし 0G faucet が現在 X login 不調のため別経路で testnet 0G 取得が必要)