### PR TITLE
fix(contracts): foundry.toml の Galileo RPC を直書きに (Bash :- 非対応エラー修正)

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -13,8 +13,10 @@ sepolia = "${SEPOLIA_RPC_URL}"
 base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
 op_sepolia = "${OP_SEPOLIA_RPC_URL}"
 arbitrum_sepolia = "${ARBITRUM_SEPOLIA_RPC_URL}"
-# 0G Galileo testnet (chainId 16602). Public RPC; override via GALILEO_RPC_URL.
-galileo = "${GALILEO_RPC_URL:-https://evmrpc-testnet.0g.ai}"
+# 0G Galileo testnet (chainId 16602). Foundry の env var 解決は `${VAR:-default}`
+# 形式の fallback 構文をサポートしないので、public RPC を直書きする。
+# 別 RPC を使いたい場合は forge コマンドに `--rpc-url https://...` を直接渡す。
+galileo = "https://evmrpc-testnet.0g.ai"
 
 [etherscan]
 sepolia = { key = "${ETHERSCAN_API_KEY}" }


### PR DESCRIPTION
## Summary

User の `make deploy_galileo` 実行で:

```
Error: environment variable `GALILEO_RPC_URL:-https://evmrpc-testnet.0g.ai` not found
```

これは Foundry の env 解決が **`${VAR:-default}` 形式の Bash 風 fallback 構文をサポートしない** ため発生。Foundry は env var 名を **literal** として扱うので、変数名を `GALILEO_RPC_URL:-https://evmrpc-testnet.0g.ai` という長い文字列として探して見つからずエラーになる。

## 直し方

Galileo は 0G の public RPC が事実上唯一の選択肢なので、`foundry.toml` で直書き:

```diff
-galileo = "${GALILEO_RPC_URL:-https://evmrpc-testnet.0g.ai}"
+galileo = "https://evmrpc-testnet.0g.ai"
```

別 RPC を使いたい場合は `forge script ... --rpc-url https://custom-rpc.example` を直接渡せばオーバーライド可能。Sepolia 系は引き続き `${SEPOLIA_RPC_URL}` 等の env var を要求 (各人の Alchemy / Infura key を使うため、デフォルトを置く意味がない)。

## Test plan

- [x] `bun run lint` (biome) — クリーン
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] User 側で `make deploy_galileo ACCOUNT=deployer SENDER=0x...` を再実行して contract address が printed されること (人間タスク)