### PR TITLE
fix(forge): chain switch を serial 化 — MetaMask の request-pending エラー解消

### DIFF
--- a/packages/frontend/src/web3/forge-onchain.ts
+++ b/packages/frontend/src/web3/forge-onchain.ts
@@ -51,11 +51,20 @@ export function aggregateProof(
   };
 }
 
-/// Run the on-chain forge pipeline: storage put → mint (mint depends on
-/// the CID, so it's chained sequentially) and ENS subname registration in
-/// parallel. Each row is reported independently so a single failure (e.g.
-/// mint reverting because the contract isn't deployed yet) doesn't mask
-/// upstream successes.
+/// Run the on-chain forge pipeline serially:
+/// 1) 0G Galileo: storage upload → iNFT mint (same chain, no extra switch)
+/// 2) Sepolia: ENS subname registration
+///
+/// 旧実装は storage+mint と ENS を `Promise.all` で並列実行していたが、
+/// MetaMask は per-origin で `wallet_requestPermissions` (= switchChain) を
+/// 1 つしか pending にできないので、Galileo と Sepolia の switch が同時に
+/// 発火すると後発が `Requested resource not available. Request of type
+/// 'wallet_requestPermissions' already pending` で reject されていた。
+///
+/// 並列実行は wallet 側がどのみち signature prompt を直列化するので、
+/// user-facing のレイテンシは serial にしてもほぼ変わらない。serial にする
+/// ことで chain switch が確実に 1 つずつ片付き、user reject も友好的な
+/// エラーとして対応する step だけに表示できる。
 ///
 /// Pure orchestration: this function does not throw. It always resolves with
 /// an OnChainProof where each step is either success or failed.
@@ -75,32 +84,30 @@ export async function runOnChainForge(
 
   const owner = account.address as Address;
   const handle = draft.agent.ensName.split('.')[0] ?? 'pilot';
-
   const playLogHash = toHexBytes(draft.agent.birthHash);
 
-  const storageThenMint = (async (): Promise<{
-    storageSettled: PromiseSettledResult<StorageProof>;
-    mintSettled: PromiseSettledResult<MintProof>;
-  }> => {
-    // 0G Storage に playLog を real put。signer 構築に失敗したら sha256 fallback。
-    let signer: ZeroGSigner | undefined;
-    try {
-      signer = await buildZeroGSigner(walletClient);
-    } catch {
-      signer = undefined;
-    }
-    let storage: StorageProof;
-    try {
-      storage = await putPlayLog(draft.playLog, signer);
-    } catch (storageError) {
-      return {
-        storageSettled: { status: 'rejected', reason: storageError },
-        mintSettled: {
-          status: 'rejected',
-          reason: new Error('skipped: storage upload failed'),
-        },
-      };
-    }
+  // ── Phase 1: 0G Galileo (storage upload → iNFT mint) ────────────────
+  let storageSettled: PromiseSettledResult<StorageProof>;
+  let mintSettled: PromiseSettledResult<MintProof>;
+  let signer: ZeroGSigner | undefined;
+  try {
+    signer = await buildZeroGSigner(walletClient);
+  } catch {
+    signer = undefined;
+  }
+  let storage: StorageProof;
+  try {
+    storage = await putPlayLog(draft.playLog, signer);
+    storageSettled = { status: 'fulfilled', value: storage };
+  } catch (storageError) {
+    storageSettled = { status: 'rejected', reason: storageError };
+    mintSettled = {
+      status: 'rejected',
+      reason: new Error('skipped: storage upload failed'),
+    };
+    storage = { cid: '' };
+  }
+  if (storageSettled.status === 'fulfilled') {
     try {
       const mint = await mintINft(walletClient, {
         ensName: draft.agent.ensName,
@@ -110,41 +117,37 @@ export async function runOnChainForge(
         combatPower: BigInt(draft.agent.profile.combatPower),
         storageCID: storage.cid,
       });
-      return {
-        storageSettled: { status: 'fulfilled', value: storage },
-        mintSettled: { status: 'fulfilled', value: mint },
-      };
+      mintSettled = { status: 'fulfilled', value: mint };
     } catch (mintError) {
-      return {
-        storageSettled: { status: 'fulfilled', value: storage },
-        mintSettled: { status: 'rejected', reason: mintError },
-      };
+      mintSettled = { status: 'rejected', reason: mintError };
     }
-  })();
+  } else {
+    // mintSettled は上の catch ブロックで既に "skipped" を入れてある。
+    // TS narrowing 用にここで noop。
+    mintSettled ??= {
+      status: 'rejected',
+      reason: new Error('skipped: storage upload failed'),
+    };
+  }
 
-  const ensPromise = registerSubname(walletClient, {
-    handle,
-    owner,
-    textRecords: {
-      'combat-power': String(draft.agent.profile.combatPower),
-      archetype: draft.agent.archetype,
-      'design-hash': draft.agent.birthHash,
-    },
-  });
-
-  const [{ storageSettled, mintSettled }, ensSettled] = await Promise.all([
-    storageThenMint,
-    ensPromise.then(
-      (value): PromiseSettledResult<EnsProof> => ({
-        status: 'fulfilled',
-        value,
-      }),
-      (reason): PromiseSettledResult<EnsProof> => ({
-        status: 'rejected',
-        reason,
-      })
-    ),
-  ]);
+  // ── Phase 2: Sepolia (ENS subname + text records) ───────────────────
+  // Phase 1 が完全に終わった後に走らせる。これで chain switch が serial に
+  // なって MetaMask の "request already pending" エラーが起きない。
+  let ensSettled: PromiseSettledResult<EnsProof>;
+  try {
+    const ens = await registerSubname(walletClient, {
+      handle,
+      owner,
+      textRecords: {
+        'combat-power': String(draft.agent.profile.combatPower),
+        archetype: draft.agent.archetype,
+        'design-hash': draft.agent.birthHash,
+      },
+    });
+    ensSettled = { status: 'fulfilled', value: ens };
+  } catch (ensError) {
+    ensSettled = { status: 'rejected', reason: ensError };
+  }
 
   return aggregateProof(storageSettled, mintSettled, ensSettled);
 }


### PR DESCRIPTION
## Summary

User の re-deploy 後の再プレイで:

```
× FAIL  0G iNFT
chain mismatch: switch to 0G Galileo (16602) was rejected (current chain 11155111):
Requested resource not available.
Details: Request of type 'wallet_requestPermissions' already pending for origin ...
```

が出ていた件への対応。

## 根本原因

`runOnChainForge` が **Galileo 系 (storage+mint) と Sepolia 系 (ENS) を `Promise.all` で並列実行** していた。各 step の手前で `ensureChain → switchChain` を呼ぶので、**MetaMask に Galileo と Sepolia の switch 要求が同時に届いていた**。

MetaMask は per-origin で `wallet_requestPermissions` を **1 つしか pending にできない仕様**なので、後発が:

> Requested resource not available.
> Request of type 'wallet_requestPermissions' already pending

で reject される。これが iNFT 行が常に FAIL になる原因。

## 解消

forge pipeline を **完全 serial 化**:

| Phase | Chain | Steps |
|---|---|---|
| 1 | 0G Galileo | 0G Storage upload → iNFT mint (同 chain なので switch 1 回) |
| 2 | Sepolia | ENS subname registration + text records (switch 1 回) |

並列化のメリットは wallet が signature prompt を直列化する関係でほぼ無いので、user-facing latency はほぼ変わらない。serial にすることで:

- chain switch が確実に 1 つずつ片付く
- user reject も対応する step (e.g. ENS の `setSubnodeRecord`) だけに表示される
- 既存の独立 settled (`storage` / `mint` / `ens` を別行で表示) はそのまま維持

## Test plan

- [x] `bun run typecheck` — shared / frontend 共に exit 0
- [x] `bun run lint` (biome) — クリーン
- [x] `bun run test` — frontend 21 pass・1 skip・0 fail (`aggregateProof` の signature 変更なし、既存テストそのまま通る)
- [x] `bun run build` — 成功
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] User がライブで再プレイ → Phase 1 (Galileo storage + mint) → Phase 2 (Sepolia ENS) が serial に進み、iNFT 行が ✅ になることを目視確認 (人間タスク)

## What this PR does NOT do (out of scope)

- ENS の text records は引き続き Sepolia 上で 1 record ずつ sequential に signing (`registerSubname` 内部の挙動)。これも serial だが、user は Sepolia chain 内で複数 sign することになる。EIP-5792 の multicall 対応は follow-up。