### PR TITLE
feat(game): 全キル発火の右下 commit toast — どんな危険を防いだかを毎回見せる

### DIFF
--- a/packages/frontend/src/components/BirthArcade.tsx
+++ b/packages/frontend/src/components/BirthArcade.tsx
@@ -23,6 +23,7 @@ import {
 } from '../game/runtime';
 import { prewarmSfx } from '../game/sfx';
 import { VIC_KEY, VIC_VIPER, drawSprite } from '../game/sprites';
+import { CommitToast, type CommitToastQueueItem } from './CommitToast';
 import { AgentHandleLabel } from './HUD';
 import {
   MisalignmentToast,
@@ -83,6 +84,18 @@ export function BirthArcade({
   const onConsumed = useCallback(() => {
     currentToastIdRef.current = null;
     setCurrentToast(null);
+  }, []);
+
+  // 全キル発火の右下サポート toast (capability commit)。
+  // MisalignmentToast (4 種失敗モードの強い警告) と並走するが、こちらは
+  // 毎キル発火するので必ず何か出ている状態になる。両方同時に出るときは
+  // CommitToast を 1 段上 (stack="raised") に積んで重ならないようにする。
+  const [currentCommitToast, setCurrentCommitToast] =
+    useState<CommitToastQueueItem | null>(null);
+  const currentCommitToastIdRef = useRef<number | null>(null);
+  const onCommitConsumed = useCallback(() => {
+    currentCommitToastIdRef.current = null;
+    setCurrentCommitToast(null);
   }, []);
 
   useEffect(() => {
@@ -174,6 +187,17 @@ export function BirthArcade({
             if (next) {
               currentToastIdRef.current = next.id;
               setCurrentToast({ id: next.id, kind: next.kind });
+            }
+          }
+          // capability commit toast: 全キル発火の右下サポート。同上の shift パターン。
+          if (!currentCommitToastIdRef.current) {
+            const next = runtimeRef.current.commitToasts.shift();
+            if (next) {
+              currentCommitToastIdRef.current = next.id;
+              setCurrentCommitToast({
+                id: next.id,
+                capability: next.capability,
+              });
             }
           }
           if (runtimeRef.current.finished) {
@@ -268,6 +292,13 @@ export function BirthArcade({
           ) : null}
           {phase === 'play' ? (
             <MisalignmentToast current={currentToast} onConsumed={onConsumed} />
+          ) : null}
+          {phase === 'play' ? (
+            <CommitToast
+              current={currentCommitToast}
+              onConsumed={onCommitConsumed}
+              stack={currentToast ? 'raised' : 'base'}
+            />
           ) : null}
           {phase === 'idle' ? (
             <button

--- a/packages/frontend/src/components/CommitToast.tsx
+++ b/packages/frontend/src/components/CommitToast.tsx
@@ -1,0 +1,106 @@
+import { useEffect } from 'react';
+import {
+  CAPABILITY_COLOR,
+  CAPABILITY_DESC,
+  CAPABILITY_LABEL,
+  CAPABILITY_RISK,
+  type Capability,
+} from '../game/runtime';
+
+export interface CommitToastQueueItem {
+  id: number;
+  capability: Capability;
+}
+
+interface Props {
+  /// 親が runtime から shift で取り出した最新のイベント (1 件)。
+  current: CommitToastQueueItem | null;
+  /// 表示が完了したときに親へ伝える。
+  onConsumed: (id: number) => void;
+  /// MisalignmentToast が同時に出ているときは bottom 16px だと重なるので、
+  /// 親側で `stack="raised"` を渡して 1 段上に上げる。
+  stack?: 'base' | 'raised';
+}
+
+const VISIBLE_MS = 2000;
+
+/// 毎キルに対して右下にサポート表示する小さなカード。
+/// MisalignmentToast (4 種失敗モードの警告) と並走するが、こちらは
+/// 全キル発火する commit log として動く。プレイヤーが画面の流れる文字
+/// (+180 LEV 等) を一瞬では読めないので、その補助。
+export function CommitToast({ current, onConsumed, stack = 'base' }: Props) {
+  useEffect(() => {
+    if (!current) return;
+    const timer = window.setTimeout(() => {
+      onConsumed(current.id);
+    }, VISIBLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [current, onConsumed]);
+
+  if (!current) return null;
+  const cap = current.capability;
+  const color = CAPABILITY_COLOR[cap];
+
+  return (
+    <output
+      aria-live="polite"
+      style={{
+        position: 'absolute',
+        right: 16,
+        bottom: stack === 'raised' ? 140 : 16,
+        maxWidth: 280,
+        padding: '12px 14px',
+        background: 'rgba(5, 8, 12, 0.92)',
+        border: `1px solid ${color}`,
+        color: '#e6f1ff',
+        fontFamily:
+          '"JetBrains Mono", "IBM Plex Mono", ui-monospace, monospace',
+        fontSize: 11,
+        letterSpacing: '0.04em',
+        lineHeight: 1.55,
+        pointerEvents: 'none',
+        boxShadow: `0 0 18px ${color}33`,
+        display: 'block',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 8,
+          marginBottom: 4,
+        }}
+      >
+        <span
+          style={{
+            color,
+            fontSize: 10,
+            letterSpacing: '0.18em',
+            fontWeight: 700,
+          }}
+        >
+          COMMITTED
+        </span>
+        <span
+          style={{
+            color,
+            fontWeight: 700,
+            letterSpacing: '0.16em',
+          }}
+        >
+          {CAPABILITY_LABEL[cap]}
+        </span>
+      </div>
+      <div style={{ marginBottom: 6 }}>{CAPABILITY_DESC[cap]}</div>
+      <div
+        style={{
+          color: '#7ee0ff',
+          fontSize: 10,
+          letterSpacing: '0.04em',
+        }}
+      >
+        Without it: {CAPABILITY_RISK[cap]}
+      </div>
+    </output>
+  );
+}

--- a/packages/frontend/src/game/runtime.ts
+++ b/packages/frontend/src/game/runtime.ts
@@ -72,7 +72,7 @@ export const ARCHETYPE_GLYPH: Record<Archetype, string> = {
   aggressive: 'RISK',
 };
 
-type Capability = Exclude<Capsule, 'double'>;
+export type Capability = Exclude<Capsule, 'double'>;
 
 export const CAPABILITY_ORDER: Capability[] = [
   'shield',
@@ -317,6 +317,17 @@ export interface MisalignmentToastEvent {
   spawnAt: number;
 }
 
+/// 全キル発火の commit トースト。MisalignmentToast が「踏み抜くと事故る
+/// 4 種失敗モード」の警告に専念しているのに対して、こちらは毎キルに対して
+/// 「いま何の module を policy にコミットしたのか」「装備しないとどう困るのか」
+/// を右下にサポート表示する。プレイヤーが画面の流れる文字 (+180 LEV 等) を
+/// 一瞬では読めない問題への補助情報。
+export interface CommitToastEvent {
+  id: number;
+  capability: Capability;
+  spawnAt: number;
+}
+
 interface MoaiBoss {
   type: 'moai';
   id: string;
@@ -387,6 +398,10 @@ export interface Runtime {
   misalignmentToasts: MisalignmentToastEvent[];
   /// MisalignmentToastEvent.id を採番するカウンタ。
   misalignmentCounter: number;
+  /// 全キル発火の右下 commit toast キュー。React 側で shift して表示。
+  commitToasts: CommitToastEvent[];
+  /// CommitToastEvent.id を採番するカウンタ。
+  commitCounter: number;
   stars: Star[];
   terrain: Terrain;
   events: PlayEvent[];
@@ -434,6 +449,8 @@ export function createRuntime(
     toasts: [],
     misalignmentToasts: [],
     misalignmentCounter: 0,
+    commitToasts: [],
+    commitCounter: 0,
     stars: makeStars(),
     terrain: makeTerrain(),
     events: [],
@@ -752,6 +769,14 @@ export function step(rt: Runtime, input: InputState) {
                 spawnAt: rt.t,
               });
             }
+            // 全キル毎に commit toast を発火。React 側が右下にサポート表示し、
+            // 「いまコミットした module + 装備しないとどう事故るか」を見せる。
+            rt.commitCounter += 1;
+            rt.commitToasts.push({
+              id: rt.commitCounter,
+              capability: e.capability,
+              spawnAt: rt.t,
+            });
             spawnBurst(rt, e.x + 4, e.y + 4, e.flashColor, 14);
             rt.scorePops.push({
               x: e.x + 4,


### PR DESCRIPTION
## Summary

User の「右下の解説が出なくなった、これがあるとどんな危険があるのか分かるのに」要望への対応。

`MisalignmentToast` は **4 種失敗モード (sycophancy / reward hacking / prompt injection / goal misgeneralization) の強い警告**専用で、misalignment 付きの敵をキルしたときしか発火しない。それ以外の通常キルでは右下が空のままで、流れる score popup (`+180 LEV` 等) を一瞬で読まないと「いま何をコミットしたのか」が分からなかった。

## 変更点

### runtime.ts

- `CommitToastEvent` 型 + `commitToasts` キュー + `commitCounter` を追加
- 全キル毎に push (misalignment フラグの有無に関係なく)
- `Capability` 型を export 化 (新コンポーネントが import するため)

### `components/CommitToast.tsx` (新規)

`MisalignmentToast` と同じパターン (右下 / 2 秒表示 / aria-live polite) で、コミットされた capability を 3 行で表示:

```
COMMITTED  LEVERAGE          ← capability 色
margin tier / max position / hedge
Without it: liquidation on the wrong tier / left return on the table
```

`stack="raised"` を渡すと bottom: 140 に上がる (MisalignmentToast と同時表示時に重ならないため)。

### `components/BirthArcade.tsx`

- 第二の queue shift ロジックを追加 (毎フレーム `commitToasts.shift()` を 1 つだけ取り出す)
- `<CommitToast>` を `<MisalignmentToast>` の隣に render
- 両方同時に出るときは `stack={currentToast ? 'raised' : 'base'}` で commit toast を上に積む

## Test plan

- [x] `bun run typecheck` — shared / frontend exit 0
- [x] `bun run lint` (biome) — 60 files クリーン (+1 ファイル)
- [x] `bun run test` — frontend 21 pass・1 skip・0 fail (既存テストそのまま通る)
- [x] `bun run build` — 成功
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] ローカル dev で 60 秒プレイ → 毎キル右下に capability + danger 説明が 2 秒だけ表示されることを目視確認 (人間タスク)
- [ ] misalignment 付き enemy をキルしたとき、misalignment toast (下) と commit toast (上) が同時に表示され重ならないことを確認 (人間タスク)
- [ ] `?seed=demo` で misalignment 4 種が連続発火するときも乱れず表示されることを確認 (人間タスク)