### PR TITLE
fix(css): .eyebrow が grid 内で full-width に伸びる問題を修正

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -55,6 +55,14 @@ button {
 .hero-kicker,
 .eyebrow {
   display: inline-block;
+  /* `.panel-header` が `display: grid` なので grid item は default で
+     align-self / justify-self: stretch する。inline-block は grid 上では
+     block 扱いになり、結果として pill が full width に伸びて上下にも
+     padding が乗って見える。明示的に self-align を start に固定して
+     compact な pill 形を保つ。 */
+  justify-self: start;
+  align-self: start;
+  width: max-content;
   padding: 6px 10px;
   border-radius: 999px;
   background: rgba(123, 223, 242, 0.18);


### PR DESCRIPTION
## Summary

User の dashboard スクショで `PORTFOLIO ARCHETYPE` のラベル pill が想定より遥かに大きく表示され、`BALANCED` 見出しとの間に巨大な空白ができていた件への修正。

## 原因

`.panel-header` が `display: grid; gap: 6px;` を使っており、grid item は default で `align-self / justify-self: stretch`。`.eyebrow` は `display: inline-block` を持つが、**grid 内では block-level 扱いになり、cell の幅 (= 親 panel の幅) に横方向 stretch する**。結果として:

- pill の幅 = panel 全幅
- `border-radius: 999px` が幅・高さ両方に効いて、両端が大きな半円になる
- 見た目が「巨大な空の pill」になっていた

## 修正

```css
.eyebrow {
  display: inline-block;
+ justify-self: start;
+ align-self: start;
+ width: max-content;
  padding: 6px 10px;
  border-radius: 999px;
  ...
}
```

- `justify-self: start` / `align-self: start` で grid item の自動 stretch を抑える
- `width: max-content` で念のため content 幅に固定

## Test plan

- [x] `bun run lint` (biome) — クリーン
- [x] `bun run build` — frontend 成功
- [ ] live demo で `PORTFOLIO ARCHETYPE` / `Agent Identity` / 他の `eyebrow` pill が compact 表示に戻ることを目視確認 (人間タスク)
- [ ] `<HeroKicker>` (`.hero-kicker` も同 selector) の見た目が崩れていないか確認 (人間タスク)