### PR TITLE
docs(feedback): Uniswap DX feedback を英語化

### DIFF
--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -2,42 +2,42 @@
 
 ## 2026-05-03
 
-Gr@diusWeb3 では、Sepolia 上での実 swap を agent の最初のオンチェーン行動として組み込みました。現在の実装では `exactInputSingle` を使い、`0.0001 ETH` を `WETH -> USDC` に swap し、tx hash と explorer URL を AgentDashboard に返します。
+For Gr@diusWeb3 we wired a real Sepolia swap as the agent's first on-chain action. The current implementation calls `exactInputSingle` to swap `0.0001 ETH` from `WETH -> USDC`, then returns the tx hash and the explorer URL to the AgentDashboard.
 
-### 何がうまくいったか
+### What worked
 
-- `walletClient.writeContract` からそのまま Uniswap v3 Router に投げられたので、viem / wagmi との相性はよかった。
-- `exactInputSingle` は最小構成で動き、1 回の swap を demo に落とし込みやすかった。
-- `waitForTransactionReceipt` で確認してから UI に返す流れにすると、judges が tx を追いやすい。
-- Native ETH を payable で渡して router 側で wrap する構成は、agent の「最初の行動」として分かりやすかった。
+- We could fire `walletClient.writeContract` directly at the Uniswap v3 Router. The integration with viem / wagmi was clean — no extra abstraction layer needed.
+- `exactInputSingle` is minimal enough to drop into a demo with one tx, and the call sites stayed tiny.
+- Waiting for `waitForTransactionReceipt` before showing the UI makes the on-chain proof easy for judges to follow on Etherscan.
+- Sending native ETH via `payable` and letting the router wrap it on the way in is a great fit for "the agent's first action" — no separate WETH dance required from the user.
 
-### 何がうまくいかなかったか
+### What did not work
 
-- Sepolia には "USDC" と名のつくトークンが複数あり、最初にどの token address を使うべきか迷った。
-- router / token / chain の address は、docs と explorer を行ったり来たりして手で確認する必要があった。
-- swap amount や slippage の既定値を決めるとき、初期の開発段階では「最小デモを優先するか」「実運用寄りにするか」の判断コストが高かった。
+- Sepolia has several tokens called "USDC". Choosing the right canonical address up front took longer than the rest of the integration combined.
+- Router / token / chain addresses required hopping between docs and the explorer to double-check. There is no single page we trusted.
+- Picking sensible defaults for `amountIn` and slippage at the demo stage involved real judgment ("optimize for the smallest visible demo" vs "stay closer to production"). That decision cost felt heavier than it should.
 
-### ぶつかった DX 摩擦
+### DX friction we hit
 
-- "この chain で本当にその router が生きているか" を毎回自分で検証しないといけない。
-- testnet では faucet / gas / token balance が揃わないと demo が止まるため、judge 用の再現手順を README 側にもっと明示したくなった。
-- 失敗時のエラーは onchain の revert reason に寄るので、UI 側で「wallet 未接続」「chain 不一致」「token 不足」を分けて見せるとさらに親切。
+- We had to verify "is this router actually live on this chain?" by hand every time. The deployments page exists but is not phrased as a runtime liveness check.
+- On testnet, demos break the moment faucets / gas / token balances are not aligned, so we ended up wanting a more explicit reproducer recipe baked into the README for judges.
+- Failure messages bubble up from on-chain revert reasons, so the UI ends up with raw revert text. Splitting "wallet not connected" / "chain mismatch" / "insufficient balance" client-side would be a much friendlier UX, and a higher-level error mapping from Uniswap would help.
 
-### バグ / つまずき
+### Bugs / surprises
 
-- token address を間違えると当然 revert するので、Sepolia 用の canonical address をコードで固定しておく必要があった。
-- RPC の調子が悪いと receipt 待ちで止まることがあるため、demo では tx hash を先に見せる導線があると安心。
-- `amountOutMinimum = 0` は demo には便利だが、本番の説明では「簡略化したデモ設定」であることを明記したほうが誤解が少ない。
+- Wrong token address obviously reverts, so we had to pin canonical Sepolia addresses in code rather than read them at runtime.
+- When the RPC degrades, `waitForTransactionReceipt` hangs. Surfacing the tx hash before the receipt completes — so judges can click through to the explorer immediately — turned out to be essential UX.
+- `amountOutMinimum = 0` is convenient for the demo but easy to misread as production-ready. We now annotate it in the code as a deliberately simplified demo setting.
 
-### 欲しかったもの
+### What we wanted
 
-- 公式に「Sepolia で動く最小 swap デモ」のサンプル。
-- token / router / chain の canonical address 一覧を 1 ページで確認できるドキュメント。
-- 失敗時の reason を UI に出すための、Uniswap 側のもう少し高レベルなエラーマッピング例。
-- 0.0001 ETH のような小額デモを、見積り API から自動で安全に調整するガイド。
+- An official "smallest possible Sepolia swap" reference sample.
+- A single doc page that lists canonical token / router / chain addresses for every supported testnet.
+- A higher-level error mapping from Uniswap so apps can render human-readable failure reasons instead of raw revert strings.
+- Guidance for safely auto-sizing tiny demo trades like `0.0001 ETH` via the quote API.
 
-### 今回の結論
+### Conclusion
 
-- Uniswap API は、agent が「実際に価値を動かす」体験を作るには十分実用的だった。
-- ただし demo 成功の鍵は API よりも、testnet address の確認・chain の固定・失敗時 UX の整備だった。
-- 次にやるなら、quote → swap → receipt → explorer link を 1 画面で追えるテンプレートを最初から用意したい。
+- The Uniswap API is comfortably good enough to build "the agent actually moves real value" experiences on top of.
+- The thing that decided whether a demo worked was not the API surface — it was confirming testnet addresses, pinning the chain, and shaping the failure UX.
+- Next time we would start from a single template that covers quote → swap → receipt → explorer link in one screen, instead of stitching it together from docs.


### PR DESCRIPTION
## Summary

Uniswap prize submission の必須資料 `FEEDBACK.md` が日本語のままだったので **全文英訳**。judges (英語想定) に届くようにする。論点と構成 (`worked` / `did not work` / `DX friction` / `bugs` / `what we wanted` / `conclusion`) はそのまま保ち、英語として自然な表現に書き直し。

## セクション対応

| Before (JP) | After (EN) |
|---|---|
| 何がうまくいったか | What worked |
| 何がうまくいかなかったか | What did not work |
| ぶつかった DX 摩擦 | DX friction we hit |
| バグ / つまずき | Bugs / surprises |
| 欲しかったもの | What we wanted |
| 今回の結論 | Conclusion |

## 要点 (内容は維持、表現は英語として自然に調整)

- `walletClient.writeContract` から viem / wagmi 経由で v3 Router を叩く相性の良さ
- `exactInputSingle` の最小構成での扱いやすさ
- Sepolia の "USDC" 名衝突問題と canonical address のドキュメント不足
- testnet faucet / gas が揃わないと demo が止まるので judges 用 reproducer が必要
- revert reason を UI にそのまま出さず higher-level error mapping が欲しい
- `amountOutMinimum = 0` は demo 用と明示が必要
- API 自体は agent が実価値を動かす体験に十分実用的

## Test plan

- [x] `bun run lint:text` (textlint) — クリーン
- [x] `bun run lint` (biome) — クリーン
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] judges (英語想定) が読んで意味が通ることを目視確認 (人間タスク)