### PR TITLE
fix(ui): 安全アテステーションパネルの日本語ラベルを英語化

### DIFF
--- a/packages/frontend/src/components/SafetyAttestationPanel.tsx
+++ b/packages/frontend/src/components/SafetyAttestationPanel.tsx
@@ -61,15 +61,16 @@ export function SafetyAttestationPanel({
           AGENT SAFETY ATTESTATION
         </span>
         <h2 style={{ color: A.ink }}>
-          安全スコア{' '}
+          Safety score{' '}
           <span style={{ color: A.acid, fontSize: 36 }}>
             {attestation.score}
           </span>
           <span style={{ color: A.mute, fontSize: 14 }}> / 100</span>
         </h2>
         <p style={{ color: A.mute, fontSize: 12 }}>
-          ENS subname に書き込まれる verifiable agent safety credential。 0G
-          Storage に attestation 本体を put、ENS text record に CID を pin。
+          A verifiable agent safety credential written to the ENS subname. The
+          attestation body is put on 0G Storage; the ENS text record pins the
+          CID.
         </p>
       </div>
 
@@ -208,20 +209,20 @@ function BreakdownLedger({
         color: A.ink,
       }}
     >
-      <LedgerRow label="ベース基準点" value={base} color={A.mute} />
+      <LedgerRow label="Base score" value={base} color={A.mute} />
       <LedgerRow
-        label="早クリアボーナス"
+        label="Clear-time bonus"
         value={breakdown.clearTimeBonus}
         color={A.green}
       />
       <LedgerRow
-        label="誤射ペナルティ"
+        label="Miss penalty"
         value={breakdown.missPenalty}
         color={A.hot}
       />
       {clampDelta !== 0 ? (
         <LedgerRow
-          label="0..100 クリップ補正"
+          label="0..100 clip correction"
           value={clampDelta}
           color={A.mute}
         />
@@ -238,7 +239,7 @@ function BreakdownLedger({
           fontWeight: 700,
         }}
       >
-        <span style={{ color: A.amber, letterSpacing: '0.16em' }}>合計</span>
+        <span style={{ color: A.amber, letterSpacing: '0.16em' }}>TOTAL</span>
         <span aria-hidden="true" />
         <span
           style={{

--- a/packages/frontend/src/web3/safety-attestation.ts
+++ b/packages/frontend/src/web3/safety-attestation.ts
@@ -70,7 +70,7 @@ async function ensureSubnameAvailable(
   const isSameOwner = owner.toLowerCase() === expectedOwner.toLowerCase();
   if (!isFree && !isSameOwner) {
     throw new Error(
-      `handle ${handle}.${parent} は別のオーナーが保有しています。再生成してください`
+      `handle ${handle}.${parent} is already owned by another address. Please regenerate.`
     );
   }
 }

--- a/packages/shared/src/safety.ts
+++ b/packages/shared/src/safety.ts
@@ -16,8 +16,9 @@ export const MISALIGNMENT_CARDS: Record<MisalignmentKind, MisalignmentCard> = {
     kind: 'sycophancy',
     label: 'Sycophancy',
     description:
-      'Agent が利用者に都合の良い signal だけ拾い、反対意見を黙殺する失敗モード。',
-    example: 'oracle に否定値が出ても無視して買い増しを推奨する。',
+      'The agent picks up only signals that flatter the user and ignores dissenting evidence.',
+    example:
+      'Recommends buying more even when the oracle prints a negative signal.',
     glyph: '◉',
     color: '#c084ff',
   },
@@ -25,8 +26,9 @@ export const MISALIGNMENT_CARDS: Record<MisalignmentKind, MisalignmentCard> = {
     kind: 'reward_hacking',
     label: 'Reward Hacking',
     description:
-      '指標 (yield や PnL) を歪めて短期スコアだけ吊り上げ、本質を最適化しない。',
-    example: 'APY 表示を maximizing する Pool に過剰アロケートする。',
+      'Bends a metric (yield or PnL) to lift a short-term score instead of optimizing the real objective.',
+    example:
+      'Over-allocates to a pool that maximizes the displayed APY rather than risk-adjusted return.',
     glyph: '◇',
     color: '#40f070',
   },
@@ -34,8 +36,9 @@ export const MISALIGNMENT_CARDS: Record<MisalignmentKind, MisalignmentCard> = {
     kind: 'prompt_injection',
     label: 'Prompt Injection',
     description:
-      '外部入力に "approve all" などの指示が混じり、安全境界を超えてしまう。',
-    example: '怪しい contract の "Sign anything" 指示にそのまま追従する。',
+      'External input slips in "approve all" style instructions and the agent crosses its own safety boundary.',
+    example:
+      'Follows a malicious contract\'s "sign anything" prompt without questioning it.',
     glyph: '▲',
     color: '#7bdff2',
   },
@@ -43,8 +46,9 @@ export const MISALIGNMENT_CARDS: Record<MisalignmentKind, MisalignmentCard> = {
     kind: 'goal_misgen',
     label: 'Goal Misgeneralization',
     description:
-      'proxy metric だけ最適化して本来のゴールから逸脱する失敗モード。',
-    example: 'スリッページ最小化に集中して取引機会自体を失う。',
+      'Optimizes a proxy metric so hard that it drifts away from the actual goal it was meant to pursue.',
+    example:
+      'Focuses on minimizing slippage and ends up missing the trade entirely.',
     glyph: '☓',
     color: '#ff5252',
   },


### PR DESCRIPTION
## Summary

User の最後の宿題: スクショで指摘された **AGENT SAFETY ATTESTATION パネルの日本語**を英語化。UI 全体が English ベースなので統一する。

## 変更箇所

| 場所 | Before | After |
|---|---|---|
| `SafetyAttestationPanel.tsx` h2 | 「安全スコア」 | "Safety score" |
| `SafetyAttestationPanel.tsx` p | 「ENS subname に書き込まれる … CID を pin。」 | "A verifiable agent safety credential written to the ENS subname. The attestation body is put on 0G Storage; the ENS text record pins the CID." |
| LedgerRow labels | 「ベース基準点 / 早クリアボーナス / 誤射ペナルティ / 0..100 クリップ補正」 | "Base score / Clear-time bonus / Miss penalty / 0..100 clip correction" |
| Total row | 「合計」 | "TOTAL" |
| `safety.ts` MISALIGNMENT_CARDS | 4 種 (sycophancy / reward_hacking / prompt_injection / goal_misgen) の description + example が日本語 | 各 failure mode を英語の自然な説明に書き直し |
| `safety-attestation.ts` ENS conflict error | 「handle ... は別のオーナーが保有しています。再生成してください」 | "handle ... is already owned by another address. Please regenerate." |

コードコメント (`///`) は引き続き JP (CLAUDE.md の docs convention に従う)。`grep` で safety 関連 3 ファイルから user-facing JP がゼロになったことを確認。

## Test plan

- [x] `bun run typecheck` — shared / frontend 共に exit 0
- [x] `bun run lint` (biome) — 60 files クリーン
- [x] `bun run test` — frontend 21 pass・1 skip・0 fail (既存 `MISALIGNMENT_CARDS` の length ≤ 140 制約は維持)
- [x] `bun run build` — 成功
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] live demo の AGENT SAFETY ATTESTATION パネルが英語で表示されることを目視確認 (人間タスク)