### PR TITLE
docs(contracts): contracts/README.md を実際のデプロイ状態に合わせて書き直す

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,8 +1,73 @@
 # Contracts
 
-Foundry はまだこの環境に入っていないため、ここでは Gr@diusWeb3 の contract stub を配置しています。
+Foundry-based Solidity 0.8.28 sources for Gr@diusWeb3. The ENS layer was moved to
+real Sepolia ENS (NameWrapper + PublicResolver), so the only contract we still
+own and deploy is the iNFT.
 
-- `AgentForgeINFT.sol`: policy hash と ENS subname を保持する最小 iNFT 風コントラクト。
-- `AgentForgeSubnameRegistry.sol`: subname と text record を束ねる最小レジストリ。
+## What's here
 
-Foundry を導入したら `forge build` と `forge test` を追加してください。
+| File | Role |
+|---|---|
+| [`src/AgentForgeINFT.sol`](./src/AgentForgeINFT.sol) | ERC-721 with deterministic `tokenId = keccak256(msg.sender, playLogHash)` and a base64 data-URI `tokenURI` that pins the agent's archetype, combat power, play-log hash, policy blob, and 0G Storage CID on-chain. |
+| [`script/Deploy.s.sol`](./script/Deploy.s.sol) | Foundry deploy script. Multi-chain (Sepolia / Base / OP / Arbitrum / 0G Galileo); reads RPCs from `foundry.toml`. |
+| [`foundry.toml`](./foundry.toml) | Solidity `0.8.28`, optimizer + via-IR, `[rpc_endpoints]` aliases for every supported testnet, `[etherscan]` keys for the Sepolia family. Galileo's RPC is hardcoded because Foundry's TOML resolver does not understand `${VAR:-default}`. |
+
+## Live deployments
+
+| Chain | ID | Address |
+|---|---|---|
+| **0G Galileo** | 16602 | [`0xcB74b0E49dB3968b4e8cEB70EFAaA6bb668346D7`](https://chainscan-galileo.0g.ai/token/0xcb74b0e49db3968b4e8ceb70efaaa6bb668346d7) |
+
+## Build & test
+
+```bash
+forge build
+forge test     # if/when tests are added; currently the contract is small enough to lean on the deploy script + on-chain verification
+```
+
+## Deploy
+
+Always go through the repo-root `Makefile` so the testnet-only guard is
+preserved. The Makefile never accepts a raw private key — signing is keystore
+/ Ledger / Trezor / interactive only. See the
+[top-level README](../README.md#make-the-inft-live) for the full flow.
+
+```bash
+# one-time: generate a fresh disposable wallet + import into Foundry's encrypted keystore
+make deploy_setup
+
+# per chain (run from the repo root, not from inside contracts/)
+make deploy_galileo          ACCOUNT=deployer SENDER=0xYourAddress
+make deploy_sepolia          ACCOUNT=deployer SENDER=0xYourAddress
+make deploy_base_sepolia     ACCOUNT=deployer SENDER=0xYourAddress
+make deploy_op_sepolia       ACCOUNT=deployer SENDER=0xYourAddress
+make deploy_arbitrum_sepolia ACCOUNT=deployer SENDER=0xYourAddress
+
+# everything in one shot
+make deploy_all ACCOUNT=deployer SENDER=0xYourAddress
+```
+
+After each deploy, copy the printed contract address into the Vercel project as
+`VITE_INFT_ADDRESS=0x...` and redeploy the frontend so the dashboard targets it.
+
+### Verification
+
+Sepolia-family deploys verify on Etherscan automatically (`--verify` flag in
+the Makefile). 0G Galileo skips `--verify` because Galileo does not yet expose
+an Etherscan-compatible verifier; the deploy still succeeds and the contract
+is visible on https://chainscan-galileo.0g.ai.
+
+## Removed: `AgentForgeSubnameRegistry.sol`
+
+An earlier version of this directory shipped an in-house ENS-like registry. It
+was removed when we wired the frontend to real Sepolia ENS via viem
+([`packages/frontend/src/web3/ens-register.ts`](../packages/frontend/src/web3/ens-register.ts)).
+The iNFT is the only contract we own.
+
+## Testnet-only invariant
+
+The frontend never sends a write to a chain outside its testnet allowlist —
+`wagmi` config, `ensureChain`, `TestnetGuard`, and a hardcoded swap cap each
+enforce this independently. See the
+["Why it can't hit mainnet" section](../README.md#why-it-cant-hit-mainnet) of
+the top-level README for how the four layers compose.


### PR DESCRIPTION
## Summary

User の指摘「`contracts/README.md` 何も書いてない」への対応。

旧 README は内容と乖離していた:

- 「Foundry はまだこの環境に入っていない」と書いてあるが、実際は AgentForgeINFT を Foundry で **0G Galileo に live deploy 済** (PR #48 / #50 / #52 の合流結果)。
- 既に削除した `AgentForgeSubnameRegistry.sol` を記載。実 Sepolia ENS (NameWrapper + PublicResolver) 移行で削除済 (PR #39 周辺)。
- 全文 JP のままで、UI / FEEDBACK / submission docs の英語化方針と不揃い。

## 新 README

- **What's here** 表で `AgentForgeINFT.sol` / `Deploy.s.sol` / `foundry.toml` を 1 行ずつ説明 (`tokenId = keccak256(msg.sender, playLogHash)` と base64 data URI tokenURI を明記)
- **Live deployments** 表で 0G Galileo 16602 + 実 contract address + chainscan リンクを judges 向けに直貼り
- `forge build` / `forge test` の最小コマンド
- repo-root Makefile 経由のデプロイフロー (`make deploy_setup` → 各 `make deploy_*` → Vercel env 反映) を再掲
- Galileo が `--verify` 非対応な点と Sepolia 系は Etherscan 自動検証される差分を明記
- 旧 `AgentForgeSubnameRegistry.sol` を削除した理由と現在の ENS 実装場所 (`ens-register.ts`) を crosslink
- testnet-only 4 層ガードを top-level README にリンク

## Test plan

- [x] `bun run lint:text` (textlint) — クリーン
- [x] `bun run lint` (biome) — 60 files クリーン
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [ ] GitHub の `contracts/README.md` プレビューでリンクが全部生きていることを目視確認 (人間タスク)