### PR TITLE
docs(readme): integrate していない sponsor を表から外す (judge 向けに事実だけ書く)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,13 @@ Bun · Vite · React 19 · Canvas 2D · TypeScript · Biome · viem · wagmi · 
 
 ## Sponsor integrations
 
-| Sponsor | Role |
-|---|---|
-| **0G** | iNFT on 0G Galileo (chain 16602) + play log on 0G Storage; root hash pinned in iNFT metadata and ENS text record. |
-| **ENS** | Wallet-deterministic subname `{4-hex}.gradiusweb3.eth` on real Sepolia ENS, with safety credential text records. |
-| **Uniswap** | Real WETH→USDC swap on Sepolia v3, capped at 0.0001 ETH. |
-| **Gensyn AXL** | Multi-agent peer-mesh topology surfaced in the dashboard. |
-| **KeeperHub** | Reliable execution narrative (private mempool, retries) in the runtime. |
+Three sponsors, all on real testnets, all load-bearing — not cosmetic.
+
+| Sponsor | Role | Code |
+|---|---|---|
+| **0G** | iNFT minted on 0G Galileo (chain 16602) + play log uploaded to 0G Storage via `Indexer.upload`. Root hash pinned both in the iNFT `storageCID` metadata and in the ENS text record `agent.safety.attestation`, with a `sha256://` fallback when the live indexer flakes. | [`web3/zerog-mint.ts`](./packages/frontend/src/web3/zerog-mint.ts) · [`web3/zerog-storage.ts`](./packages/frontend/src/web3/zerog-storage.ts) |
+| **ENS** | Wallet-deterministic subname `{4-hex}.gradiusweb3.eth` on real Sepolia ENS (NameWrapper + PublicResolver). Pre-flight `Registry.owner()` check prevents collisions. Verifiable text records: `combat-power` / `archetype` / `design-hash` plus the safety credential trio. | [`web3/ens-register.ts`](./packages/frontend/src/web3/ens-register.ts) |
+| **Uniswap** | Real WETH → USDC swap on Sepolia v3 via `exactInputSingle`, hardcoded at `parseEther('0.0001')`. The agent's first on-chain action. DX feedback for the prize lives in [`FEEDBACK.md`](./FEEDBACK.md). | [`web3/uniswap-swap.ts`](./packages/frontend/src/web3/uniswap-swap.ts) |
 
 Prize requirements live in [`docs/prizes/`](./docs/prizes/).
 


### PR DESCRIPTION
## Summary

**User 指摘**: 「ここ (= README) しか審査員は見てくれないので事実を書いて」「インテグしてないスポンサーの情報が書いてある」「古くないですか」

`Plan.md` には既に「A 案 (0G + ENS + Uniswap) で確定。Gensyn AXL / KeeperHub は除外」と書いてあるが、**README の Sponsor integrations 表が更新されておらず**、judges に対して実装していない統合を主張している状態だった。**judges は README しか見ないので、これは致命的**。

## 対応

### 削除

- `Gensyn AXL` 行 (実装ゼロ)
- `KeeperHub` 行 (narrative のみ、実装ゼロ)

### 残った 3 sponsor を強化 (= judges が click 1 つで検証できる形式)

各行に **Code 列** を追加して、主張している統合を裏付けるソースファイルへの直接リンクを貼る。Role 説明も「実際にどの API / Contract / Function を叩いているか」具体的に書き直し:

| Sponsor | Role | Code 列 (新規) |
|---|---|---|
| 0G | `Indexer.upload` で 0G Storage、0G Galileo に iNFT mint | `web3/zerog-mint.ts` + `web3/zerog-storage.ts` |
| ENS | NameWrapper + PublicResolver、`Registry.owner()` 事前チェック | `web3/ens-register.ts` |
| Uniswap | v3 `exactInputSingle` (WETH→USDC、`parseEther('0.0001')` 固定) | `web3/uniswap-swap.ts` |

表の上に「Three sponsors, all on real testnets, all load-bearing — not cosmetic.」と 1 行添えて、絞ったことを honest に明示。

## Test plan

- [x] `bun run lint:text` (textlint) — クリーン
- [x] `bun run lint` (biome) — 60 files クリーン
- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 違反 0 件
- [x] `grep` で README から `Gensyn` / `AXL` / `KeeperHub` / `peer mesh` が消えていることを確認
- [ ] GitHub の README プレビューで Code 列のリンクが全部生きていること、judges が「主張 = 実装」を 1 行ずつ click 1 つで検証できることを目視確認 (人間タスク)

## What this PR intentionally does NOT touch

- `Plan.md` (historical 開発ログ。"A 案で確定、AXL / KeeperHub は除外" と既に正しく書いてある)
- `.claude/skills/prizes/` (dev tooling として全 prize の選択肢を網羅する。judge 向け文書ではない)
- `docs/specs/` (スペック履歴)